### PR TITLE
Refactor emitters, extracting reusable rewriters to traits

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -137,14 +137,7 @@ abstract class Emitter {
   }
 
   protected function returnType($type) {
-    if (null === $type || $type instanceof UnionType || $type instanceof FunctionType) {
-      return '';
-    } else if ($type instanceof ArrayType || $type instanceof MapType) {
-      return 'array';
-    } else {
-      $name= $type->literal();
-      return isset($this->unsupported[$name]) ? '' : $name;
-    }
+    return $this->type($type->literal());
   }
 
   // See https://wiki.php.net/rfc/typed_properties_v2#supported_types
@@ -153,9 +146,10 @@ abstract class Emitter {
       return '';
     } else if ($type instanceof ArrayType || $type instanceof MapType) {
       return 'array';
+    } else if ($type instanceof Type && 'callable' !== $type->literal() && 'void' !== $type->literal()) {
+      return $type->literal();
     } else {
-      $name= $type->literal();
-      return 'callable' === $type->literal() || 'void' === $type->literal() ? '' : $name;
+      return '';
     }
   }
 

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -137,7 +137,14 @@ abstract class Emitter {
   }
 
   protected function returnType($type) {
-    return $this->type($type->literal());
+    if (null === $type || $type instanceof UnionType || $type instanceof FunctionType) {
+      return '';
+    } else if ($type instanceof ArrayType || $type instanceof MapType) {
+      return 'array';
+    } else {
+      $name= $type->literal();
+      return isset($this->unsupported[$name]) ? '' : $name;
+    }
   }
 
   // See https://wiki.php.net/rfc/typed_properties_v2#supported_types
@@ -146,10 +153,9 @@ abstract class Emitter {
       return '';
     } else if ($type instanceof ArrayType || $type instanceof MapType) {
       return 'array';
-    } else if ($type instanceof Type && 'callable' !== $type->literal() && 'void' !== $type->literal()) {
-      return $type->literal();
     } else {
-      return '';
+      $name= $type->literal();
+      return 'callable' === $type->literal() || 'void' === $type->literal() ? '' : $name;
     }
   }
 

--- a/src/main/php/lang/ast/emit/OmitConstModifiers.class.php
+++ b/src/main/php/lang/ast/emit/OmitConstModifiers.class.php
@@ -1,0 +1,16 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Omits public / protected / private modifiers from class constants for
+ * PHP versions not supporting them (all versions below PHP 7.1).
+ *
+ * @see  https://wiki.php.net/rfc/class_const_visibility
+ */
+trait OmitConstModifiers {
+
+  protected function emitConst($const) {
+    $this->out->write('const '.$const->name.'=');
+    $this->emit($const->expression);
+    $this->out->write(';');
+  }
+}

--- a/src/main/php/lang/ast/emit/OmitPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/OmitPropertyTypes.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Removes type hints for PHP versions that do not support typed
+ * properties - everything below PHP 7.4
+ *
+ * @see  https://wiki.php.net/rfc/typed_properties_v2
+ */
+trait OmitPropertyTypes {
+
+  /**
+   * Returns property type
+   *
+   * @param  lang.ast.Type $type
+   * @return string
+   */
+  protected function propertyType($type) { return ''; }
+}

--- a/src/main/php/lang/ast/emit/OmitReturnTypes.class.php
+++ b/src/main/php/lang/ast/emit/OmitReturnTypes.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Removes type hints for PHP versions that do not support return
+ * types - everything below PHP 7.0
+ *
+ * @see  https://wiki.php.net/rfc/return_types
+ */
+trait OmitReturnTypes {
+
+  /**
+   * Returns property type
+   *
+   * @param  lang.ast.Type $type
+   * @return string
+   */
+  protected function returnType($type) { return ''; }
+}

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -1,16 +1,17 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Emitter;
 use lang\ast\nodes\Value;
 
 /**
  * PHP 5.6 syntax
  *
- * @see  https://wiki.php.net/rfc/pow-operator
- * @see  https://wiki.php.net/rfc/variadics
- * @see  https://wiki.php.net/rfc/argument_unpacking
- * @see  https://wiki.php.net/rfc/use_function
+ * @see  https://wiki.php.net/rfc#php_56
  */
