### PR TITLE
Implement list comprehensions

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -247,7 +247,7 @@ abstract class Emitter {
         break;
       }
 
-      if ('forexpr' === $pair[1]->kind || 'foreachexpr' === $pair[1]->kind || 'ifexpr' === $pair[1]->kind) {
+      if ('for' === $pair[1]->kind || 'foreach' === $pair[1]->kind || 'if' === $pair[1]->kind) {
         $unpack= true;
         $capture= [];
         foreach ($this->search($pair[1]->value, 'variable') as $var) {
@@ -265,35 +265,9 @@ abstract class Emitter {
     if ($unpack) {
       $this->out->write('array_merge([');
       foreach ($array as $pair) {
-        if ('forexpr' === $pair[1]->kind) {
-          $this->out->write('],iterator_to_array(('.$temp.'=function() '.$use.' { for (');
-          $this->emitArguments($pair[1]->value->initialization);
-          $this->out->write(';');
-          $this->emitArguments($pair[1]->value->condition);
-          $this->out->write(';');
-          $this->emitArguments($pair[1]->value->loop);
-          $this->out->write(') ');
-          $this->emit($pair[1]->value->body);
-          $this->out->write(';}) ? '.$temp.'() : null),[');
-          continue;
-        } else if ('foreachexpr' === $pair[1]->kind) {
-          $this->out->write('],iterator_to_array(('.$temp.'=function() '.$use.' { foreach (');
-          $this->emit($pair[1]->value->expression);
-          $this->out->write(' as ');
-          if ($pair[1]->value->key) {
-            $this->emit($pair[1]->value->key);
-            $this->out->write(' => ');
-          }
-          $this->emit($pair[1]->value->value);
-          $this->out->write(') ');
-          $this->emit($pair[1]->value->body);
-          $this->out->write(';}) ? '.$temp.'() : null),[');
-          continue;
-        } else if ('ifexpr' === $pair[1]->kind) {
-          $this->out->write('],iterator_to_array(('.$temp.'=function() '.$use.' { if (');
-          $this->emit($pair[1]->value->expression);
-          $this->out->write(') ');
-          $this->emit($pair[1]->value->body);
+        if ('for' === $pair[1]->kind || 'foreach' === $pair[1]->kind || 'if' === $pair[1]->kind) {
+          $this->out->write('],iterator_to_array(('.$temp.'=function() '.$use.' {');
+          $this->emit($pair[1]);
           $this->out->write(';}) ? '.$temp.'() : null),[');
           continue;
         }

--- a/src/test/php/lang/ast/unittest/emit/ComprehensionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ComprehensionsTest.class.php
@@ -1,0 +1,85 @@
+<?php namespace lang\ast\unittest\emit;
+
+class ComprehensionsTest extends EmittingTest {
+
+  #[@test]
+  public function for_expression() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [for ($i= 1; $i < 4; $i++) yield $i];
+      }
+    }');
+
+    $this->assertEquals([1, 2, 3], $r);
+  }
+
+  #[@test]
+  public function for_expression_with_variables() {
+    $r= $this->run('class <T> {
+      public function run($factor) {
+        return [for ($i= 1; $i < 4; $i++) yield $i * $factor];
+      }
+    }', 2);
+
+    $this->assertEquals([2, 4, 6], $r);
+  }
+
+  #[@test]
+  public function foreach_expression() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $input= ["one" => "eins", "three" => "drei"];
+        return [foreach ($input as $key => $val) yield $val => $key];
+      }
+    }');
+
+    $this->assertEquals(['eins' => 'one', 'drei' => 'three'], $r);
+  }
+
+  #[@test]
+  public function if_expression_true() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [if (true) yield 1];
+      }
+    }');
+
+    $this->assertEquals([1], $r);
+  }
+
+  #[@test]
+  public function if_expression_false() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [if (false) yield 1];
+      }
+    }');
+
+    $this->assertEquals([], $r);
+  }
+
+  #[@test]
+  public function if_expression_with_variables() {
+    $r= $this->run('class <T> {
+      public function run($conditional) {
+        return [if (true) yield $conditional];
+      }
+    }', 2);
+
+    $this->assertEquals([2], $r);
+  }
+
+  #[@test, @values(map= [
+  #  true  => [1, 2, 3],
+  #  false => [1, 3],
+  #])]
+  public function if_expression_with_array($condition, $expected) {
+    $r= $this->run('class <T> {
+      public function run($condition) {
+        return [1, if ($condition) yield 2, 3];
+      }
+    }', $condition);
+
+    $this->assertEquals($expected, $r);
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/ComprehensionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ComprehensionsTest.class.php
@@ -25,6 +25,28 @@ class ComprehensionsTest extends EmittingTest {
   }
 
   #[@test]
+  public function for_expression_with_if() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [for ($i= 1; $i < 4; $i++) if (0 === $i % 2) yield $i];
+      }
+    }');
+
+    $this->assertEquals([2], $r);
+  }
+
+  #[@test]
+  public function nested_for_expression() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [for ($i= 1; $i < 4; $i++) for ($j= 1; $j < 4; $j++) yield $i * $j];
+      }
+    }');
+
+    $this->assertEquals([1, 2, 3, 2, 4, 6, 3, 6, 9], $r);
+  }
+
+  #[@test]
   public function foreach_expression() {
     $r= $this->run('class <T> {
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/ComprehensionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ComprehensionsTest.class.php
@@ -104,4 +104,17 @@ class ComprehensionsTest extends EmittingTest {
 
     $this->assertEquals($expected, $r);
   }
+
+  #[@test]
+  public function find_common_numbers() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $la= [1, 2, 3, 4];
+        $lb= [2, 3, 4, 5];
+        return [foreach ($la as $a) foreach ($lb as $b) if ($a === $b) yield $a];
+      }
+    }');
+
+    $this->assertEquals([2, 3, 4], $r);
+  }
 }


### PR DESCRIPTION
## Examples

### for
```php
// This...
$list= [];
for ($i= 0; $i < 10; $i++) {
  $list[]= $i;
}

// ...becomes:
$list= [for ($i= 0; $i < 10; $i++) yield $i];
```

### if
```php
// This...
$actions= [new Add()];
if ($admin) $actions[]= new Delete();
$actions[]= new Delete();

// ...or this:
$actions= array_filter([new Add(), $admin ? new Delete() : null, new Edit()];

// ...becomes:
$actions= [new Add(), if ($admin) yield new Delete(), new Edit()];
```

### foreach
```php
// This...
$flipped= [];
foreach ($input as $key => $val) {
  $flipped[$val]= $key;
}

// ...becomes
$flipped= [foreach ($input as $key => $val) yield $val => $key];
```

See https://docs.python.org/3/reference/expressions.html and https://dart.dev/guides/language/language-tour#collection-operators

/cc @mikey179