### PR TITLE
Using statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following table gives an overview of the current implementation status. The 
 | • [Property types](https://wiki.php.net/rfc/property_type_hints)                            | ✔(1)   | ✔(1)    | ✔(1)   | ✔(1)    | ✔(1)    |
 |                                                                                             |          |          |          |          |          |
 | **[Hack](https://docs.hhvm.com/hack/)**                                                     |          |          |          |          |          |
+| • [Using statement / Disposables](https://docs.hhvm.com/hack/disposables/introduction)      | ✔(1)   | ✔(1)    | ✔(1)   | ✔(1)    | ✔(1)    |
 | • [Function types](https://github.com/xp-framework/compiler/wiki/Type-system#functions)     | ✔(1)   | ✔(1)    | ✔(1)   | ✔(1)    | ✔(1)    |
 | • [Array and map types](https://github.com/xp-framework/compiler/wiki/Type-system#arrays)   | ✔(1)   | ✔(1)    | ✔(1)   | ✔(1)    | ✔(1)    |
 | • [Lambdas / arrow functions](https://github.com/xp-framework/compiler/wiki/Arrow-functions)| ✔      | ✔       | ✔      | ✔       | ✔       |

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.10",
     "xp-framework/tokenize": "^8.0",
-    "xp-framework/ast": "dev-feature/using as 1.3.0",
+    "xp-framework/ast": "^1.3",
     "php" : ">=5.6.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.10",
     "xp-framework/tokenize": "^8.0",
-    "xp-framework/ast": "^1.2",
+    "xp-framework/ast": "dev-feature/using as 1.3.0",
     "php" : ">=5.6.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
   "require-dev" : {
     "xp-framework/unittest": "^9.3"
   },
+  "suggest" : {
+    "xp-framework/core": "^9.4"
+  },
   "bin": ["bin/xp.xp-framework.compiler.compile"],
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -758,7 +758,8 @@ abstract class Emitter {
 
     $this->out->write('} finally {');
     foreach ($using->arguments as $variable => $expression) {
-      $this->out->write('$'.$variable.'->__dispose();');
+      $this->out->write('if ($'.$variable.' instanceof \lang\Closeable) { $'.$variable.'->close(); }');
+      $this->out->write('else if ($'.$variable.' instanceof \IDisposable) { $'.$variable.'->__dispose(); }');
     }
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -746,6 +746,23 @@ abstract class Emitter {
     $this->emit($from);
   }
 
+  protected function emitUsing($using) {
+    foreach ($using->arguments as $variable => $expression) {
+      $this->out->write('$'.$variable.'=');
+      $this->emit($expression);
+      $this->out->write(';');
+    }
+
+    $this->out->write('try {');
+    $this->emit($using->body);
+
+    $this->out->write('} finally {');
+    foreach ($using->arguments as $variable => $expression) {
+      $this->out->write('$'.$variable.'->__dispose();');
+    }
+    $this->out->write('}');
+  }
+
   public function emit($arg) {
     if ($arg instanceof Element) {
       if ($arg->line > $this->line) {

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -750,8 +750,8 @@ abstract class Emitter {
     $variables= [];
     foreach ($using->arguments as $expression) {
       switch ($expression->kind) {
-        case 'variable': $variables[]= $expression->value; break;
-        case 'assignment': $variables[]= $expression->value->variable->value; break;
+        case 'variable': $variables[]= '$'.$expression->value; break;
+        case 'assignment': $variables[]= '$'.$expression->value->variable->value; break;
         default: $temp= $this->temp(); $variables[]= $temp; $this->out->write($temp.'=');
       }
       $this->emit($expression);
@@ -763,9 +763,9 @@ abstract class Emitter {
 
     $this->out->write('} finally {');
     foreach ($variables as $variable) {
-      $this->out->write('if ($'.$variable.' instanceof \lang\Closeable) { $'.$variable.'->close(); }');
-      $this->out->write('else if ($'.$variable.' instanceof \IDisposable) { $'.$variable.'->__dispose(); }');
-      $this->out->write('unset($'.$variable.');');
+      $this->out->write('if ('.$variable.' instanceof \lang\Closeable) { '.$variable.'->close(); }');
+      $this->out->write('else if ('.$variable.' instanceof \IDisposable) { '.$variable.'->__dispose(); }');
+      $this->out->write('unset('.$variable.');');
     }
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -760,6 +760,7 @@ abstract class Emitter {
     foreach ($using->arguments as $variable => $expression) {
       $this->out->write('if ($'.$variable.' instanceof \lang\Closeable) { $'.$variable.'->close(); }');
       $this->out->write('else if ($'.$variable.' instanceof \IDisposable) { $'.$variable.'->__dispose(); }');
+      $this->out->write('unset($'.$variable.');');
     }
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -34,6 +34,7 @@ use lang\ast\nodes\TryStatement;
 use lang\ast\nodes\CatchStatement;
 use lang\ast\nodes\Signature;
 use lang\ast\nodes\Parameter;
+use lang\ast\nodes\UsingStatement;
 
 class Parse {
   private $tokens, $token, $scope;
@@ -794,6 +795,27 @@ class Parse {
       $node->value= new TraitDeclaration([], $type, $body, $this->scope->annotations, $comment);
       $node->kind= 'trait';
       $this->scope->annotations= [];
+      return $node;
+    });
+
+    $this->stmt('using', function($node) {
+      $this->token= $this->expect('(');
+      $arguments= [];
+      do {
+        $argument= $this->token->value;
+        $this->token= $this->advance('=');
+        $this->token= $this->expect('=');
+
+        $arguments[$argument]= $this->expression(0);
+      } while (0);
+      $this->token= $this->expect(')');
+
+      $this->token= $this->expect('{');
+      $statements= $this->statements();
+      $this->token= $this->expect('}');
+
+      $node->value= new UsingStatement($arguments, $statements);
+      $node->kind= 'using';
       return $node;
     });
   }

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -800,14 +800,7 @@ class Parse {
 
     $this->stmt('using', function($node) {
       $this->token= $this->expect('(');
-      $arguments= [];
-      do {
-        $argument= $this->token->value;
-        $this->token= $this->advance('=');
-        $this->token= $this->expect('=');
-
-        $arguments[$argument]= $this->expression(0);
-      } while (0);
+      $arguments= $this->arguments();
       $this->token= $this->expect(')');
 
       $this->token= $this->expect('{');

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -12,7 +12,7 @@ module xp-framework/compiler {
     $runtime= defined('HHVM_VERSION') ? 'HHVM.'.HHVM_VERSION : 'PHP.'.PHP_VERSION;
     ClassLoader::registerLoader(CompilingClassloader::instanceFor($runtime));
 
-    if (!class_exists(\IDisposable::class)) {
+    if (!interface_exists(\IDisposable::class, false)) {
       eval('interface IDisposable { public function __dispose(); }');
     }
   }

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -11,5 +11,9 @@ module xp-framework/compiler {
   public function initialize() {
     $runtime= defined('HHVM_VERSION') ? 'HHVM.'.HHVM_VERSION : 'PHP.'.PHP_VERSION;
     ClassLoader::registerLoader(CompilingClassloader::instanceFor($runtime));
+
+    if (!class_exists(\IDisposable::class)) {
+      eval('interface IDisposable { public function __dispose(); }');
+    }
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/FileInput.class.php
+++ b/src/test/php/lang/ast/unittest/emit/FileInput.class.php
@@ -3,6 +3,7 @@
 use lang\Closeable;
 use lang\IllegalArgumentException;
 
+/** Used by `UsingTest` */
 class FileInput implements Closeable {
   public static $open= false;
 

--- a/src/test/php/lang/ast/unittest/emit/FileInput.class.php
+++ b/src/test/php/lang/ast/unittest/emit/FileInput.class.php
@@ -1,0 +1,23 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\Closeable;
+use lang\IllegalArgumentException;
+
+class FileInput implements Closeable {
+  public static $open= false;
+
+  public function __construct($filename) {
+    self::$open= true;
+  }
+
+  public function read($bytes= 8192) {
+    if (!self::$open) {
+      throw new IllegalArgumentException('Cannot read from closed file');
+    }
+    return 'test';
+  }
+
+  public function close() {
+    self::$open= false;
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/Handle.class.php
+++ b/src/test/php/lang/ast/unittest/emit/Handle.class.php
@@ -4,9 +4,12 @@ use lang\IllegalArgumentException;
 
 class Handle implements \IDisposable {
   public static $called= [];
+  private $id;
+
+  public function __construct($id) { $this->id= $id; }
 
   public function read($bytes= 8192) {
-    self::$called[]= 'read';
+    self::$called[]= 'read@'.$this->id;
 
     if ($bytes <= 0) {
       throw new IllegalArgumentException('Cannot read '.$bytes.' bytes');
@@ -15,6 +18,6 @@ class Handle implements \IDisposable {
   }
 
   public function __dispose() {
-    self::$called[]= '__dispose';
+    self::$called[]= '__dispose@'.$this->id;
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/Handle.class.php
+++ b/src/test/php/lang/ast/unittest/emit/Handle.class.php
@@ -1,0 +1,20 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\IllegalArgumentException;
+
+class Handle implements \IDisposable {
+  public static $called= [];
+
+  public function read($bytes= 8192) {
+    self::$called[]= 'read';
+
+    if ($bytes <= 0) {
+      throw new IllegalArgumentException('Cannot read '.$bytes.' bytes');
+    }
+    return 'test';
+  }
+
+  public function __dispose() {
+    self::$called[]= '__dispose';
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/Handle.class.php
+++ b/src/test/php/lang/ast/unittest/emit/Handle.class.php
@@ -2,6 +2,7 @@
 
 use lang\IllegalArgumentException;
 
+/** Used by `UsingTest` */
 class Handle implements \IDisposable {
   public static $called= [];
   private $id;

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -1,0 +1,45 @@
+<?php namespace lang\ast\unittest\emit;
+
+/**
+ * Using statement and disposables
+ *
+ * @see  https://docs.hhvm.com/hack/disposables/introduction
+ */
+class UsingTest extends EmittingTest {
+
+  #[@test]
+  public function dispose_called() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        Handle::$called= [];
+
+        using ($x= new Handle()) {
+          $x->read();
+        }
+
+        return Handle::$called;
+      }
+    }');
+    $this->assertEquals(['read', '__dispose'], $r);
+  }
+
+  #[@test]
+  public function dispose_called_even_when_exceptions_occur() {
+    $r= $this->run('use lang\{IllegalArgumentException, IllegalStateException}; use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        Handle::$called= [];
+
+        try {
+          using ($x= new Handle()) {
+            $x->read(-1);
+          }
+        } catch (IllegalArgumentException $expected) {
+          return Handle::$called;  
+        }
+
+        throw new IllegalStateException("No exception caught");
+      }
+    }');
+    $this->assertEquals(['read', '__dispose'], $r);
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -89,4 +89,18 @@ class UsingTest extends EmittingTest {
     }');
     $this->assertFalse($r);
   }
+
+  #[@test]
+  public function variable_undefined_after_using_even_if_previously_defined() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        $x= new Handle();
+        using ($x) {
+          // NOOP
+        }
+        return isset($x);
+      }
+    }');
+    $this->assertFalse($r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -58,4 +58,22 @@ class UsingTest extends EmittingTest {
     }');
     $this->assertFalse($r);
   }
+
+  #[@test]
+  public function can_return_from_inside_using() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private function read() {
+        using ($x= new Handle()) {
+          return $x->read();
+        }
+      }
+
+      public function run() {
+        Handle::$called= [];
+        $returned= $this->read();
+        return ["called" => Handle::$called, "returned" => $returned];
+      }
+    }');
+    $this->assertEquals(['called' => ['read', '__dispose'], 'returned' => 'test'], $r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -42,4 +42,20 @@ class UsingTest extends EmittingTest {
     }');
     $this->assertEquals(['read', '__dispose'], $r);
   }
+
+  #[@test]
+  public function supports_closeables() {
+    $r= $this->run('use lang\ast\unittest\emit\FileInput; class <T> {
+      public function run() {
+        FileInput::$open= false;
+
+        using ($f= new FileInput(__FILE__)) {
+          $f->read();
+        }
+
+        return FileInput::$open;
+      }
+    }');
+    $this->assertFalse($r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -76,4 +76,17 @@ class UsingTest extends EmittingTest {
     }');
     $this->assertEquals(['called' => ['read', '__dispose'], 'returned' => 'test'], $r);
   }
+
+  #[@test]
+  public function variable_undefined_after_using() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        using ($x= new Handle()) {
+          // NOOP
+        }
+        return isset($x);
+      }
+    }');
+    $this->assertFalse($r);
+  }
 }


### PR DESCRIPTION
Implements #29 and adds support for HHVM's [using statement](https://docs.hhvm.com/hack/disposables/introduction).

```php
class Handle implements \IDisposable {
  public function invoke() { ... }
  public function __dispose() { /* Cleanup logic here */ }
}

using ($f= new Handle()) {
  $f->invoke();
} // $f->__dispose() called for IDisposables; $f->close() for lang.Closeable instances
```