### PR TITLE
Allow using unpack operator inside array literals

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -255,16 +255,43 @@ abstract class Emitter {
       return;
     }
 
-    $this->out->write('[');
+    $unpack= false;
     foreach ($node->value as $pair) {
-      if ($pair[0]) {
-        $this->emit($pair[0]);
-        $this->out->write('=>');
+      if ('unpack' === $pair[1]->arity) {
+        $unpack= true;
+        break;
       }
-      $this->emit($pair[1]);
-      $this->out->write(',');
     }
-    $this->out->write(']');
+
+    if ($unpack) {
+      $this->out->write('array_merge([');
+      foreach ($node->value as $pair) {
+        if ($pair[0]) {
+          $this->emit($pair[0]);
+          $this->out->write('=>');
+        }
+        if ('unpack' === $pair[1]->arity) {
+          $this->out->write('],');
+          $this->emit($pair[1]->value);
+          $this->out->write(',[');
+        } else {
+          $this->emit($pair[1]);
+          $this->out->write(',');
+        }
+      }
+      $this->out->write('])');
+    } else {
+      $this->out->write('[');
+      foreach ($node->value as $pair) {
+        if ($pair[0]) {
+          $this->emit($pair[0]);
+          $this->out->write('=>');
+        }
+        $this->emit($pair[1]);
+        $this->out->write(',');
+      }
+      $this->out->write(']');
+    }
   }
 
   // [$name, $signature, $statements]

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -279,7 +279,7 @@ abstract class Emitter {
             $t= $this->temp();
             $this->out->write('],('.$t.'=');
             $this->emit($pair[1]->value);
-            $this->out->write(') instanceof \Generator ? iterator_to_array('.$t.') : '.$t.',[');
+            $this->out->write(') instanceof \Traversable ? iterator_to_array('.$t.') : '.$t.',[');
           }
         } else {
           $this->emit($pair[1]);

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -271,9 +271,16 @@ abstract class Emitter {
           $this->out->write('=>');
         }
         if ('unpack' === $pair[1]->arity) {
-          $this->out->write('],');
-          $this->emit($pair[1]->value);
-          $this->out->write(',[');
+          if ('array' === $pair[1]->value->arity) {
+            $this->out->write('],');
+            $this->emit($pair[1]->value);
+            $this->out->write(',[');
+          } else {
+            $t= $this->temp();
+            $this->out->write('],('.$t.'=');
+            $this->emit($pair[1]->value);
+            $this->out->write(') instanceof \Generator ? iterator_to_array('.$t.') : '.$t.',[');
+          }
         } else {
           $this->emit($pair[1]);
           $this->out->write(',');

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -295,9 +295,7 @@ class Parse {
 
     $this->prefix('...', function($node) {
       $node->arity= 'unpack';
-      $node->value= $this->token;
-
-      $this->token= $this->advance();
+      $node->value= $this->expression(0);
       return $node;
     });
 

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -230,7 +230,8 @@ class PHP56 extends \lang\ast\Emitter {
       $this->out->write('return self::__callStatic0($name, ...$args); }');
     }
 
-    $this->emitMeta($node);
-    $this->out->write('} '.$node->value[0].'::__init();');
+    $this->out->write('static function __init() {');
+    $this->emitMeta($node->value[0], $node->value[5], $node->value[6]);
+    $this->out->write('}} '.$node->value[0].'::__init();');
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
@@ -56,11 +56,25 @@ class ArgumentUnpackingTest extends EmittingTest {
   }
 
   #[@test]
-  public function from_iterable() {
+  public function from_generator() {
     $r= $this->run('class <T> {
       private function items() {
         yield 1;
         yield 2;
+      }
+
+      public function run() {
+        return [...$this->items()];
+      }
+    }');
+    $this->assertEquals([1, 2], $r);
+  }
+
+  #[@test]
+  public function from_iterator() {
+    $r= $this->run('class <T> {
+      private function items() {
+        return new \ArrayIterator([1, 2]);
       }
 
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
@@ -1,0 +1,57 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\Primitive;
+
+/**
+ * Argument unpacking
+ *
+ * @see  https://wiki.php.net/rfc/argument_unpacking
+ * @see  https://wiki.php.net/rfc/additional-splat-usage (Under Discussion)
+ */
+class ArgumentUnpackingTest extends EmittingTest {
+
+  #[@test]
+  public function invoking_method() {
+    $r= $this->run('class <T> {
+      public function fixture(... $args) { return $args; }
+
+      public function run() {
+        $args= [1, 2, 3];
+        return $this->fixture(...$args);
+      }
+    }');
+    $this->assertEquals([1, 2, 3], $r);
+  }
+
+  #[@test]
+  public function in_array_initialization_with_variable() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $args= [3, 4];
+        return [1, 2, ...$args];
+      }
+    }');
+    $this->assertEquals([1, 2, 3, 4], $r);
+  }
+
+  #[@test]
+  public function in_array_initialization_with_literal() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [1, 2, ...[3, 4]];
+      }
+    }');
+    $this->assertEquals([1, 2, 3, 4], $r);
+  }
+
+  #[@test]
+  public function in_map_initialization() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $args= ["type" => "car"];
+        return ["color" => "red", ...$args, "year" => 2002];
+      }
+    }');
+    $this->assertEquals(['color' => 'red', 'type' => 'car', 'year' => 2002], $r);
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
@@ -54,4 +54,19 @@ class ArgumentUnpackingTest extends EmittingTest {
     }');
     $this->assertEquals(['color' => 'red', 'type' => 'car', 'year' => 2002], $r);
   }
+
+  #[@test]
+  public function from_iterable() {
+    $r= $this->run('class <T> {
+      private function items() {
+        yield 1;
+        yield 2;
+      }
+
+      public function run() {
+        return [...$this->items()];
+      }
+    }');
+    $this->assertEquals([1, 2], $r);
+  }
 }


### PR DESCRIPTION
## In a nutshell

```php
// Current
$a= array_merge([1, 2], items());

// New
$a= [1, 2, ...items()];
```

Also supports unpacking traversable structures like iterators and generators (*yield*).

## Further reading

* PHP RFC: https://wiki.php.net/rfc/additional-splat-usage
* JavaScript: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator
