### PR TITLE
Add support for annotations in anonymous classes

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -4,6 +4,7 @@ use lang\ast\Code;
 use lang\ast\Emitter;
 use lang\ast\Node;
 use lang\ast\nodes\Method;
+use lang\ast\nodes\Parameter;
 use lang\ast\nodes\Signature;
 
 abstract class PHP extends Emitter {
@@ -681,6 +682,11 @@ abstract class PHP extends Emitter {
     // Initialize meta data in constructor
     if (isset($new->definition->body['__construct()'])) {
       array_unshift($new->definition->body['__construct()']->body, new Code('self::__init()'));
+    } else if ($new->definition->parent) {
+      $param= new Parameter('args', null, null, false, true, null, []);
+      $new->definition->body['__construct()']= new Method([], '__construct', new Signature([$param], null), [
+        new Code('method_exists(parent::class, "__construct") && parent::__construct(...$args); self::__init()')
+      ]);
     } else {
       $new->definition->body['__construct()']= new Method([], '__construct', new Signature([], null), [
         new Code('self::__init()')

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -1,7 +1,10 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Code;
 use lang\ast\Emitter;
 use lang\ast\Node;
+use lang\ast\nodes\Method;
+use lang\ast\nodes\Signature;
 
 abstract class PHP extends Emitter {
   const PROPERTY = 0;
@@ -292,7 +295,11 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitMeta($result, $name, $annotations, $comment) {
-    $result->out->write('\xp::$meta[\''.strtr(ltrim($name, '\\'), '\\', '.').'\']= [');
+    if (null === $name) {
+      $result->out->write('\xp::$meta[strtr(self::class, "\\\\", ".")]= [');
+    } else {
+      $result->out->write('\xp::$meta[\''.strtr(ltrim($name, '\\'), '\\', '.').'\']= [');
+    }
     $result->out->write('"class" => [DETAIL_ANNOTATIONS => [');
     $this->emitAnnotations($result, $annotations);
     $result->out->write('], DETAIL_COMMENT => \''.str_replace("'", "\\'", $comment).'\'],');
@@ -661,6 +668,8 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitNewClass($result, $new) {
+    array_unshift($result->meta, []);
+
     $result->out->write('new class(');
     $this->emitArguments($result, $new->arguments);
     $result->out->write(')');
@@ -668,11 +677,23 @@ abstract class PHP extends Emitter {
     $new->definition->parent && $result->out->write(' extends '.$new->definition->parent);
     $new->definition->implements && $result->out->write(' implements '.implode(', ', $new->definition->implements));
     $result->out->write('{');
+
+    // Initialize meta data in constructor
+    if (isset($new->definition->body['__construct()'])) {
+      array_unshift($new->definition->body['__construct()']->body, new Code('self::__init()'));
+    } else {
+      $new->definition->body['__construct()']= new Method([], '__construct', new Signature([], null), [
+        new Code('self::__init()')
+      ]);
+    }
+
     foreach ($new->definition->body as $member) {
       $this->emitOne($result, $member);
       $result->out->write("\n");
     }
-    $result->out->write('}');
+    $result->out->write('static function __init() {');
+    $this->emitMeta($result, null, [], null);
+    $result->out->write('}}');
   }
 
   protected function emitInvoke($result, $invoke) {

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -1,10 +1,5 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\Code;
-use lang\ast\nodes\Method;
-use lang\ast\nodes\Parameter;
-use lang\ast\nodes\Signature;
-
 /**
  * PHP 5.6 syntax
  *
@@ -209,34 +204,19 @@ class PHP56 extends PHP {
     $result->out->write(', "use" => []');
     $result->out->write('], \'{');
     $result->out->write(strtr($result->buffer(function($result) use($definition) {
-
-      // Initialize meta data in constructor
-      if (isset($definition->body['__construct()'])) {
-        array_unshift($definition->body['__construct()']->body, new Code('self::__init()'));
-      } else if ($definition->parent) {
-        $param= new Parameter('args', null, null, false, true, null, []);
-        $definition->body['__construct()']= new Method([], '__construct', new Signature([$param], null), [
-          new Code('method_exists(parent::class, "__construct") && parent::__construct(...$args); self::__init()')
-        ]);
-      } else {
-        $definition->body['__construct()']= new Method([], '__construct', new Signature([], null), [
-          new Code('self::__init()')
-        ]);
-      }
-
       foreach ($definition->body as $member) {
         $this->emitOne($result, $member);
         $result->out->write("\n");
       }
 
-      $result->out->write('static function __init() {');
+      $result->out->write('function __new() {');
       $this->emitMeta($result, null, [], null);
-      $result->out->write('}');
+      $result->out->write('return $this; }');
 
     }), ['\'' => '\\\'', '\\' => '\\\\']));
     $result->out->write('}\')->newInstance(');
     $this->emitArguments($result, $new->arguments);
-    $result->out->write(')');
+    $result->out->write(')->__new()');
   }
 
   protected function emitFrom($result, $from) {

--- a/src/main/php/lang/ast/emit/PHP56.class.php
+++ b/src/main/php/lang/ast/emit/PHP56.class.php
@@ -2,6 +2,7 @@
 
 use lang\ast\Code;
 use lang\ast\nodes\Method;
+use lang\ast\nodes\Parameter;
 use lang\ast\nodes\Signature;
 
 /**
@@ -212,6 +213,11 @@ class PHP56 extends PHP {
       // Initialize meta data in constructor
       if (isset($definition->body['__construct()'])) {
         array_unshift($definition->body['__construct()']->body, new Code('self::__init()'));
+      } else if ($definition->parent) {
+        $param= new Parameter('args', null, null, false, true, null, []);
+        $definition->body['__construct()']= new Method([], '__construct', new Signature([$param], null), [
+          new Code('method_exists(parent::class, "__construct") && parent::__construct(...$args); self::__init()')
+        ]);
       } else {
         $definition->body['__construct()']= new Method([], '__construct', new Signature([], null), [
           new Code('self::__init()')

--- a/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
@@ -87,4 +87,25 @@ class AnonymousClassTest extends EmittingTest {
     $this->assertEquals(['test' => null], typeof($r)->getMethod('fixture')->getAnnotations());
     $this->assertEquals('test', $r->name);
   }
+
+  #[@test]
+  public function method_annotations_with_inherited_constructor() {
+    $r= $this->run('class <T> {
+      public $name;
+
+      public function __construct($name= null) {
+        $this->name= $name;
+      }
+
+      public function run() {
+        return new class("test") extends <T> {
+
+          <<test>>
+          public function fixture() { }
+        };
+      }
+    }');
+    $this->assertEquals(['test' => null], typeof($r)->getMethod('fixture')->getAnnotations());
+    $this->assertEquals('test', $r->name);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
@@ -61,51 +61,8 @@ class AnonymousClassTest extends EmittingTest {
           public function fixture() { }
         };
       }
-
-      public function fixture() { }
     }');
 
     $this->assertEquals(['inside' => null], typeof($r)->getMethod('fixture')->getAnnotations());
-  }
-
-  #[@test]
-  public function method_annotations_with_constructor() {
-    $r= $this->run('class <T> {
-      public function run() {
-        return new class("test") {
-          public $name;
-
-          public function __construct($name) {
-            $this->name= $name;
-          }
-
-          <<test>>
-          public function fixture() { }
-        };
-      }
-    }');
-    $this->assertEquals(['test' => null], typeof($r)->getMethod('fixture')->getAnnotations());
-    $this->assertEquals('test', $r->name);
-  }
-
-  #[@test]
-  public function method_annotations_with_inherited_constructor() {
-    $r= $this->run('class <T> {
-      public $name;
-
-      public function __construct($name= null) {
-        $this->name= $name;
-      }
-
-      public function run() {
-        return new class("test") extends <T> {
-
-          <<test>>
-          public function fixture() { }
-        };
-      }
-    }');
-    $this->assertEquals(['test' => null], typeof($r)->getMethod('fixture')->getAnnotations());
-    $this->assertEquals('test', $r->name);
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
@@ -50,4 +50,41 @@ class AnonymousClassTest extends EmittingTest {
     }');
     $this->assertInstanceOf(Runnable::class, $r);
   }
+
+  #[@test]
+  public function method_annotations() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return new class() {
+
+          <<inside>>
+          public function fixture() { }
+        };
+      }
+
+      public function fixture() { }
+    }');
+
+    $this->assertEquals(['inside' => null], typeof($r)->getMethod('fixture')->getAnnotations());
+  }
+
+  #[@test]
+  public function method_annotations_with_constructor() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return new class("test") {
+          public $name;
+
+          public function __construct($name) {
+            $this->name= $name;
+          }
+
+          <<test>>
+          public function fixture() { }
+        };
+      }
+    }');
+    $this->assertEquals(['test' => null], typeof($r)->getMethod('fixture')->getAnnotations());
+    $this->assertEquals('test', $r->name);
+  }
 }


### PR DESCRIPTION
Example:

```php
$instance= new class() {

  <<test>>
  public function fixture() { }
};

$annotations= typeof($instance)->getMethod('fixture')->getAnnotations();
// ['test' => null]
```

See also xp-framework/core#226