### PR TITLE
Allow empty catch type to catch all exceptions

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -589,7 +589,11 @@ abstract class Emitter {
   }
 
   protected function emitCatch($catch) {
-    $this->out->write('catch('.implode('|', $catch->types).' $'.$catch->variable.') {');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $this->out->write('catch('.implode('|', $catch->types).' $'.$catch->variable.') {');
+    }
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -589,10 +589,11 @@ abstract class Emitter {
   }
 
   protected function emitCatch($catch) {
+    $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+      $this->out->write('catch(\\Throwable '.$var.') {');
     } else {
-      $this->out->write('catch('.implode('|', $catch->types).' $'.$catch->variable.') {');
+      $this->out->write('catch('.implode('|', $catch->types).' '.$var.') {');
     }
     $this->emit($catch->body);
     $this->out->write('}');

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -689,8 +689,12 @@ class Parse {
             $this->token= $this->advance();
           }
 
-          $variable= $this->token->value;
-          $this->token= $this->advance();
+          if ('variable' === $this->token->kind) {
+            $variable= $this->token->value;
+            $this->token= $this->advance();
+          } else {
+            $variable= null;
+          }
           $this->token= $this->expect(')');
         } else {
           $variable= null;

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -677,22 +677,28 @@ class Parse {
       $catches= [];
       while ('catch'  === $this->token->value) {
         $this->token= $this->advance();
-        $this->token= $this->expect('(');
 
-        $types= [];
-        while ('name' === $this->token->kind) {
-          $types[]= $this->scope->resolve($this->token->value);
+        if ('(' === $this->token->value) {
+          $this->token= $this->expect('(');
+
+          $types= [];
+          while ('name' === $this->token->kind) {
+            $types[]= $this->scope->resolve($this->token->value);
+            $this->token= $this->advance();
+            if ('|' !== $this->token->value) break;
+            $this->token= $this->advance();
+          }
+
+          $variable= $this->token->value;
           $this->token= $this->advance();
-          if ('|' !== $this->token->value) break;
-          $this->token= $this->advance();
+          $this->token= $this->expect(')');
+        } else {
+          $variable= null;
+          $types= [];
         }
 
-        $variable= $this->token;
-        $this->token= $this->advance();
-        $this->token= $this->expect(')');
-
         $this->token= $this->expect('{');
-        $catches[]= new CatchStatement($types, $variable->value, $this->statements());
+        $catches[]= new CatchStatement($types, $variable, $this->statements());
         $this->token= $this->expect('}');
       }
 

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -32,14 +32,14 @@ class HHVM320 extends Emitter {
   protected function emitCatch($catch) {
     $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Throwable $'.$var.') {');
+      $this->out->write('catch(\\Throwable '.$var.') {');
     } else {
       $last= array_pop($catch->types);
       $label= sprintf('c%u', crc32($last));
       foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$var.') { goto '.$label.'; }');
+        $this->out->write('catch('.$type.' '.$var.') { goto '.$label.'; }');
       }
-      $this->out->write('catch('.$last.' $'.$var.') { '.$label.':');
+      $this->out->write('catch('.$last.' '.$var.') { '.$label.':');
     }
 
     $this->emit($catch->body);

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -30,15 +30,16 @@ class HHVM320 extends Emitter {
   }
 
   protected function emitCatch($catch) {
+    $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+      $this->out->write('catch(\\Throwable $'.$var.') {');
     } else {
       $last= array_pop($catch->types);
       $label= sprintf('c%u', crc32($last));
       foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+        $this->out->write('catch('.$type.' $'.$var.') { goto '.$label.'; }');
       }
-      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
+      $this->out->write('catch('.$last.' $'.$var.') { '.$label.':');
     }
 
     $this->emit($catch->body);

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -30,13 +30,17 @@ class HHVM320 extends Emitter {
   }
 
   protected function emitCatch($catch) {
-    $last= array_pop($catch->types);
-    $label= sprintf('c%u', crc32($last));
-    foreach ($catch->types as $type) {
-      $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     }
 
-    $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -106,15 +106,16 @@ class PHP56 extends \lang\ast\Emitter {
   }
 
   protected function emitCatch($catch) {
+    $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Exception $'.$catch->variable.') {');
+      $this->out->write('catch(\\Exception $'.$var.') {');
     } else {
       $last= array_pop($catch->types);
       $label= sprintf('c%u', crc32($last));
       foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+        $this->out->write('catch('.$type.' $'.$var.') { goto '.$label.'; }');
       }
-      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
+      $this->out->write('catch('.$last.' $'.$var.') { '.$label.':');
     }
 
     $this->emit($catch->body);

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -106,13 +106,17 @@ class PHP56 extends \lang\ast\Emitter {
   }
 
   protected function emitCatch($catch) {
-    $last= array_pop($catch->types);
-    $label= sprintf('c%u', crc32($last));
-    foreach ($catch->types as $type) {
-      $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Exception $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     }
 
-    $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -108,14 +108,14 @@ class PHP56 extends \lang\ast\Emitter {
   protected function emitCatch($catch) {
     $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Exception $'.$var.') {');
+      $this->out->write('catch(\\Exception '.$var.') {');
     } else {
       $last= array_pop($catch->types);
       $label= sprintf('c%u', crc32($last));
       foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$var.') { goto '.$label.'; }');
+        $this->out->write('catch('.$type.' '.$var.') { goto '.$label.'; }');
       }
-      $this->out->write('catch('.$last.' $'.$var.') { '.$label.':');
+      $this->out->write('catch('.$last.' '.$var.') { '.$label.':');
     }
 
     $this->emit($catch->body);

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -23,14 +23,14 @@ class PHP70 extends \lang\ast\Emitter {
   protected function emitCatch($catch) {
     $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Throwable $'.$var.') {');
+      $this->out->write('catch(\\Throwable '.$var.') {');
     } else {
       $last= array_pop($catch->types);
       $label= sprintf('c%u', crc32($last));
       foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$var.') { goto '.$label.'; }');
+        $this->out->write('catch('.$type.' '.$var.') { goto '.$label.'; }');
       }
-      $this->out->write('catch('.$last.' $'.$var.') { '.$label.':');
+      $this->out->write('catch('.$last.' '.$var.') { '.$label.':');
     }
 
     $this->emit($catch->body);

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -21,15 +21,16 @@ class PHP70 extends \lang\ast\Emitter {
   ];
 
   protected function emitCatch($catch) {
+    $var= $catch->variable ? '$'.$catch->variable : $this->temp();
     if (empty($catch->types)) {
-      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+      $this->out->write('catch(\\Throwable $'.$var.') {');
     } else {
       $last= array_pop($catch->types);
       $label= sprintf('c%u', crc32($last));
       foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+        $this->out->write('catch('.$type.' $'.$var.') { goto '.$label.'; }');
       }
-      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
+      $this->out->write('catch('.$last.' $'.$var.') { '.$label.':');
     }
 
     $this->emit($catch->body);

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -21,13 +21,17 @@ class PHP70 extends \lang\ast\Emitter {
   ];
 
   protected function emitCatch($catch) {
-    $last= array_pop($catch->types);
-    $label= sprintf('c%u', crc32($last));
-    foreach ($catch->types as $type) {
-      $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     }
 
-    $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -55,6 +55,21 @@ class ExceptionsTest extends EmittingTest {
       public function run() {
         try {
           throw new \\lang\\IllegalArgumentException("test");
+        } catch (\\lang\\IllegalArgumentException) {
+          return true;
+        }
+      }
+    }');
+
+    $this->assertTrue($t->newInstance()->run());
+  }
+
+  #[@test]
+  public function anonymous_catch() {
+    $t= $this->type('class <T> {
+      public function run() {
+        try {
+          throw new \\lang\\IllegalArgumentException("test");
         } catch {
           return false;
         }

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -48,4 +48,19 @@ class ExceptionsTest extends EmittingTest {
 
     $this->assertEquals(IllegalArgumentException::class, $t->newInstance()->run());
   }
+
+  #[@test]
+  public function catch_without_variable() {
+    $t= $this->type('class <T> {
+      public function run() {
+        try {
+          throw new \\lang\\IllegalArgumentException("test");
+        } catch {
+          return false;
+        }
+      }
+    }');
+
+    $this->assertFalse($t->newInstance()->run());
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -33,4 +33,19 @@ class ExceptionsTest extends EmittingTest {
 
     $this->assertEquals(4, $t->newInstance()->run());
   }
+
+  #[@test]
+  public function catch_without_type() {
+    $t= $this->type('class <T> {
+      public function run() {
+        try {
+          throw new \\lang\\IllegalArgumentException("test");
+        } catch ($e) {
+          return get_class($e);
+        }
+      }
+    }');
+
+    $this->assertEquals(IllegalArgumentException::class, $t->newInstance()->run());
+  }
 }


### PR DESCRIPTION
## Form without variable

Will catch but not assign any variable:

```php
try {
  …
} catch (IllegalArgumentException) {
  // Handle exception
}
```


## Form without type

Will catch *all* exceptions - a shorthand for `catch (\Throwable $e)`:

```php
try {
  …
} catch ($e) {
  // Handle exception
}
```

## Anonymous catch

Will catch all exceptions and not assign any variable:

```php
try {
  …
} catch {
  // Handle
}
```

## Related

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
https://wiki.php.net/rfc/anonymous_catch - allows omitting variable if not needed.