### PR TITLE
Support unicode escape sequences in PHP 5.6

### DIFF
--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -93,6 +93,18 @@ class PHP56 extends \lang\ast\Emitter {
     return null;
   }
 
+  protected function emitLiteral($literal) {
+    if ('"' === $literal{0}) {
+      $this->out->write(preg_replace_callback(
+        '/\\\\u\{([0-9a-f]+)\}/i',
+        function($matches) { return html_entity_decode('&#'.hexdec($matches[1]).';'); },
+        $literal
+      ));
+    } else {
+      $this->out->write($literal);
+    }
+  }
+
   protected function emitCatch($catch) {
     $last= array_pop($catch->types);
     $label= sprintf('c%u', crc32($last));

--- a/src/test/php/lang/ast/unittest/emit/UnicodeEscapesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UnicodeEscapesTest.class.php
@@ -1,0 +1,26 @@
+<?php namespace lang\ast\unittest\emit;
+
+class UnicodeEscapesTest extends EmittingTest {
+
+  #[@test]
+  public function spanish_ñ() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return "ma\u{00F1}ana";
+      }
+    }');
+
+    $this->assertEquals('mañana', $r);
+  }
+
+  #[@test]
+  public function emoji() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return "Smile! \u{1F602}";
+      }
+    }');
+
+    $this->assertEquals('Smile! 😂', $r);
+  }
+}


### PR DESCRIPTION
Implements #38 

```php
$str= "\u{1F602}"; // 😂
```