### PR TITLE
Implement `is` operator as replacement for instanceof & is_*()

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -752,15 +752,26 @@ abstract class Emitter {
       $this->emit($instanceof->expression);
       $this->out->write(')');
       return;
+    } else if (
+      $instanceof->type instanceof MapType ||
+      $instanceof->type instanceof ArrayType ||
+      $instanceof->type instanceof UnionType ||
+      $instanceof->type instanceof FunctionType
+    ) {
+      $this->out->write('is("'.$instanceof->type->name().'",');
+      $this->emit($instanceof->expression);
+      $this->out->write(')');
+      return;
     }
 
-    if ('?' === $instanceof->type[0]) {
+    $type= $instanceof->type->literal();
+    if ('?' === $type[0]) {
       $t= $this->temp();
       $this->out->write('null===('.$t.'=');
       $this->emit($instanceof->expression);
       $this->out->write(')||');
 
-      $type= substr($instanceof->type, 1);
+      $type= substr($type, 1);
       if ('iterable' === $type) {
         $this->out->write('is_array('.$t.')||'.$t.' instanceof \\Traversable');
       } else if (isset($is[$type])) {
@@ -769,18 +780,18 @@ abstract class Emitter {
         $this->out->write($t.' instanceof '.$type);
       }
     } else {
-      if ('iterable' === $instanceof->type) {
+      if ('iterable' === $type) {
         $t= $this->temp();
         $this->out->write('is_array('.$t.'=');
         $this->emit($instanceof->expression);
         $this->out->write(')||'.$t.' instanceof \\Traversable');
-      } else if (isset($is[$instanceof->type])) {
-        $this->out->write('is_'.$instanceof->type.'(');
+      } else if (isset($is[$type])) {
+        $this->out->write('is_'.$type.'(');
         $this->emit($instanceof->expression);
         $this->out->write(')');
       } else {
         $this->emit($instanceof->expression);
-        $this->out->write(' instanceof '.$instanceof->type);
+        $this->out->write(' instanceof '.$type);
       }
     }
   }

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -122,15 +122,11 @@ class Parse {
     });
 
     $this->infix('is', 60, function($node, $left) {
-      if ('?' === $this->token->value) {
-        $this->token= $this->advance();
-        $node->value= new InstanceOfExpression($left, '?'.$this->scope->resolve($this->token->value));
-        $this->token= $this->advance();
-      } else if ('name' === $this->token->kind) {
-        $node->value= new InstanceOfExpression($left, $this->scope->resolve($this->token->value));
-        $this->token= $this->advance();
-      } else {
+      $t= $this->type(true);
+      if (null === $t) {
         $node->value= new InstanceOfExpression($left, $this->expression(0));
+      } else {
+        $node->value= new InstanceOfExpression($left, $t);
       }
 
       $node->kind= 'is';

--- a/src/main/php/lang/ast/Parse.class.php
+++ b/src/main/php/lang/ast/Parse.class.php
@@ -121,6 +121,22 @@ class Parse {
       return $node;
     });
 
+    $this->infix('is', 60, function($node, $left) {
+      if ('?' === $this->token->value) {
+        $this->token= $this->advance();
+        $node->value= new InstanceOfExpression($left, '?'.$this->scope->resolve($this->token->value));
+        $this->token= $this->advance();
+      } else if ('name' === $this->token->kind) {
+        $node->value= new InstanceOfExpression($left, $this->scope->resolve($this->token->value));
+        $this->token= $this->advance();
+      } else {
+        $node->value= new InstanceOfExpression($left, $this->expression(0));
+      }
+
+      $node->kind= 'is';
+      return $node;
+    });
+
     $this->infix('->', 80, function($node, $left) {
       if ('{' === $this->token->value) {
         $this->token= $this->advance();

--- a/src/test/php/lang/ast/unittest/emit/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IsOperatorTest.class.php
@@ -92,7 +92,7 @@ class IsOperatorTest extends EmittingTest {
   }
 
   #[@test]
-  public function is_array_type() {
+  public function is_array_pseudo_type() {
     $r= $this->run('class <T> {
       public function run() {
         return [[] is array, [1, 2, 3] is array, ["key" => "value"] is array, null is array];
@@ -103,7 +103,7 @@ class IsOperatorTest extends EmittingTest {
   }
 
   #[@test]
-  public function is_object_type() {
+  public function is_object_pseudo_type() {
     $r= $this->run('class <T> {
       public function run() {
         return [$this is object, function() { } is object, null is object];
@@ -114,7 +114,7 @@ class IsOperatorTest extends EmittingTest {
   }
 
   #[@test]
-  public function is_callable_type() {
+  public function is_callable_pseudo_type() {
     $r= $this->run('class <T> {
       public function run() {
         return [function() { } is callable, [$this, "run"] is callable, null is callable];
@@ -125,7 +125,7 @@ class IsOperatorTest extends EmittingTest {
   }
 
   #[@test]
-  public function is_iterable_type() {
+  public function is_native_iterable_type() {
     $r= $this->run('class <T> implements \IteratorAggregate {
       public function getIterator() {
         yield 1;
@@ -137,5 +137,49 @@ class IsOperatorTest extends EmittingTest {
     }');
 
     $this->assertEquals([true, true, false], $r);
+  }
+
+  #[@test]
+  public function is_map_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [["key" => "value"] is array<string, string>, null is array<string, string>];
+      }
+    }');
+
+    $this->assertEquals([true, false], $r);
+  }
+
+  #[@test]
+  public function is_array_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [["key"] is array<string>, ["key"] is array<int>, null is array<string>];
+      }
+    }');
+
+    $this->assertEquals([true, false, false], $r);
+  }
+
+  #[@test]
+  public function is_union_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [1 is int|string, "test" is int|string, null is int|string];
+      }
+    }');
+
+    $this->assertEquals([true, true, false], $r);
+  }
+
+  #[@test]
+  public function is_function_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [function(int $a): int { } is function(int): int, null is function(int): int];
+      }
+    }');
+
+    $this->assertEquals([true, false], $r);
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IsOperatorTest.class.php
@@ -182,4 +182,16 @@ class IsOperatorTest extends EmittingTest {
 
     $this->assertEquals([true, false], $r);
   }
+
+  #[@test]
+  public function precedence() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $arg= "Test";
+        return $arg is string ? sprintf("string <%s>", $arg) : typeof($arg)->literal();
+      }
+    }');
+
+    $this->assertEquals('string <Test>', $r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/IsOperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IsOperatorTest.class.php
@@ -1,0 +1,141 @@
+<?php namespace lang\ast\unittest\emit;
+
+class IsOperatorTest extends EmittingTest {
+
+  #[@test]
+  public function this_is_self() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return $this is self;
+      }
+    }');
+
+    $this->assertTrue($r);
+  }
+
+  #[@test]
+  public function new_self_is_static() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return new self() is static;
+      }
+    }');
+
+    $this->assertTrue($r);
+  }
+
+  #[@test]
+  public function is_qualified_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return new \util\Date() is \util\Date;
+      }
+    }');
+
+    $this->assertTrue($r);
+  }
+
+  #[@test]
+  public function is_imported_type() {
+    $r= $this->run('use util\Date; class <T> {
+      public function run() {
+        return new Date() is Date;
+      }
+    }');
+
+    $this->assertTrue($r);
+  }
+
+  #[@test]
+  public function is_aliased_type() {
+    $r= $this->run('use util\Date as D; class <T> {
+      public function run() {
+        return new D() is D;
+      }
+    }');
+
+    $this->assertTrue($r);
+  }
+
+  #[@test]
+  public function is_type_variable() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $type= self::class;
+        return new self() is $type;
+      }
+    }');
+
+    $this->assertTrue($r);
+  }
+
+  #[@test]
+  public function is_primitive_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [1 is int, true is bool, -6.1 is float, "test" is string];
+      }
+    }');
+
+    $this->assertEquals([true, true, true, true], $r);
+  }
+
+  #[@test]
+  public function is_nullable_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [null is ?int, null is ?self];
+      }
+    }');
+
+    $this->assertEquals([true, true], $r);
+  }
+
+  #[@test]
+  public function is_array_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [[] is array, [1, 2, 3] is array, ["key" => "value"] is array, null is array];
+      }
+    }');
+
+    $this->assertEquals([true, true, true, false], $r);
+  }
+
+  #[@test]
+  public function is_object_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [$this is object, function() { } is object, null is object];
+      }
+    }');
+
+    $this->assertEquals([true, true, false], $r);
+  }
+
+  #[@test]
+  public function is_callable_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return [function() { } is callable, [$this, "run"] is callable, null is callable];
+      }
+    }');
+
+    $this->assertEquals([true, true, false], $r);
+  }
+
+  #[@test]
+  public function is_iterable_type() {
+    $r= $this->run('class <T> implements \IteratorAggregate {
+      public function getIterator() {
+        yield 1;
+      }
+
+      public function run() {
+        return [[] is iterable, $this is iterable, null is iterable];
+      }
+    }');
+
+    $this->assertEquals([true, true, false], $r);
+  }
+}


### PR DESCRIPTION
## Before
A mix of functions, syntax and XP core functionality `is()`:

```php
is_string($value)                                  // for primitives, use is_[T]()
is_callable($value)                                // for pseudo types callable, array, object
is_array($value) || $value instanceof \Traversable // no is_iterable in PHP 5 and 7.0 
$value instanceof Date                             // for value types
null === $value || is_int($value)                  // nullable types cannot be tested directly
is('[:string]', $value)                            // for types beyond PHP type system
is('string|util.URI', $value)                      // for types beyond PHP type system
```

## After
Anything that works as a parameter, property or return type can be used with the `is` operator.

```php
$value is string
$value is callable
$value is iterable
$value is Date
$value is ?int
$value is array<string, string>
$value is string|URI
```

## See also

https://docs.hhvm.com/hack/expressions-and-operators/is
https://kotlinlang.org/docs/reference/typecasts.html
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/is