### PR TITLE
Implement throw expressions

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -674,6 +674,22 @@ abstract class Emitter {
     $this->out->write(';');
   }
 
+  protected function emitThrowExpression($throw) {
+    $capture= [];
+    foreach ($this->search($throw->value, 'variable') as $var) {
+      if (isset($this->locals[$var->value])) {
+        $capture[$var->value]= true;
+      }
+    }
+    unset($capture['this']);
+
+    $this->out->write('(function()');
+    $capture && $this->out->write(' use($'.implode(', $', array_keys($capture)).')');
+    $this->out->write('{ throw ');
+    $this->emit($throw);
+    $this->out->write('; })()');
+  }
+
   protected function emitForeach($foreach) {
     $this->out->write('foreach (');
     $this->emit($foreach->expression);

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -204,9 +204,9 @@ class Parse {
     });
 
     $this->infix('?', 80, function($node, $left) {
-      $when= $this->expression(0);
+      $when= $this->expressionWithThrows(0);
       $this->token= $this->expect(':');
-      $else= $this->expression(0);
+      $else= $this->expressionWithThrows(0);
       $node->value= new TernaryExpression($left, $when, $else);
       $node->kind= 'ternary';
       return $node;

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -1,13 +1,13 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\ast\Emitter;
 use io\streams\MemoryOutputStream;
 use io\streams\StringWriter;
 use lang\DynamicClassLoader;
-use text\StringTokenizer;
-use lang\ast\Parse;
+use lang\ast\Emitter;
 use lang\ast\Node;
+use lang\ast\Parse;
 use lang\ast\Tokens;
+use text\StringTokenizer;
 
 abstract class EmittingTest extends \unittest\TestCase {
   private static $cl;

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -48,4 +48,54 @@ class ExceptionsTest extends EmittingTest {
 
     $this->assertEquals(IllegalArgumentException::class, $t->newInstance()->run());
   }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function throw_expression_with_null_coalesce() {
+    $t= $this->type('class <T> {
+      public function run($user) {
+        return $user ?? throw new \\lang\\IllegalArgumentException("test");
+      }
+    }');
+    $t->newInstance()->run(null);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function throw_expression_with_ternary() {
+    $t= $this->type('class <T> {
+      public function run($user) {
+        return $user ?: throw new \\lang\\IllegalArgumentException("test");
+      }
+    }');
+    $t->newInstance()->run(null);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function throw_expression_with_lambda() {
+    $t= $this->type('class <T> {
+      public function run() {
+        $f= () ==> throw new \\lang\\IllegalArgumentException("test");
+        $f();
+      }
+    }');
+    $t->newInstance()->run();
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function throw_expression_with_lambda_capturing_variable() {
+    $t= $this->type('class <T> {
+      public function run() {
+        $f= $message ==> throw new \\lang\\IllegalArgumentException($message);
+        $f("test");
+      }
+    }');
+    $t->newInstance()->run();
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function throw_expression_with_compact_method() {
+    $t= $this->type('class <T> {
+      public function run() ==> throw new \\lang\\IllegalArgumentException("test");
+    }');
+    $t->newInstance()->run();
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -70,6 +70,16 @@ class ExceptionsTest extends EmittingTest {
   }
 
   #[@test, @expect(IllegalArgumentException::class)]
+  public function throw_expression_with_short_ternary() {
+    $t= $this->type('class <T> {
+      public function run($user) {
+        return $user ? new User($user) : throw new \\lang\\IllegalArgumentException("test");
+      }
+    }');
+    $t->newInstance()->run(null);
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
   public function throw_expression_with_lambda() {
     $t= $this->type('class <T> {
       public function run() {


### PR DESCRIPTION
As suggested in #51:

### Inside null-coalescing operator (??)

```php
return $user ?? throw new IllegalStateException('No such user');
```

### Inside ternary operator (?:)

```php
return $user ?: throw new IllegalStateException('No such user');
return $args ? $args[0] : throw new IllegalStateException('At least one argument expected');
```

### Inside arrow functions

```php
$raise= $message ==> throw new IllegalStateException($message);
$raise('No such user');
```

### Inside compact functions and methods

```php
class Test {
  public function setup() ==> throw new MethodNotImplementedException(__METHOD__);
}
```

