### PR TITLE
Multiple errors

### DIFF
--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -170,7 +170,7 @@ class CompilingClassLoader implements \lang\IClassLoader {
       $emitter->emit($parse->execute());
 
       return $declaration->getBytes();
-    } catch (Error $e) {
+    } catch (Errors $e) {
       $message= sprintf('Syntax error in %s, line %d: %s', $e->getFile(), $e->getLine(), $e->getMessage());
       throw new ClassFormatException($message);
     } finally {

--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -169,6 +169,9 @@ class CompilingClassLoader implements IClassLoader {
     } catch (\Throwable $e) {
       unset(\xp::$cl[$class]);
       throw new ClassFormatException('Compiler error: '.$e->getMessage(), $e);
+    } catch (\Exception $e) {
+      unset(\xp::$cl[$class]);
+      throw new ClassFormatException('Compiler error: '.$e->getMessage(), $e);
     } finally {
       \xp::$cll--;
       unset(Compiled::$source[$uri]);

--- a/src/main/php/lang/ast/Errors.class.php
+++ b/src/main/php/lang/ast/Errors.class.php
@@ -8,7 +8,7 @@ class Errors extends IllegalStateException {
   /**
    * Creates a new error
    *
-   * @param  lang.ast.Error $errors
+   * @param  lang.ast.Error[] $errors
    * @param  string $file
    */
   public function __construct($errors, $file) {
@@ -27,11 +27,18 @@ class Errors extends IllegalStateException {
         }
         $message.= '}';
     }
+
     parent::__construct($message);
     $this->file= $file;
     $this->line= $errors[0]->getLine();
   }
 
+  /**
+   * Returns diagnostics
+   *
+   * @param  string $indent
+   * @return string
+   */
   public function diagnostics($indent= '') {
     return str_replace("\n", "\n".$indent, $this->message);
   }

--- a/src/main/php/lang/ast/Errors.class.php
+++ b/src/main/php/lang/ast/Errors.class.php
@@ -1,0 +1,38 @@
+<?php namespace lang\ast;
+
+use lang\IllegalArgumentException;
+use lang\IllegalStateException;
+
+class Errors extends IllegalStateException {
+
+  /**
+   * Creates a new error
+   *
+   * @param  lang.ast.Error $errors
+   * @param  string $file
+   */
+  public function __construct($errors, $file) {
+    switch (sizeof($errors)) {
+      case 0:
+        throw new IllegalArgumentException('Errors may not be empty!');
+
+      case 1:
+        $message= $errors[0]->getMessage();
+        break;
+
+      default: 
+        $message= "Errors {\n";
+        foreach ($errors as $error) {
+          $message.= '  '.$error->message.' at line '.$error->line."\n";
+        }
+        $message.= '}';
+    }
+    parent::__construct($message);
+    $this->file= $file;
+    $this->line= $errors[0]->getLine();
+  }
+
+  public function diagnostics($indent= '') {
+    return str_replace("\n", "\n".$indent, $this->message);
+  }
+}

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -640,10 +640,10 @@ class Parse {
     $this->stmt('do', function($node) {
       $block= $this->block();
 
-      $this->token= $this->expect('while');
-      $this->token= $this->expect('(');
+      $this->token= $this->next('while');
+      $this->token= $this->next('(');
       $expression= $this->expression(0);
-      $this->token= $this->expect(')');
+      $this->token= $this->next(')');
       $this->token= $this->next(';');
 
       $node->value= new DoLoop($expression, $block);
@@ -652,9 +652,9 @@ class Parse {
     });
 
     $this->stmt('while', function($node) {
-      $this->token= $this->expect('(');
+      $this->token= $this->next('(');
       $expression= $this->expression(0);
-      $this->token= $this->expect(')');
+      $this->token= $this->next(')');
       $block= $this->block();
 
       $node->value= new WhileLoop($expression, $block);
@@ -663,13 +663,13 @@ class Parse {
     });
 
     $this->stmt('for', function($node) {
-      $this->token= $this->expect('(');
+      $this->token= $this->next('(');
       $init= $this->arguments(';');
-      $this->token= $this->advance(';');
+      $this->token= $this->next(';');
       $cond= $this->arguments(';');
-      $this->token= $this->advance(';');
+      $this->token= $this->next(';');
       $loop= $this->arguments(')');
-      $this->token= $this->advance(')');
+      $this->token= $this->next(')');
 
       $block= $this->block();
 
@@ -679,7 +679,7 @@ class Parse {
     });
 
     $this->stmt('foreach', function($node) {
-      $this->token= $this->expect('(');
+      $this->token= $this->next('(');
       $expression= $this->expression(0);
 
       $this->token= $this->advance('as');
@@ -694,7 +694,7 @@ class Parse {
         $value= $expr;
       }
 
-      $this->token= $this->expect(')');
+      $this->token= $this->next(')');
 
       $block= $this->block();
       $node->value= new ForeachLoop($expression, $key, $value, $block);
@@ -710,14 +710,14 @@ class Parse {
     });
 
     $this->stmt('try', function($node) {
-      $this->token= $this->expect('{');
+      $this->token= $this->next('{');
       $statements= $this->statements();
-      $this->token= $this->expect('}');
+      $this->token= $this->next('}');
 
       $catches= [];
       while ('catch'  === $this->token->value) {
         $this->token= $this->advance();
-        $this->token= $this->expect('(');
+        $this->token= $this->next('(');
 
         $types= [];
         while ('name' === $this->token->kind) {
@@ -729,18 +729,18 @@ class Parse {
 
         $variable= $this->token;
         $this->token= $this->advance();
-        $this->token= $this->expect(')');
+        $this->token= $this->next(')');
 
-        $this->token= $this->expect('{');
+        $this->token= $this->next('{');
         $catches[]= new CatchStatement($types, $variable->value, $this->statements());
-        $this->token= $this->expect('}');
+        $this->token= $this->next('}');
       }
 
       if ('finally' === $this->token->value) {
         $this->token= $this->advance();
-        $this->token= $this->expect('{');
+        $this->token= $this->next('{');
         $finally= $this->statements();
-        $this->token= $this->expect('}');
+        $this->token= $this->next('}');
       } else {
         $finally= null;
       }
@@ -790,9 +790,9 @@ class Parse {
         $this->token= $this->advance();
 
         if ('(' === $this->token->value) {
-          $this->token= $this->expect('(');
+          $this->token= $this->next('(');
           $this->scope->annotations[$name]= $this->expression(0);
-          $this->token= $this->expect(')');
+          $this->token= $this->next(')');
         } else {
           $this->scope->annotations[$name]= null;
         }
@@ -802,11 +802,12 @@ class Parse {
         } else if ('>>' === $this->token->value) {
           break;
         } else {
-          $this->expect(', or >>', 'annotation');
+          $this->next(', or >>', 'annotation');
+          break;
         }
       } while (true);
 
-      $this->token= $this->expect('>>', 'annotation');
+      $this->token= $this->advance();
       $node->kind= 'annotation';
       return $node;
     });

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -802,10 +802,9 @@ class Parse {
         } else if ('>>' === $this->token->value) {
           break;
         } else {
-          $this->next(', or >>', 'annotation');
-          break;
+          $this->token= $this->next(', or >>', 'annotation');
         }
-      } while (true);
+      } while (null !== $this->token->value);
 
       $this->token= $this->advance();
       $node->kind= 'annotation';
@@ -838,9 +837,9 @@ class Parse {
           } else if ('{' === $this->token->value) {
             break;
           } else {
-            $this->expect(', or {', 'interface parents');
+            $this->token= $this->next(', or {', 'interface parents');
           }
-        } while (true);
+        } while (null !== $this->token->value);
       }
 
       $this->token= $this->expect('{');
@@ -1090,9 +1089,9 @@ class Parse {
         } else if ('{' === $this->token->value) {
           break;
         } else {
-          $this->expect(', or {', 'interfaces list');
+          $this->token= $this->next(', or {', 'interfaces list');
         }
-      } while (true);
+      } while (null !== $this->token->value);
     }
 
     $this->token= $this->expect('{');

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1328,7 +1328,14 @@ class Parse {
     }
 
     $expr= $this->expression(0);
-    $this->token= $this->expect(';');
+
+    if (';' !== $this->token->symbol->id) {
+      $message= sprintf('Missing semicolon before %s %s', $this->token->symbol->id, $this->token->value);
+      $this->errors[]= new Error($message, $this->file, $this->token->line);
+    } else {
+      $this->token= $this->advance();
+    }
+
     return $expr;
   }
 

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -329,13 +329,6 @@ class Parse {
       return $node;
     });
 
