### PR TITLE
Allow arrow functions with blocks

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -335,8 +335,8 @@ abstract class Emitter {
 
     if ($closure->use) {
       $this->out->write(' use('.implode(',', $closure->use).') ');
-      foreach ($closure->use as $name) {
-        $this->locals[substr($name, 1)]= true;
+      foreach ($closure->use as $variable) {
+        $this->locals[substr($variable, 1)]= true;
       }
     }
     $this->out->write('{');

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -209,7 +209,6 @@ abstract class Emitter {
   }
 
   protected function emitVariable($variable) {
-    $this->locals[$variable]= true;
     $this->out->write('$'.$variable);
   }
 
@@ -565,8 +564,24 @@ abstract class Emitter {
     }
   }
 
+  protected function emitAssign($target) {
+    if ('variable' === $target->kind) {
+      $this->out->write('$'.$target->value);
+      $this->locals[$target->value]= true;
+    } else if ('array' === $target->kind) {
+      $this->out->write('[');
+      foreach ($target->value as $pair) {
+        $this->emitAssign($pair[1]);
+        $this->out->write(',');
+      }
+      $this->out->write(']');
+    } else {
+      $this->emit($target);
+    }
+  }
+
   protected function emitAssignment($assignment) {
-    $this->emit($assignment->variable);
+    $this->emitAssign($assignment->variable);
     $this->out->write($assignment->operator);
     $this->emit($assignment->expression);
   }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -567,8 +567,10 @@ abstract class Emitter {
   protected function emitAssignment($assignment) {
     if ('variable' === $assignment->variable->kind) {
       $this->locals[$assignment->variable->value]= true;
+      $this->out->write('$'.$assignment->variable->value);
+    } else {
+      $this->emit($assignment->variable);
     }
-    $this->emit($assignment->variable);
     $this->out->write($assignment->operator);
     $this->emit($assignment->expression);
   }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -588,12 +588,12 @@ abstract class Emitter {
       $this->out->write('$'.$target->value);
       $this->locals[$target->value]= true;
     } else if ('array' === $target->kind) {
-      $this->out->write('[');
+      $this->out->write('list(');
       foreach ($target->value as $pair) {
         $this->emitAssign($pair[1]);
         $this->out->write(',');
       }
-      $this->out->write(']');
+      $this->out->write(')');
     } else {
       $this->emit($target);
     }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -209,6 +209,7 @@ abstract class Emitter {
   }
 
   protected function emitVariable($variable) {
+    $this->locals[$variable]= true;
     $this->out->write('$'.$variable);
   }
 
@@ -565,12 +566,7 @@ abstract class Emitter {
   }
 
   protected function emitAssignment($assignment) {
-    if ('variable' === $assignment->variable->kind) {
-      $this->locals[$assignment->variable->value]= true;
-      $this->out->write('$'.$assignment->variable->value);
-    } else {
-      $this->emit($assignment->variable);
-    }
+    $this->emit($assignment->variable);
     $this->out->write($assignment->operator);
     $this->emit($assignment->expression);
   }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -331,7 +331,7 @@ abstract class Emitter {
   }
 
   protected function emitLambda($lambda) {
-    $this->out->write('function'); 
+    $this->out->write('@function');
     $this->emitSignature($lambda->signature);
 
     $capture= [];
@@ -344,9 +344,15 @@ abstract class Emitter {
     }
     $capture && $this->out->write(' use($'.implode(', $', array_keys($capture)).')');
 
-    $this->out->write('{ return ');
-    $this->emit($lambda->body);
-    $this->out->write('; }');
+    if (is_array($lambda->body)) {
+      $this->out->write('{');
+      $this->emit($lambda->body);
+      $this->out->write('}');
+    } else {
+      $this->out->write('{ return ');
+      $this->emit($lambda->body);
+      $this->out->write('; }');
+    }
   }
 
   protected function emitClass($class) {

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -154,7 +154,16 @@ class Parse {
 
     $this->infix('==>', 80, function($node, $left) {
       $signature= new Signature([new Parameter($left->value, null)], null);
-      $node->value= new LambdaExpression($signature, $this->expression(0));
+
+      if ('{' === $this->token->value) {
+        $this->token= $this->expect('{');
+        $statements= $this->statements();
+        $this->token= $this->expect('}');
+      } else {
+        $statements= $this->expression(0);
+      }
+
+      $node->value= new LambdaExpression($signature, $statements);
       $node->kind= 'lambda';
       return $node;
     });
@@ -262,7 +271,16 @@ class Parse {
         $this->token= $this->advance();
         $signature= $this->signature();
         $this->token= $this->advance();
-        $node->value= new LambdaExpression($signature, $this->expression(0));
+
+        if ('{' === $this->token->value) {
+          $this->token= $this->expect('{');
+          $statements= $this->statements();
+          $this->token= $this->expect('}');
+        } else {
+          $statements= $this->expression(0);
+        }
+
+        $node->value= new LambdaExpression($signature, $statements);
       } else if ($cast && ('operator' !== $this->token->kind || '(' === $this->token->value || '[' === $this->token->value)) {
         $node->kind= 'cast';
 

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -46,18 +46,19 @@ class HHVM320 extends Emitter {
     $this->out->write('}');
   }
 
-  protected function emitAssignment($assignment) {
-    if ('array' === $assignment->variable->kind) {
+  protected function emitAssign($target) {
+    if ('variable' === $target->kind) {
+      $this->out->write('$'.$target->value);
+      $this->locals[$target->value]= true;
+    } else if ('array' === $target->kind) {
       $this->out->write('list(');
-      foreach ($assignment->variable->value as $pair) {
-        $this->emit($pair[1]);
+      foreach ($target->value as $pair) {
+        $this->emitAssign($pair[1]);
         $this->out->write(',');
       }
       $this->out->write(')');
-      $this->out->write($assignment->operator);
-      $this->emit($assignment->expression);
     } else {
-      parent::emitAssignment($assignment);
+      $this->emit($target);
     }
   }
 

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -27,7 +27,7 @@ class HHVM320 extends Emitter {
       $this->out->write('=');
       $this->emit($parameter->default);
     }
-    $this->locals[0][$parameter->name]= true;
+    $this->locals[$parameter->name]= true;
   }
 
   protected function emitCatch($catch) {

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -46,22 +46,6 @@ class HHVM320 extends Emitter {
     $this->out->write('}');
   }
 
-  protected function emitAssign($target) {
-    if ('variable' === $target->kind) {
-      $this->out->write('$'.$target->value);
-      $this->locals[$target->value]= true;
-    } else if ('array' === $target->kind) {
-      $this->out->write('list(');
-      foreach ($target->value as $pair) {
-        $this->emitAssign($pair[1]);
-        $this->out->write(',');
-      }
-      $this->out->write(')');
-    } else {
-      $this->emit($target);
-    }
-  }
-
   protected function emitConst($const) {
     $this->out->write('const '.$const->name.'=');
     $this->emit($const->expression);

--- a/src/main/php/lang/ast/emit/HHVM320.class.php
+++ b/src/main/php/lang/ast/emit/HHVM320.class.php
@@ -27,6 +27,7 @@ class HHVM320 extends Emitter {
       $this->out->write('=');
       $this->emit($parameter->default);
     }
+    $this->locals[0][$parameter->name]= true;
   }
 
   protected function emitCatch($catch) {

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -127,22 +127,6 @@ class PHP56 extends \lang\ast\Emitter {
     $this->out->write(';');
   }
 
-  protected function emitAssign($target) {
-    if ('variable' === $target->kind) {
-      $this->out->write('$'.$target->value);
-      $this->locals[$target->value]= true;
-    } else if ('array' === $target->kind) {
-      $this->out->write('list(');
-      foreach ($target->value as $pair) {
-        $this->emitAssign($pair[1]);
-        $this->out->write(',');
-      }
-      $this->out->write(')');
-    } else {
-      $this->emit($target);
-    }
-  }
-
   protected function emitBinary($binary) {
     if ('??' === $binary->operator) {
       $this->out->write('isset(');

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -127,18 +127,19 @@ class PHP56 extends \lang\ast\Emitter {
     $this->out->write(';');
   }
 
-  protected function emitAssignment($assignment) {
-    if ('array' === $assignment->variable->kind) {
+  protected function emitAssign($target) {
+    if ('variable' === $target->kind) {
+      $this->out->write('$'.$target->value);
+      $this->locals[$target->value]= true;
+    } else if ('array' === $target->kind) {
       $this->out->write('list(');
-      foreach ($assignment->variable->value as $pair) {
-        $this->emit($pair[1]);
+      foreach ($target->value as $pair) {
+        $this->emitAssign($pair[1]);
         $this->out->write(',');
       }
       $this->out->write(')');
-      $this->out->write($assignment->operator);
-      $this->emit($assignment->expression);
     } else {
-      parent::emitAssignment($assignment);
+      $this->emit($target);
     }
   }
 

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -36,22 +36,6 @@ class PHP70 extends \lang\ast\Emitter {
     $this->out->write('}');
   }
 
-  protected function emitAssign($target) {
-    if ('variable' === $target->kind) {
-      $this->out->write('$'.$target->value);
-      $this->locals[$target->value]= true;
-    } else if ('array' === $target->kind) {
-      $this->out->write('list(');
-      foreach ($target->value as $pair) {
-        $this->emitAssign($pair[1]);
-        $this->out->write(',');
-      }
-      $this->out->write(')');
-    } else {
-      $this->emit($target);
-    }
-  }
-
   protected function emitConst($const) {
     $this->out->write('const '.$const->name.'=');
     $this->emit($const->expression);

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -36,18 +36,19 @@ class PHP70 extends \lang\ast\Emitter {
     $this->out->write('}');
   }
 
-  protected function emitAssignment($assignment) {
-    if ('array' === $assignment->variable->kind) {
+  protected function emitAssign($target) {
+    if ('variable' === $target->kind) {
+      $this->out->write('$'.$target->value);
+      $this->locals[$target->value]= true;
+    } else if ('array' === $target->kind) {
       $this->out->write('list(');
-      foreach ($assignment->variable->value as $pair) {
-        $this->emit($pair[1]);
+      foreach ($target->value as $pair) {
+        $this->emitAssign($pair[1]);
         $this->out->write(',');
       }
       $this->out->write(')');
-      $this->out->write($assignment->operator);
-      $this->emit($assignment->expression);
     } else {
-      parent::emitAssignment($assignment);
+      $this->emit($target);
     }
   }
 

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -63,6 +63,34 @@ class LambdasTest extends EmittingTest {
   }
 
   #[@test]
+  public function captures_local_from_use_list() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $addend= 2;
+        $f= function() use($addend) {
+          return ($a) ==> $a + $addend;
+        };
+        return $f();
+      }
+    }');
+
+    $this->assertEquals(3, $r(1));
+  }
+
+  #[@test]
+  public function captures_local_from_lambd() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $addend= 2;
+        $f= () ==> ($a) ==> $a + $addend;
+        return $f();
+      }
+    }');
+
+    $this->assertEquals(3, $r(1));
+  }
+
+  #[@test]
   public function captures_local_assigned_via_list() {
     $r= $this->run('class <T> {
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -63,6 +63,18 @@ class LambdasTest extends EmittingTest {
   }
 
   #[@test]
+  public function captures_local_assigned_via_list() {
+    $r= $this->run('class <T> {
+      public function run() {
+        [$addend]= [2];
+        return ($a) ==> $a + $addend;
+      }
+    }');
+
+    $this->assertEquals(3, $r(1));
+  }
+
+  #[@test]
   public function captures_param() {
     $r= $this->run('class <T> {
       public function run($addend) {

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -140,4 +140,18 @@ class LambdasTest extends EmittingTest {
 
     $this->assertEquals('IIFE', $r);
   }
+
+  #[@test]
+  public function with_braces() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return () ==> {
+          $a= 1;
+          return $a;
+        };
+      }
+    }');
+
+    $this->assertEquals(1, $r());
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -63,6 +63,17 @@ class LambdasTest extends EmittingTest {
   }
 
   #[@test]
+  public function captures_param() {
+    $r= $this->run('class <T> {
+      public function run($addend) {
+        return ($a) ==> $a + $addend;
+      }
+    }', 2);
+
+    $this->assertEquals(3, $r(1));
+  }
+
+  #[@test]
   public function captures_braced_local() {
     $r= $this->run('class <T> {
       public function run() {


### PR DESCRIPTION
Implements #49

```php
// Current, equivalent to: ==> { return expression; } 
(param1, param2, …, paramN) ==> expression

// New added functionality
(param1, param2, …, paramN) ==> { statements } 
```

This way, this feature is consistent with JavaScript arrow functions, except for the different operator used (`==>` vs `=>`).