### PR TITLE
Ensure filenames in errors reflect source files

### DIFF
--- a/src/main/php/lang/ast/Compiled.class.php
+++ b/src/main/php/lang/ast/Compiled.class.php
@@ -57,6 +57,12 @@ class Compiled {
   }
 
   /** @return [:var] */
+  public function url_stat($path) {
+    $opened= substr($path, strpos($path, '://') + 3);
+    return ['size' => self::$source[$opened]->getResourceAsStream($opened)->size()];
+  }
+
+  /** @return [:var] */
   public function stream_stat() {
     return ['size' => strlen($this->compiled)];
   }
@@ -68,6 +74,11 @@ class Compiled {
 
   /** @return void */
   public function stream_close() {
+    // NOOP
+  }
+
+  /** @return void */
+  public function stream_flush() {
     // NOOP
   }
 }

--- a/src/main/php/lang/ast/Compiled.class.php
+++ b/src/main/php/lang/ast/Compiled.class.php
@@ -1,0 +1,73 @@
+<?php namespace lang\ast;
+
+use io\streams\MemoryOutputStream;
+use lang\ClassFormatException;
+use lang\ast\transform\Transformations;
+use text\StreamTokenizer;
+
+class Compiled {
+  public static $source= [];
+  public static $emit;
+
+  private $compiled, $offset;
+
+  /**
+   * Opens path
+   *
+   * @param  string $path
+   * @param  string $mode
+   * @param  int $options
+   * @param  string $opened
+   */
+  public function stream_open($path, $mode, $options, &$opened) {
+    $opened= substr($path, strpos($path, '://') + 3);
+    $in= self::$source[$opened]->getResourceAsStream($opened)->in();
+
+    $declaration= new MemoryOutputStream();
+    try {
+      $parse= new Parse(new Tokens(new StreamTokenizer($in)), $opened);
+      $emitter= self::$emit->newInstance($declaration);
+      foreach (Transformations::registered() as $kind => $function) {
+        $emitter->transform($kind, $function);
+      }
+      $emitter->emit($parse->execute());
+
+      $this->compiled= $declaration->getBytes();
+    } catch (Error $e) {
+      $message= sprintf('Syntax error in %s, line %d: %s', $e->getFile(), $e->getLine(), $e->getMessage());
+      throw new ClassFormatException($message);
+    } finally {
+      $in->close();
+    }
+
+    $this->offset= 0;
+    return true;
+  }
+
+  /**
+   * Reads bytes
+   *
+   * @param  int $count
+   * @return string
+   */
+  public function stream_read($count) {
+    $chunk= substr($this->compiled, $this->offset, $count);
+    $this->offset+= $count;
+    return $chunk;
+  }
+
+  /** @return [:var] */
+  public function stream_stat() {
+    return ['size' => strlen($this->compiled)];
+  }
+
+  /** @return bool */
+  public function stream_eof() {
+    return $this->offset >= strlen($this->compiled);
+  }
+
+  /** @return void */
+  public function stream_close() {
+    // NOOP
+  }
+}

