### PR TITLE
Raise errors when members are redeclared

### DIFF
--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1136,7 +1136,7 @@ class Parse {
         $name= $this->token->value;
         $lookup= $name.'()';
         if (isset($body[$lookup])) {
-          throw new Error('Cannot redeclare method '.$lookup, $this->file, $this->token->line);
+          $this->raise('Cannot redeclare method '.$lookup);
         }
 
         $this->token= $this->advance();
@@ -1192,7 +1192,7 @@ class Parse {
           }
 
           if (isset($body[$name])) {
-            throw new Error('Cannot redeclare constant '.$name, $this->file, $this->token->line);
+            $this->raise('Cannot redeclare constant '.$name);
           }
 
           $this->token= $this->expect('=');
@@ -1224,7 +1224,7 @@ class Parse {
 
           $lookup= '$'.$name;
           if (isset($body[$lookup])) {
-            throw new Error('Cannot redeclare property '.$lookup, $this->file, $this->token->line);
+            $this->raise('Cannot redeclare property '.$lookup);
           }
 
           $this->token= $this->advance();
@@ -1406,6 +1406,25 @@ class Parse {
   }
   // }}}
 
+  /**
+   * Raise an error
+   *
+   * @param  string $error
+   * @param  string $context
+   * @return void
+   */
+  private function raise($message, $context= null) {
+    $context && $message.= ' in '.$context;
+    throw new Error($message, $this->file, $this->token->line);
+  }
+
+  /**
+   * Expect a given token, raise an error if another is encountered
+   *
+   * @param  string $id
+   * @param  string $context
+   * @return var
+   */
   private function expect($id, $context= null) {
     if ($id !== $this->token->symbol->id) {
       $message= sprintf('Expected "%s", have "%s"%s', $id, $this->token->symbol->id, $context ? ' in '.$context : '');

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -179,6 +179,15 @@ class MembersTest extends ParseTest {
   }
 
   #[@test]
+  public function typed_property_with_value() {
+    $decl= ['$a' => ['(variable)' => ['a', ['private'], ['(literal)' => '"test"'], new Type('string'), [], null]]];
+    $this->assertNodes(
+      [['class' => ['\\A', [], null, [], $decl, [], null]]],
+      $this->parse('class A { private string $a = "test"; }')
+    );
+  }
+
+  #[@test]
   public function typed_properties() {
     $decl= [
       '$a' => ['(variable)' => ['a', ['private'], null, new Type('string'), [], null]],

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\unittest\parse;
 
+use lang\ast\Error;
+
 class TypesTest extends ParseTest {
 
   #[@test]
@@ -112,5 +114,20 @@ class TypesTest extends ParseTest {
       [['namespace' => 'test'], ['class' => ['\\test\\A', [], null, [], [], [], null]]],
       $this->parse('namespace test; class A { }')
     );
+  }
+
+  #[@test, @expect(class= Error::class, withMessage= 'Cannot redeclare method b()')]
+  public function cannot_redeclare_method() {
+    iterator_to_array($this->parse('class A { public function b() { } public function b() { }}'));
+  }
+
+  #[@test, @expect(class= Error::class, withMessage= 'Cannot redeclare property $b')]
+  public function cannot_redeclare_property() {
+    iterator_to_array($this->parse('class A { public $b; private $b; }'));
+  }
+
+  #[@test, @expect(class= Error::class, withMessage= 'Cannot redeclare constant B')]
+  public function cannot_redeclare_constant() {
+    iterator_to_array($this->parse('class A { const B = 1; const B = 3; }'));
   }
 }


### PR DESCRIPTION
```bash
$ cat Test.php
<?php

class Test {

  public function a() { }

  public function a() { }
}

$ xp compile Test.php > /dev/null
! Test.php Cannot redeclare method a() at line 7

× Compiled 1 file(s) to - using lang.ast.emit.PHP72, 1 error(s) occurred
Memory used: 2150.29 kB (2214.14 kB peak)
Time taken: 0.011 seconds
```