### PR TITLE
Add "-n" command line option to compile only...

### DIFF
--- a/src/main/php/xp/compiler/CompileOnly.class.php
+++ b/src/main/php/xp/compiler/CompileOnly.class.php
@@ -1,0 +1,20 @@
+<?php namespace xp\compiler;
+
+use io\streams\OutputStream;
+
+class CompileOnly extends Output {
+
+  /**
+   * Returns the target for a given input 
+   *
+   * @param  string $name
+   * @return io.streams.OutputStream
+   */
+  public function target($name) {
+    return newinstance(OutputStream::class, [], [
+      'write' => function($bytes) { },
+      'flush' => function() { },
+      'close' => function() { }
+    ]);
+  }
+}

--- a/src/main/php/xp/compiler/CompileRunner.class.php
+++ b/src/main/php/xp/compiler/CompileRunner.class.php
@@ -24,15 +24,18 @@ use util\profiling\Timer;
  *   ```
  * - Compile `src/main/php` and `src/test/php` to the `dist` folder.
  *   ```sh
- *   $ xp compile -o dist src/main/php/ src/test/php
+ *   $ xp compile -o dist src/main/php/ src/test/php/
+ *   ```
+ * - Compile `src/main/php`, do not write output
+ *   ```sh
+ *   $ xp compile -n src/main/php/
  *   ```
  * - Target PHP 5.6 (default target is current PHP version)
  *   ```sh
  *   $ xp compile -t PHP.5.6 HelloWorld.php HelloWorld.class.php
  *   ```
  *
- * By using the *-o* option, you can pass multiple input sources
- * following it.
+ * The *-o* and *-n* options accept multiple input sources following them.
  * 
  * @see  https://github.com/xp-framework/rfc/issues/299
  */
@@ -52,6 +55,10 @@ class CompileRunner {
         $target= $args[++$i];
       } else if ('-o' === $args[$i]) {
         $out= $args[++$i];
+        $in= array_slice($args, $i + 1);
+        break;
+      } else if ('-n' === $args[$i]) {
+        $out= null;
         $in= array_slice($args, $i + 1);
         break;
       } else {

--- a/src/main/php/xp/compiler/Output.class.php
+++ b/src/main/php/xp/compiler/Output.class.php
@@ -11,7 +11,9 @@ abstract class Output {
    * @return self
    */
   public static function newInstance($arg) {
-    if ('-' === $arg) {
+    if (null === $arg) {
+      return new CompileOnly();
+    } else if ('-' === $arg) {
       return new ToStream(Console::$out->getStream());
     } else if (strstr($arg, '.php')) {
       return new ToFile($arg);


### PR DESCRIPTION
...and not write output anywhere. This can be used for syntax and compilation error checking:

```bash
$ xp compile -n src/main/php/
> autoload.php (0.006 seconds)
> lang/ast/CompilingClassloader.class.php (0.012 seconds)
> lang/ast/emit/HHVM320.class.php (0.003 seconds)
> lang/ast/emit/PHP56.class.php (0.011 seconds)
> lang/ast/emit/PHP70.class.php (0.002 seconds)
> lang/ast/emit/PHP71.class.php (0.000 seconds)
> lang/ast/emit/PHP72.class.php (0.000 seconds)
> lang/ast/Emitter.class.php (0.029 seconds)
> lang/ast/Error.class.php (0.001 seconds)
> lang/ast/Parse.class.php (0.053 seconds)
> lang/ast/Scope.class.php (0.002 seconds)
> lang/ast/Tokens.class.php (0.005 seconds)
> xp/compiler/CompileOnly.class.php (0.001 seconds)
> xp/compiler/CompileRunner.class.php (0.003 seconds)
> xp/compiler/FromFile.class.php (0.001 seconds)
> xp/compiler/FromFilesIn.class.php (0.001 seconds)
> xp/compiler/FromInputs.class.php (0.001 seconds)
> xp/compiler/FromStream.class.php (0.001 seconds)
> xp/compiler/Input.class.php (0.001 seconds)
> xp/compiler/Output.class.php (0.001 seconds)
> xp/compiler/ToFile.class.php (0.001 seconds)
> xp/compiler/ToFileSystem.class.php (0.001 seconds)
> xp/compiler/ToFolder.class.php (0.001 seconds)
> xp/compiler/ToStream.class.php (0.001 seconds)

♥ Compiled 24 file(s) to  using lang.ast.emit.PHP72, 0 error(s) occurred
Memory used: 3516.17 kB (4291.33 kB peak)
Time taken: 0.137 seconds
```

```bash
$ cat Test.php
<?php

class Test {

  public

$ xp compile -n Test.php
! Test.php Expected "a type, modifier, property, annotation, method or }", have "(end)" 
  in type body at line 1

× Compiled 1 file(s) to  using lang.ast.emit.PHP72, 1 error(s) occurred
Memory used: 2139.34 kB (2211.44 kB peak)
Time taken: 0.062 seconds
```