-    $this->prefix('{', function($node) {
-      $node->kind= 'block';
-      $node->value= $this->statements();
-      $this->token= new Node(self::symbol(';'));
-      return $node;
-    });
-
     $this->prefix('new', function($node) {
       $type= $this->token;
       $this->token= $this->advance();
@@ -488,6 +481,13 @@ class Parse {
       $node->kind= 'start';
       $node->value= $this->token->value;
 
+      $this->token= $this->advance();
+      return $node;
+    });
+
+    $this->stmt('{', function($node) {
+      $node->kind= 'block';
+      $node->value= $this->statements();
       $this->token= $this->advance();
       return $node;
     });

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -319,11 +319,14 @@ class Parse {
           $values[]= [null, $expr];
         }
 
-        if (']' === $this->token->value) break;
-        $this->token= $this->expect(',', 'array literal');
+        if (']' === $this->token->value) {
+          break;
+        } else {
+          $this->token= $this->next(',', 'array literal');
+        }
       }
 
-      $this->token= $this->expect(']', 'array literal');
+      $this->token= $this->next(']', 'array literal');
       $node->kind= 'array';
       $node->value= $values;
       return $node;
@@ -1108,7 +1111,7 @@ class Parse {
     while ($end !== $this->token->value) {
       $arguments[]= $this->expression(0, false);    // Undefined arguments are OK
       if (',' === $this->token->value) {
-        $this->token= $this->expect(',');
+        $this->token= $this->advance();
       } else if ($end === $this->token->value) {
         break;
       } else {
@@ -1298,13 +1301,13 @@ class Parse {
 
           $body[$lookup]= $member;
           if (',' === $this->token->value) {
-            $this->token= $this->expect(',');
+            $this->token= $this->advance();
           }
         }
         $modifiers= [];
         $annotations= [];
         $type= null;
-        $this->token= $this->expect(';', 'field declaration');
+        $this->token= $this->next(';', 'field declaration');
       } else if ('<<' === $this->token->symbol->id) {
         do {
           $this->token= $this->advance();
@@ -1328,7 +1331,7 @@ class Parse {
             $this->token= $this->next(', or >>', 'annotations');
           }
         } while (null !== $this->token->value);
-        $this->token= $this->expect('>>');
+        $this->token= $this->advance();
       } else if ($type= $this->type()) {
         continue;
       } else {

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1335,7 +1335,7 @@ class Parse {
     $expr= $this->expression(0);
 
     if (';' !== $this->token->symbol->id) {
-      $this->raise('Missing semicolon before '.$this->token->symbol->id);
+      $this->raise('Missing semicolon after '.$expr->kind.' statement', null, $expr->line);
     } else {
       $this->token= $this->advance();
     }
@@ -1431,11 +1431,12 @@ class Parse {
    *
    * @param  string $error
    * @param  string $context
+   * @param  int $line
    * @return void
    */
-  private function raise($message, $context= null) {
+  private function raise($message, $context= null, $line= null) {
     $context && $message.= ' in '.$context;
-    $this->errors[]= new Error($message, $this->file, $this->token->line);
+    $this->errors[]= new Error($message, $this->file, $line ?: $this->token->line);
   }
 
   /**

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -916,9 +916,9 @@ class Parse {
         } else if (')' === $this->token->value) {
           break;
         } else {
-          $this->expect(', or )', 'function type');
+          $this->token= $this->next(', or )', 'function type');
         }
-      } while (true);
+      } while (null !== $this->token->value);
       $this->token= $this->expect(')');
       $this->token= $this->expect(':');
       return new FunctionType($signature, $this->type(false));
@@ -983,9 +983,9 @@ class Parse {
           } else if ('>>' === $this->token->value) {
             break;
           } else {
-            $this->expect(', or >>', 'parameter annotation');
+            $this->token= $this->next(', or >>', 'parameter annotation');
           }
-        } while (true);
+        } while (null !== $this->token->value);
         $this->token= $this->expect('>>', 'parameter annotation');
       }
 
@@ -1325,9 +1325,9 @@ class Parse {
           } else if ('>>' === $this->token->value) {
             break;
           } else {
-            $this->expect(', or >>', 'annotations');
+            $this->token= $this->next(', or >>', 'annotations');
           }
-        } while (true);
+        } while (null !== $this->token->value);
         $this->token= $this->expect('>>');
       } else if ($type= $this->type()) {
         continue;

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1330,8 +1330,7 @@ class Parse {
     $expr= $this->expression(0);
 
     if (';' !== $this->token->symbol->id) {
-      $message= sprintf('Missing semicolon before %s %s', $this->token->symbol->id, $this->token->value);
-      $this->errors[]= new Error($message, $this->file, $this->token->line);
+      $this->raise(sprintf('Missing semicolon before %s', $this->token->symbol->id));
     } else {
       $this->token= $this->advance();
     }

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -790,7 +790,7 @@ class Parse {
         $this->token= $this->advance();
 
         if ('(' === $this->token->value) {
-          $this->token= $this->next('(');
+          $this->token= $this->advance();
           $this->scope->annotations[$name]= $this->expression(0);
           $this->token= $this->next(')');
         } else {
@@ -833,7 +833,7 @@ class Parse {
           $parents[]= $this->scope->resolve($this->token->value);
           $this->token= $this->advance();
           if (',' === $this->token->value) {
-            $this->token= $this->expect(',');
+            $this->token= $this->advance();
           } else if ('{' === $this->token->value) {
             break;
           } else {
@@ -1046,9 +1046,9 @@ class Parse {
 
    private function block() {
     if ('{'  === $this->token->value) {
-      $this->token= $this->expect('{');
+      $this->token= $this->advance();
       $block= $this->statements();
-      $this->token= $this->expect('}');
+      $this->token= $this->next('}');
       return $block;
     } else {
       return [$this->statement()];
@@ -1290,7 +1290,7 @@ class Parse {
 
           $this->token= $this->advance();
           if ('=' === $this->token->value) {
-            $this->token= $this->expect('=');
+            $this->token= $this->advance();
             $member->value= new Property($modifiers, $name, $type, $this->expression(0), $annotations, $comment);
           } else {
             $member->value= new Property($modifiers, $name, $type, null, $annotations, $comment);
@@ -1313,9 +1313,9 @@ class Parse {
           $this->token= $this->advance();
 
           if ('(' === $this->token->value) {
-            $this->token= $this->expect('(');
+            $this->token= $this->advance();
             $annotations[$name]= $this->expression(0);
-            $this->token= $this->expect(')');
+            $this->token= $this->next(')');
           } else {
             $annotations[$name]= null;
           }

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -430,7 +430,7 @@ class Parse {
           $n->line= $this->token->line;
           $n->kind= 'return';
           $statements= [$n];
-          $this->token= $this->expect(';');
+          $this->token= $this->next(';');
         } else {                              // Regular function
           $this->token= $this->expect('{');
           $statements= $this->statements();
@@ -462,7 +462,7 @@ class Parse {
 
           $node->value[$variable]= $initial;
           if (',' === $this->token->value) {
-            $this->token= $this->expect(',');
+            $this->token= $this->advance();
           }
         }
       }
@@ -604,7 +604,7 @@ class Parse {
           $cases[sizeof($cases) - 1]->body[]= $this->statement();
         }
       }
-      $this->token= $this->expect('}');
+      $this->token= $this->advance();
 
       $node->value= new SwitchStatement($condition, $cases);
       $node->kind= 'switch';
@@ -753,10 +753,11 @@ class Parse {
     $this->stmt('return', function($node) {
       if (';' === $this->token->value) {
         $expr= null;
+        $this->token= $this->advance();
       } else {
         $expr= $this->expression(0);
+        $this->token= $this->next(';');
       }
-      $this->token= $this->expect(';');
 
       $node->value= $expr;
       $node->kind= 'return';

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1280,7 +1280,12 @@ class Parse {
       } else if ($type= $this->type()) {
         continue;
       } else {
-        $this->expect('a type, modifier, property, annotation, method or }', 'type body');
+        $this->raise(sprintf(
+          'Expected a type, modifier, property, annotation, method or "}", have "%s"',
+          $this->token->symbol->id
+        ));
+        $this->token= $this->advance();
+        if (null === $this->token->value) break;
       }
     }
     return $body;
@@ -1330,7 +1335,7 @@ class Parse {
     $expr= $this->expression(0);
 
     if (';' !== $this->token->symbol->id) {
-      $this->raise(sprintf('Missing semicolon before %s', $this->token->symbol->id));
+      $this->raise('Missing semicolon before '.$this->token->symbol->id);
     } else {
       $this->token= $this->advance();
     }

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -1521,9 +1521,10 @@ class Parse {
   }
 
   private function advance() {
+    static $line= 1;
+
     if ($this->queue) return array_shift($this->queue);
 
-    $line= 1;
     while ($this->tokens->valid()) {
       $type= $this->tokens->key();
       list($value, $line)= $this->tokens->current();

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -280,9 +280,9 @@ class Parse {
         $this->token= $this->advance();
 
         if ('{' === $this->token->value) {
-          $this->token= $this->expect('{');
+          $this->token= $this->advance();
           $statements= $this->statements();
-          $this->token= $this->expect('}');
+          $this->token= $this->next('}');
         } else {
           $statements= $this->expressionWithThrows(0);
         }
@@ -454,7 +454,7 @@ class Parse {
           $this->token= $this->advance();
 
           if ('=' === $this->token->value) {
-            $this->token= $this->expect('=');
+            $this->token= $this->advance();
             $initial= $this->expression(0);
           } else {
             $initial= null;
@@ -559,7 +559,7 @@ class Parse {
         $this->scope->import($import);
       }
 
-      $this->token= $this->expect(';');
+      $this->token= $this->next(';');
       $node->value= $types;
       return $node;
     });
@@ -617,7 +617,7 @@ class Parse {
         $this->token= $this->advance();
       } else {
         $node->value= $this->expression(0);
-        $this->token= $this->expect(';');
+        $this->token= $this->next(';');
       }
 
       $node->kind= 'break';
@@ -630,7 +630,7 @@ class Parse {
         $this->token= $this->advance();
       } else {
         $node->value= $this->expression(0);
-        $this->token= $this->expect(';');
+        $this->token= $this->next(';');
       }
 
       $node->kind= 'continue';
@@ -644,7 +644,7 @@ class Parse {
       $this->token= $this->expect('(');
       $expression= $this->expression(0);
       $this->token= $this->expect(')');
-      $this->token= $this->expect(';');
+      $this->token= $this->next(';');
 
       $node->value= new DoLoop($expression, $block);
       $node->kind= 'do';
@@ -705,7 +705,7 @@ class Parse {
     $this->stmt('throw', function($node) {
       $node->value= $this->expression(0);
       $node->kind= 'throw';
-      $this->token= $this->expect(';');
+      $this->token= $this->next(';');
       return $node;      
     });
 

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -125,7 +125,7 @@ class Parse {
       if ('{' === $this->token->value) {
         $this->token= $this->advance();
         $expr= $this->expression(0);
-        $this->token= $this->anticipate('}');
+        $this->token= $this->next('}');
       } else {
         $expr= $this->token;
         $this->token= $this->advance();
@@ -140,7 +140,7 @@ class Parse {
       if ('{' === $this->token->value) {
         $this->token= $this->advance();
         $expr= $this->expression(0);
-        $this->token= $this->anticipate('}');
+        $this->token= $this->next('}');
       } else {
         $expr= $this->token;
         $this->token= $this->advance();
@@ -164,7 +164,7 @@ class Parse {
       if ('{' === $this->token->value) {
         $this->token= $this->advance();
         $statements= $this->statements();
-        $this->token= $this->anticipate('}');
+        $this->token= $this->next('}');
       } else {
         $statements= $this->expressionWithThrows(0);
       }
@@ -176,7 +176,7 @@ class Parse {
 
     $this->infix('(', 80, function($node, $left) {
       $arguments= $this->arguments();
-      $this->token= $this->expect(')');
+      $this->token= $this->next(')');
       $node->value= new InvokeExpression($left, $arguments);
       $node->kind= 'invoke';
       return $node;
@@ -188,7 +188,7 @@ class Parse {
         $this->token= $this->advance();
       } else {
         $expr= $this->expression(0);
-        $this->token= $this->anticipate(']');
+        $this->token= $this->next(']');
       }
 
       $node->value= new OffsetExpression($left, $expr);
@@ -198,7 +198,7 @@ class Parse {
 
     $this->infix('{', 80, function($node, $left) {
       $expr= $this->expression(0);
-      $this->token= $this->expect('}');
+      $this->token= $this->next('}');
 
       $node->value= new OffsetExpression($left, $expr);
       $node->kind= 'offset';
@@ -207,7 +207,7 @@ class Parse {
 
     $this->infix('?', 80, function($node, $left) {
       $when= $this->expressionWithThrows(0);
-      $this->token= $this->expect(':');
+      $this->token= $this->next(':');
       $else= $this->expressionWithThrows(0);
       $node->value= new TernaryExpression($left, $when, $else);
       $node->kind= 'ternary';
@@ -1507,7 +1507,7 @@ class Parse {
    * @param  string $context
    * @return var
    */
-  private function anticipate($id, $context= null) {
+  private function next($id, $context= null) {
     if ($id === $this->token->symbol->id) return $this->advance();
 
     $message= sprintf(

--- a/src/main/php/xp/compiler/CompileRunner.class.php
+++ b/src/main/php/xp/compiler/CompileRunner.class.php
@@ -3,7 +3,7 @@
 use io\Path;
 use lang\Runtime;
 use lang\ast\Emitter;
-use lang\ast\Error;
+use lang\ast\Errors;
 use lang\ast\Parse;
 use lang\ast\Tokens;
 use lang\ast\transform\Transformations;

--- a/src/main/php/xp/compiler/CompileRunner.class.php
+++ b/src/main/php/xp/compiler/CompileRunner.class.php
@@ -76,9 +76,10 @@ class CompileRunner {
     $total= $errors= 0;
     $time= 0.0;
     foreach ($input as $path => $in) {
+      $file= $path->toString('/');
       $t->start();
       try {
-        $parse= new Parse(new Tokens(new StreamTokenizer($in)));
+        $parse= new Parse(new Tokens(new StreamTokenizer($in)), $file);
         $emitter= $emit->newInstance($output->target((string)$path));
         foreach (Transformations::registered() as $kind => $function) {
           $emitter->transform($kind, $function);
@@ -86,10 +87,10 @@ class CompileRunner {
         $emitter->emit($parse->execute());
 
         $t->stop();
-        Console::$err->writeLinef('> %s (%.3f seconds)', $path->toString('/'), $t->elapsedTime());
-      } catch (Error $e) {
+        Console::$err->writeLinef('> %s (%.3f seconds)', $file, $t->elapsedTime());
+      } catch (Errors $e) {
         $t->stop();
-        Console::$err->writeLinef('! %s %s at line %d', $path->toString('/'), $e->getMessage(), $e->getLine());
+        Console::$err->writeLinef('! %s: %s ', $file, $e->diagnostics('  '));
         $errors++;
       } finally {
         $total++;

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -1,12 +1,12 @@
 <?php namespace lang\ast\unittest\loader;
 
-use unittest\TestCase;
-use lang\ast\CompilingClassLoader;
-use lang\ClassFormatException;
-use lang\ClassLoader;
 use io\File;
 use io\FileUtil;
+use lang\ClassFormatException;
+use lang\ClassLoader;
 use lang\Environment;
+use lang\ast\CompilingClassLoader;
+use unittest\TestCase;
 
 class CompilingClassLoaderTest extends TestCase {
   private static $runtime;
@@ -29,7 +29,7 @@ class CompilingClassLoaderTest extends TestCase {
   #[@test]
   public function load_class_with_syntax_errors() {
     $f= new File(Environment::tempDir(), 'Errors.php');
-    FileUtil::setContents($f, "<?php\n<Syntax error in line 2>");
+    FileUtil::setContents($f, "<?php\nclass A");
     $cl= ClassLoader::registerPath($f->getPath());
 
     $loader= new CompilingClassLoader(self::$runtime);
@@ -37,7 +37,7 @@ class CompilingClassLoaderTest extends TestCase {
       $loader->loadClass('Errors');
       $this->fail('No exception raised', null, ClassFormatException::class);
     } catch (ClassFormatException $expected) {
-      $this->assertEquals('Syntax error in Errors.php, line 2: Expected ";", have "Syntax"', $expected->getMessage());
+      $this->assertEquals('Syntax error in Errors.php, line 1: Expected "{", have "(end)"', $expected->getMessage());
     } finally {
       ClassLoader::removeLoader($cl);
       $f->unlink();

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -48,7 +48,7 @@ class CompilingClassLoaderTest extends TestCase {
 
   #[@test, @expect(
   #  class= ClassFormatException::class,
-  #  withMessage= 'Syntax error in Errors.php, line 1: Expected "{", have "(end)"'
+  #  withMessage= 'Syntax error in Errors.php, line 2: Expected "{", have "(end)"'
   #)]
   public function load_class_with_syntax_errors() {
     $this->load('Errors', "<?php\nclass");

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -23,7 +23,7 @@ class ErrorsTest extends ParseTest {
   #[@test]
   public function missing_semicolon() {
     $this->assertError(
-      'Expected ";", have "(variable)"',
+      'Missing semicolon before (variable) b',
       $this->parse('$a= 1 $b= 1;')
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -47,8 +47,8 @@ class ErrorsTest extends ParseTest {
   #[@test]
   public function unclosed_type() {
     $this->assertError(
-      'Expected "a type, modifier, property, annotation, method or }", have "-" in type body',
-      $this->parse('class T { -')
+      'Expected a type, modifier, property, annotation, method or "}", have "-"',
+      $this->parse('class T { - }')
     );
   }
 

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -23,7 +23,7 @@ class ErrorsTest extends ParseTest {
   #[@test]
   public function missing_semicolon() {
     $this->assertError(
-      'Missing semicolon before (variable)',
+      'Missing semicolon after assignment statement',
       $this->parse('$a= 1 $b= 1;')
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -23,7 +23,7 @@ class ErrorsTest extends ParseTest {
   #[@test]
   public function missing_semicolon() {
     $this->assertError(
-      'Missing semicolon before (variable) b',
+      'Missing semicolon before (variable)',
       $this->parse('$a= 1 $b= 1;')
     );
   }

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\Error;
+use lang\ast\Errors;
 
 class ErrorsTest extends ParseTest {
 
@@ -14,8 +14,8 @@ class ErrorsTest extends ParseTest {
   private function assertError($message, $parse) {
     try {
       iterator_to_array($parse);
-      $this->fail('No exception raised', null, Error::class);
-    } catch (Error $expected) {
+      $this->fail('No exception raised', null, Errors::class);
+    } catch (Errors $expected) {
       $this->assertEquals($message, $expected->getMessage());
     }
   }

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -56,7 +56,7 @@ class ErrorsTest extends ParseTest {
   public function missing_comma_in_implements() {
     $this->assertError(
       'Expected ", or {", have "B" in interfaces list',
-      $this->parse('class A implements I B')
+      $this->parse('class A implements I B { }')
     );
   }
 
@@ -64,7 +64,7 @@ class ErrorsTest extends ParseTest {
   public function missing_comma_in_interface_parents() {
     $this->assertError(
       'Expected ", or {", have "B" in interface parents',
-      $this->parse('interface I extends A B')
+      $this->parse('interface I extends A B { }')
     );
   }
 

--- a/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/ErrorsTest.class.php
@@ -75,4 +75,12 @@ class ErrorsTest extends ParseTest {
       $this->parse('<<annotation')
     );
   }
+
+  #[@test]
+  public function unclosed_offset() {
+    $this->assertError(
+      'Expected "]", have ";"',
+      $this->parse('$a[$s[0]= 5;')
+    );
+  }
 }

--- a/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/TypesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\parse;
 
-use lang\ast\Error;
+use lang\ast\Errors;
 
 class TypesTest extends ParseTest {
 
@@ -116,17 +116,17 @@ class TypesTest extends ParseTest {
     );
   }
 
-  #[@test, @expect(class= Error::class, withMessage= 'Cannot redeclare method b()')]
+  #[@test, @expect(class= Errors::class, withMessage= 'Cannot redeclare method b()')]
   public function cannot_redeclare_method() {
     iterator_to_array($this->parse('class A { public function b() { } public function b() { }}'));
   }
 
-  #[@test, @expect(class= Error::class, withMessage= 'Cannot redeclare property $b')]
+  #[@test, @expect(class= Errors::class, withMessage= 'Cannot redeclare property $b')]
   public function cannot_redeclare_property() {
     iterator_to_array($this->parse('class A { public $b; private $b; }'));
   }
 
-  #[@test, @expect(class= Error::class, withMessage= 'Cannot redeclare constant B')]
+  #[@test, @expect(class= Errors::class, withMessage= 'Cannot redeclare constant B')]
   public function cannot_redeclare_constant() {
     iterator_to_array($this->parse('class A { const B = 1; const B = 3; }'));
   }


### PR DESCRIPTION
```bash
$ cat -n Test.php
     1  <?php
     2
     3  class Test {
     4    yield;
     5
     6    public static function main() {
     7      echo 'Hello World', "\n";
     8    }
     9
    10    public function main() {
    11      print('Main method')
    12    }
    13  }

$ xp compile -n Test.php
! Test.php: Errors {
    Expected a type, modifier, property, annotation, method or "}", have ";" at line 4
    Cannot redeclare method main() at line 10
    Missing semicolon after invoke statement at line 11
  }

× Compiled 1 file(s) to  using lang.ast.emit.PHP72, 1 error(s) occurred
Memory used: 2219.24 kB (2269.96 kB peak)
Time taken: 0.011 seconds
```