--- a/src/main/php/lang/ast/Compiled.class.php
+++ b/src/main/php/lang/ast/Compiled.class.php
@@ -6,8 +6,7 @@ use lang\ast\transform\Transformations;
 use text\StreamTokenizer;
 
 class Compiled implements OutputStream {
-  public static $source= [];
-  public static $emit;
+  public static $source= [], $emit= [];
 
   private $compiled= '', $offset= 0;
 
@@ -20,12 +19,12 @@ class Compiled implements OutputStream {
    * @param  string $opened
    */
   public function stream_open($path, $mode, $options, &$opened) {
-    $opened= substr($path, strpos($path, '://') + 3);
+    list($version, $opened)= explode('://', $path);
     $in= self::$source[$opened]->getResourceAsStream($opened)->in();
 
     try {
       $parse= new Parse(new Tokens(new StreamTokenizer($in)), $opened);
-      $emitter= self::$emit->newInstance($this);
+      $emitter= self::$emit[$version]->newInstance($this);
       foreach (Transformations::registered() as $kind => $function) {
         $emitter->transform($kind, $function);
       }

--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -236,7 +236,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return string
    */
   public function toString() {
-    return 'CompilingCL<'.$this->emit->getName().'>';
+    return 'CompilingCL<'.$this->version.'>';
   }
 
   /**

--- a/src/test/php/lang/ast/unittest/emit/TypeDeclarationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TypeDeclarationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\reflect\Modifiers;
 use lang\XPClass;
+use lang\reflect\Modifiers;
 
 class TypeDeclarationTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -67,7 +67,8 @@ class CompilingClassLoaderTest extends TestCase {
     }');
 
     $t->newInstance()->trigger();
-    $this->assertEquals(strtr($t->getName(), '.', '/').'.php', key(\xp::$errors));
+    $name= (defined('HHVM_VERSION') ? 'src://' : '').strtr($t->getName(), '.', '/').'.php';
+    $this->assertEquals($name, key(\xp::$errors));
     \xp::gc();
   }
 }

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -67,8 +67,7 @@ class CompilingClassLoaderTest extends TestCase {
     }');
 
     $t->newInstance()->trigger();
-    $name= (defined('HHVM_VERSION') ? 'src://' : '').strtr($t->getName(), '.', '/').'.php';
-    $this->assertEquals($name, key(\xp::$errors),\xp::$errors);
+    $this->assertEquals(strtr($t->getName(), '.', '/').'.php', preg_replace('#^.+://#', '', key(\xp::$errors)));
     \xp::gc();
   }
 }

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -2,6 +2,7 @@
 
 use io\File;
 use io\FileUtil;
+use io\Folder;
 use lang\ClassFormatException;
 use lang\ClassLoader;
 use lang\Environment;
@@ -23,16 +24,19 @@ class CompilingClassLoaderTest extends TestCase {
    * @return lang.XPClass
    */
   private function load($type, $source) {
-    $f= new File(Environment::tempDir(), $type.'.php');
-    FileUtil::setContents($f, sprintf($source, 'ns'.uniqid()));
-    $cl= ClassLoader::registerPath($f->getPath());
+    $namespace= 'ns'.uniqid();
+    $folder= new Folder(Environment::tempDir(), $namespace);
+    $folder->exists() || $folder->create();
+
+    FileUtil::setContents(new File($folder, $type.'.php'), sprintf($source, $namespace));
+    $cl= ClassLoader::registerPath($folder->path);
 
     $loader= new CompilingClassLoader(self::$runtime);
     try {
-      return $loader->loadClass($type);
+      return $loader->loadClass($namespace.'.'.$type);
     } finally {
       ClassLoader::removeLoader($cl);
-      $f->unlink();
+      $folder->unlink();
     }
   }
 
@@ -48,9 +52,22 @@ class CompilingClassLoaderTest extends TestCase {
 
   #[@test, @expect(
   #  class= ClassFormatException::class,
-  #  withMessage= 'Syntax error in Errors.php, line 2: Expected ";", have "Syntax"'
+  #  withMessage= '/Syntax error in .+Errors.php, line 2: Expected ";", have "Syntax"/'
   #)]
   public function load_class_with_syntax_errors() {
     $this->load('Errors', "<?php\n<Syntax error in line 2>");
+  }
+
+  #[@test]
+  public function triggered_errors_filename() {
+    $t= $this->load('Triggers', '<?php namespace %s; class Triggers { 
+      public function trigger() {
+        trigger_error("Test");
+      }
+    }');
+
+    $t->newInstance()->trigger();
+    $this->assertEquals(strtr($t->getName(), '.', '/').'.php', key(\xp::$errors));
+    \xp::gc();
   }
 }

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -31,7 +31,7 @@ class CompilingClassLoaderTest extends TestCase {
     FileUtil::setContents(new File($folder, $type.'.php'), sprintf($source, $namespace));
     $cl= ClassLoader::registerPath($folder->path);
 
-    $loader= new CompilingClassLoader(self::$runtime);
+    $loader= CompilingClassLoader::instanceFor(self::$runtime);
     try {
       return $loader->loadClass($namespace.'.'.$type);
     } finally {
@@ -42,7 +42,7 @@ class CompilingClassLoaderTest extends TestCase {
 
   #[@test]
   public function can_create() {
-    new CompilingClassLoader(self::$runtime);
+    CompilingClassLoader::instanceFor(self::$runtime);
   }
 
   #[@test]
@@ -68,7 +68,7 @@ class CompilingClassLoaderTest extends TestCase {
 
     $t->newInstance()->trigger();
     $name= (defined('HHVM_VERSION') ? 'src://' : '').strtr($t->getName(), '.', '/').'.php';
-    $this->assertEquals($name, key(\xp::$errors));
+    $this->assertEquals($name, key(\xp::$errors),\xp::$errors);
     \xp::gc();
   }
 }


### PR DESCRIPTION
So e.g. "src/main/php/com/example/Service.php" instead of "CompilingClassLoader, eval()`ed code"


```bash
$ cat Test.php
<?php

use lang\Error;

class Test {

  public static function main() {
    trigger_error('Error');
    throw new Error('Test');
  }
}

# Current behavior
$ xp Test
Uncaught exception: Exception lang.Error (Test)
  at <main>::trigger_error() [line 8 of CompilingClassloader.class.php(162) : eval()`d code] Error
  at Test::main(array[0]) [line 374 of class-main.php]

# New behavior
$ xp Test
Uncaught exception: Exception lang.Error (Test)
  at <main>::trigger_error() [line 8 of Test.php] Error
  at Test::main(array[0]) [line 374 of class-main.php]
``` 