-class PHP56 extends \lang\ast\Emitter {
+class PHP56 extends Emitter {
+  use OmitPropertyTypes, OmitReturnTypes, OmitConstModifiers;
+  use RewriteLambdaExpressions;
+
   protected $unsupported= [
     'object'   => 72,
     'void'     => 71,
@@ -89,9 +90,6 @@ class PHP56 extends \lang\ast\Emitter {
     'parent'       => true
   ];
 
-  protected function returnType($name) {
-    return null;
-  }
 
   protected function emitLiteral($literal) {
     if ('"' === $literal{0}) {
@@ -119,12 +117,6 @@ class PHP56 extends \lang\ast\Emitter {
 
     $this->emit($catch->body);
     $this->out->write('}');
-  }
-
-  protected function emitConst($const) {
-    $this->out->write('const '.$const->name.'=');
-    $this->emit($const->expression);
-    $this->out->write(';');
   }
 
   protected function emitBinary($binary) {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,44 +1,20 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Emitter;
+
 /**
  * PHP 7.0 syntax
  *
- * @see  https://wiki.php.net/rfc/generator-delegation - Not yet implemented
- * @see  https://wiki.php.net/rfc/generator-return-expressions - Not yet implemented
- * @see  https://wiki.php.net/rfc/anonymous_classes
- * @see  https://wiki.php.net/rfc/return_types
- * @see  https://wiki.php.net/rfc/isset_ternary
- * @see  https://wiki.php.net/rfc/uniform_variable_syntax
- * @see  https://wiki.php.net/rfc/group_use_declarations
- * @see  https://wiki.php.net/rfc/scalar_type_hints_v5
+ * @see  https://wiki.php.net/rfc#php_70
  */
-class PHP70 extends \lang\ast\Emitter {
+class PHP70 extends Emitter {
+  use OmitPropertyTypes, OmitConstModifiers;
+  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch;
+
   protected $unsupported= [
     'object'   => 72,
     'void'     => 71,
     'iterable' => 71,
     'mixed'    => null,
   ];
-
-  protected function emitCatch($catch) {
-    if (empty($catch->types)) {
-      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
-    } else {
-      $last= array_pop($catch->types);
-      $label= sprintf('c%u', crc32($last));
-      foreach ($catch->types as $type) {
-        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
-      }
-      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
-    }
-
-    $this->emit($catch->body);
-    $this->out->write('}');
-  }
-
-  protected function emitConst($const) {
-    $this->out->write('const '.$const->name.'=');
-    $this->emit($const->expression);
-    $this->out->write(';');
-  }
 }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -1,16 +1,16 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Emitter;
+
 /**
  * PHP 7.1 syntax
  *
- * @see  https://wiki.php.net/rfc/nullable_types - Not yet implemented!
- * @see  https://wiki.php.net/rfc/short_list_syntax - Not yet implemented!
- * @see  https://wiki.php.net/rfc/class_const_visibility - Not yet implemented!
- * @see  https://wiki.php.net/rfc/multiple-catch
- * @see  https://wiki.php.net/rfc/void_return_type
- * @see  https://wiki.php.net/rfc/iterable
+ * @see  https://wiki.php.net/rfc#php_71
  */
-class PHP71 extends \lang\ast\Emitter {
+class PHP71 extends Emitter {
+  use OmitPropertyTypes;
+  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions;
+
   protected $unsupported= [
     'object'   => 72,
     'mixed'    => null,

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -1,11 +1,16 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Emitter;
+
 /**
  * PHP 7.2 syntax
  *
- * @see  https://wiki.php.net/rfc/object-typehint
+ * @see  https://wiki.php.net/rfc#php_72
  */
-class PHP72 extends \lang\ast\Emitter {
+class PHP72 extends Emitter {
+  use OmitPropertyTypes;
+  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions;
+
   protected $unsupported= [
     'mixed'    => null,
   ];

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -1,48 +1,16 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\ArrayType;
 use lang\ast\Emitter;
-use lang\ast\FunctionType;
-use lang\ast\MapType;
-use lang\ast\Type;
-use lang\ast\UnionType;
 
 /**
  * PHP 7.4 syntax
  *
- * @see  https://wiki.php.net/rfc/null_coalesce_equal_operator
- * @see  https://wiki.php.net/rfc/typed_properties_v2
+ * @see  https://wiki.php.net/rfc#php_74
  */
 class PHP74 extends Emitter {
+  use RewriteBlockLambdaExpressions;
+
   protected $unsupported= [
     'mixed'    => null,
   ];
-
-  // See https://wiki.php.net/rfc/typed_properties_v2#supported_types
-  protected function propertyType($type) {
-    if (null === $type || $type instanceof UnionType || $type instanceof FunctionType) {
-      return '';
-    } else if ($type instanceof ArrayType || $type instanceof MapType) {
-      return 'array';
-    } else if ($type instanceof Type && 'callable' !== $type->literal() && 'void' !== $type->literal()) {
-      return $type->literal();
-    } else {
-      return '';
-    }
-  }
-
-  protected function emitAssignment($assignment) {
-    $this->emitAssign($assignment->variable);
-    $this->out->write($assignment->operator);
-    $this->emit($assignment->expression);
-  }
-
-  protected function emitLambda($lambda) {
-    if (is_array($lambda->body)) return parent::emitLambda($lambda);
-
-    $this->out->write('fn');
-    $this->emitSignature($lambda->signature);
-    $this->out->write('=>');
-    $this->emit($lambda->body);
-  }
 }

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -1,11 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\ArrayType;
 use lang\ast\Emitter;
-use lang\ast\FunctionType;
-use lang\ast\MapType;
-use lang\ast\Type;
-use lang\ast\UnionType;
 
 /**
  * PHP 8.0 syntax
@@ -13,35 +8,9 @@ use lang\ast\UnionType;
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends Emitter {
+  use RewriteBlockLambdaExpressions;
+
   protected $unsupported= [
     'mixed'    => null,
   ];
-
-  // See https://wiki.php.net/rfc/typed_properties_v2#supported_types
-  protected function propertyType($type) {
-    if (null === $type || $type instanceof UnionType || $type instanceof FunctionType) {
-      return '';
-    } else if ($type instanceof ArrayType || $type instanceof MapType) {
-      return 'array';
-    } else if ($type instanceof Type && 'callable' !== $type->literal() && 'void' !== $type->literal()) {
-      return $type->literal();
-    } else {
-      return '';
-    }
-  }
-
-  protected function emitAssignment($assignment) {
-    $this->emitAssign($assignment->variable);
-    $this->out->write($assignment->operator);
-    $this->emit($assignment->expression);
-  }
-
-  protected function emitLambda($lambda) {
-    if (is_array($lambda->body)) return parent::emitLambda($lambda);
-
-    $this->out->write('fn');
-    $this->emitSignature($lambda->signature);
-    $this->out->write('=>');
-    $this->emit($lambda->body);
-  }
 }

--- a/src/main/php/lang/ast/emit/RewriteBlockLambdaExpressions.class.php
+++ b/src/main/php/lang/ast/emit/RewriteBlockLambdaExpressions.class.php
@@ -1,0 +1,19 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites lambda expressions with multi-statement bodies to regular
+ * closures.
+ *
+ * @see  https://wiki.php.net/rfc/arrow_functions_v2#multi-statement_bodies
+ */
+trait RewriteBlockLambdaExpressions {
+  use RewriteLambdaExpressions { emitLambda as rewriteLambda; }
+
+  protected function emitLambda($lambda) {
+    if (is_array($lambda->body)) {
+      $this->rewriteLambda($lambda);
+    } else {
+      parent::emitLambda($lambda);
+    }
+  }
+}

--- a/src/main/php/lang/ast/emit/RewriteLambdaExpressions.class.php
+++ b/src/main/php/lang/ast/emit/RewriteLambdaExpressions.class.php
@@ -1,0 +1,47 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites lambda expressions (or "arrow functions") to regular closures.
+ *
+ * @see  https://wiki.php.net/rfc/arrow_functions_v2
+ */
+trait RewriteLambdaExpressions {
+
+  protected function emitLambda($lambda) {
+    $capture= [];
+    foreach ($this->search($lambda->body, 'variable') as $var) {
+      if (isset($this->locals[$var->value])) {
+        $capture[$var->value]= true;
+      }
+    }
+    unset($capture['this']);
+
+    $this->stack[]= $this->locals;
+    $this->locals= [];
+
+    $this->out->write('function');
+    $this->emitSignature($lambda->signature);
+    foreach ($lambda->signature->parameters as $param) {
+      unset($capture[$param->name]);
+    }
+
+    if ($capture) {
+      $this->out->write(' use($'.implode(', $', array_keys($capture)).')');
+      foreach ($capture as $name => $_) {
+        $this->locals[$name]= true;
+      }
+    }
+
+    if (is_array($lambda->body)) {
+      $this->out->write('{');
+      $this->emit($lambda->body);
+      $this->out->write('}');
+    } else {
+      $this->out->write('{ return ');
+      $this->emit($lambda->body);
+      $this->out->write('; }');
+    }
+
+    $this->locals= array_pop($this->stack);
+  }
+}

--- a/src/main/php/lang/ast/emit/RewriteMultiCatch.class.php
+++ b/src/main/php/lang/ast/emit/RewriteMultiCatch.class.php
@@ -1,0 +1,25 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites multiple catch exception types
+ *
+ * @see  https://wiki.php.net/rfc/multiple-catch
+ */
+trait RewriteMultiCatch {
+ 
+  protected function emitCatch($catch) {
+    if (empty($catch->types)) {
+      $this->out->write('catch(\\Throwable $'.$catch->variable.') {');
+    } else {
+      $last= array_pop($catch->types);
+      $label= sprintf('c%u', crc32($last));
+      foreach ($catch->types as $type) {
+        $this->out->write('catch('.$type.' $'.$catch->variable.') { goto '.$label.'; }');
+      }
+      $this->out->write('catch('.$last.' $'.$catch->variable.') { '.$label.':');
+    }
+
+    $this->emit($catch->body);
+    $this->out->write('}');
+  }
+}

--- a/src/main/php/lang/ast/emit/RewriteNullCoalesceAssignment.class.php
+++ b/src/main/php/lang/ast/emit/RewriteNullCoalesceAssignment.class.php
@@ -1,0 +1,22 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites the null-coalesce equal operator `??=` using the regular
+ * assignment operator.
+ *
+ * @see  https://wiki.php.net/rfc/null_coalesce_equal_operator
+ */
+trait RewriteNullCoalesceAssignment {
+
+  protected function emitAssignment($assignment) {
+    if ('??=' === $assignment->operator) {
+      $this->emitAssign($assignment->variable);
+      $this->out->write('=');
+      $this->emit($assignment->variable);
+      $this->out->write('??');
+      $this->emit($assignment->expression);
+    } else {
+      parent::emitAssignment($assignment);
+    }
+  }
+}


### PR DESCRIPTION
Instead of having the most common implementation inside `lang.ast.Emitter` and then overwriting inside the specialized emitters in `lang.ast.emit`, the latter now use traits to compose overwritten functionality.