### PR TITLE
Allow empty catch type to catch all exceptions

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -589,7 +589,11 @@ abstract class Emitter {
   }
 
   protected function emitCatch($catch) {
-    $this->out->write('catch('.implode('|', $catch->types).' $'.$catch->variable.') {');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $this->out->write('catch('.implode('|', $catch->types).' $'.$catch->variable.') {');
+    }
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -30,13 +30,17 @@ class HHVM320 extends Emitter {
   }
 
   protected function emitCatch($catch) {
-    $last= array_pop($catch->types);
-    $label= sprintf('c%u', crc32($last));
-    foreach ($catch->types as $type) {
-      $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     }
 
-    $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -106,13 +106,17 @@ class PHP56 extends \lang\ast\Emitter {
   }
 
   protected function emitCatch($catch) {
-    $last= array_pop($catch->types);
-    $label= sprintf('c%u', crc32($last));
-    foreach ($catch->types as $type) {
-      $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Exception $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     }
 
-    $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -21,13 +21,17 @@ class PHP70 extends \lang\ast\Emitter {
   ];
 
   protected function emitCatch($catch) {
-    $last= array_pop($catch->types);
-    $label= sprintf('c%u', crc32($last));
-    foreach ($catch->types as $type) {
-      $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     }
 
-    $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
     $this->emit($catch->body);
     $this->out->write('}');
   }

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -33,4 +33,19 @@ class ExceptionsTest extends EmittingTest {
 
     $this->assertEquals(4, $t->newInstance()->run());
   }
+
+  #[@test]
+  public function catch_without_type() {
+    $t= $this->type('class <T> {
+      public function run() {
+        try {
+          throw new \\lang\\IllegalArgumentException("test");
+        } catch ($e) {
+          return get_class($e);
+        }
+      }
+    }');
+
+    $this->assertEquals(IllegalArgumentException::class, $t->newInstance()->run());
+  }
 }


### PR DESCRIPTION
Like #46 but only with "catch all" form - a shorthand for `catch (\Throwable $e)`:

```php
try {
  …
} catch ($e) {
  // Handle exception
}
```
