### PR TITLE
Allow `new (<expr>)` as syntax

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -122,7 +122,7 @@ abstract class PHP extends Emitter {
     static $native= ['string' => true, 'int' => true, 'float' => true, 'bool' => true, 'array' => true, 'object' => true];
 
     $name= $cast->type->name();
-    if ('?' === $name{0}) {
+    if ('?' === $name[0]) {
       $result->out->write('cast(');
       $this->emitOne($result, $cast->expression);
       $result->out->write(',\''.$name.'\', false)');

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -662,9 +662,18 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitNew($result, $new) {
-    $result->out->write('new '.$new->type.'(');
-    $this->emitArguments($result, $new->arguments);
-    $result->out->write(')');
+    if ($new->type instanceof Node) {
+      $t= $result->temp();
+      $result->out->write('('.$t.'= ');
+      $this->emitOne($result, $new->type);
+      $result->out->write(') ? new '.$t.'(');
+      $this->emitArguments($result, $new->arguments);
+      $result->out->write(') : null');
+    } else {
+      $result->out->write('new '.$new->type.'(');
+      $this->emitArguments($result, $new->arguments);
+      $result->out->write(')');
+    }
   }
 
   protected function emitNewClass($result, $new) {

--- a/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
@@ -1,0 +1,54 @@
+<?php namespace lang\ast\unittest\emit;
+
+use unittest\Assert;
+use util\Date;
+
+class InstantiationTest extends EmittingTest {
+
+  #[@test]
+  public function new_type() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return new \\util\\Date();
+      }
+    }');
+    Assert::instance(Date::class, $r);
+  }
+
+  #[@test]
+  public function new_var() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $class= \\util\\Date::class;
+        return new $class();
+      }
+    }');
+    Assert::instance(Date::class, $r);
+  }
+
+  #[@test]
+  public function new_expr() {
+    $r= $this->run('class <T> {
+      private function factory() { return \\util\\Date::class; }
+
+      public function run() {
+        return new ($this->factory())();
+      }
+    }');
+    Assert::instance(Date::class, $r);
+  }
+
+  #[@test]
+  public function passing_argument() {
+    $r= $this->run('class <T> {
+      public $value;
+
+      public function __construct($value= null) { $this->value= $value; }
+
+      public function run() {
+        return new self("Test");
+      }
+    }');
+    Assert::equals('Test', $r->value);
+  }
+}

--- a/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/OperatorTest.class.php
@@ -158,6 +158,22 @@ class OperatorTest extends ParseTest {
   }
 
   #[@test]
+  public function new_var() {
+    $this->assertParsed(
+      [new NewExpression('$class', [], self::LINE)],
+      'new $class();'
+    );
+  }
+
+  #[@test]
+  public function new_expr() {
+    $this->assertParsed(
+      [new NewExpression(new InvokeExpression(new Literal('factory', self::LINE), [], self::LINE), [], self::LINE)],
+      'new (factory())();'
+    );
+  }
+
+  #[@test]
   public function new_type_with_args() {
     $this->assertParsed(
       [new NewExpression('\\T', [new Variable('a', self::LINE), new Variable('b', self::LINE)], self::LINE)],


### PR DESCRIPTION
See php/php-src#5061, merged Feb. 11th, 2020 and targeted for PHP 8.0

```php
function factory() { return Date::class; }

$date= new (factory())();  // instance of Date class
```

Previously, a temporary variable would have been necessary:

```php
function factory() { return Date::class; }

$class= factory();
$date= new $class();  // instance of Date class
```