### PR TITLE
Allow `instanceof (<expr>)` as syntax

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -645,23 +645,24 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitInstanceOf($result, $instanceof) {
+    $type= $instanceof->type;
 
-    // Supported: instanceof T, instanceof $t, instanceof $t DEREF; instanceof T::(NAME | VARIABLE)
+    // Supported: instanceof T, instanceof $t, instanceof $t->MEMBER; instanceof T::MEMBER
     // Unsupported: instanceof EXPR
-    if ($instanceof->type instanceof Variable || $instanceof->type instanceof InstanceExpression || $instanceof->type instanceof ScopeExpression) {
+    if ($type instanceof Variable || $type instanceof InstanceExpression || $type instanceof ScopeExpression) {
       $this->emitOne($result, $instanceof->expression);
       $result->out->write(' instanceof ');
-      $this->emitOne($result, $instanceof->type);
-    } else if ($instanceof->type instanceof Node) {
+      $this->emitOne($result, $type);
+    } else if ($type instanceof Node) {
       $t= $result->temp();
       $result->out->write('('.$t.'= ');
-      $this->emitOne($result, $instanceof->type);
+      $this->emitOne($result, $type);
       $result->out->write(')?');
       $this->emitOne($result, $instanceof->expression);
       $result->out->write(' instanceof '.$t.':null');
     } else {
       $this->emitOne($result, $instanceof->expression);
-      $result->out->write(' instanceof '.$instanceof->type);
+      $result->out->write(' instanceof '.$type);
     }
   }
 

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -116,13 +116,16 @@ class PHP extends Language {
     $this->infixr('>>', 70);
 
     $this->infix('instanceof', 110, function($parse, $token, $left) {
+
+      // Solve ambiguity EXPR instanceof T vs. EXPR instanceof T::MEMBER by look-ahead
       if ('name' === $parse->token->kind) {
-        $type= $parse->scope->resolve($parse->token->value);
+        $name= $parse->token;
         $parse->forward();
-        return new InstanceOfExpression($left, $type, $token->line);
-      } else {
-        return new InstanceOfExpression($left, $this->expression($parse, 0), $token->line);
+        if ('::' !== $parse->token->value) return new InstanceOfExpression($left, $parse->scope->resolve($name->value), $token->line);
+        $parse->queue[]= $parse->token;
+        $parse->token= $name;
       }
+      return new InstanceOfExpression($left, $this->expression($parse, 0), $token->line);
     });
 
     $this->infix('->', 100, function($parse, $token, $left) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -116,16 +116,12 @@ class PHP extends Language {
     $this->infixr('>>', 70);
 
     $this->infix('instanceof', 110, function($parse, $token, $left) {
-
-      // Solve ambiguity EXPR instanceof T vs. EXPR instanceof T::MEMBER by look-ahead
-      if ('name' === $parse->token->kind) {
-        $name= $parse->token;
-        $parse->forward();
-        if ('::' !== $parse->token->value) return new InstanceOfExpression($left, $parse->scope->resolve($name->value), $token->line);
-        $parse->queue[]= $parse->token;
-        $parse->token= $name;
+      $type= $this->expression($parse, 0);
+      if ($type instanceof Literal) {
+        return new InstanceOfExpression($left, $parse->scope->resolve($type->expression), $token->line);
+      } else {
+        return new InstanceOfExpression($left, $type, $token->line);
       }
-      return new InstanceOfExpression($left, $this->expression($parse, 0), $token->line);
     });
 
     $this->infix('->', 100, function($parse, $token, $left) {

--- a/src/test/php/lang/ast/unittest/emit/InstanceOfTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstanceOfTest.class.php
@@ -58,4 +58,43 @@ class InstanceOfTest extends EmittingTest {
 
     Assert::true($r);
   }
+
+  #[@test]
+  public function instanceof_instance_expr() {
+    $r= $this->run('class <T> {
+      private $type= self::class;
+
+      public function run() {
+        return $this instanceof $this->type;
+      }
+    }');
+
+    Assert::true($r);
+  }
+
+  #[@test]
+  public function instanceof_scope_expr() {
+    $r= $this->run('class <T> {
+      private static $type= self::class;
+
+      public function run() {
+        return $this instanceof self::$type;
+      }
+    }');
+
+    Assert::true($r);
+  }
+
+  #[@test]
+  public function instanceof_expr() {
+    $r= $this->run('class <T> {
+      private function type() { return self::class; }
+
+      public function run() {
+        return $this instanceof ($this->type());
+      }
+    }');
+
+    Assert::true($r);
+  }
 }


### PR DESCRIPTION
See php/php-src#5061

```php
function type() { return Date::class; }

return new Date() instanceof (type());  // true
```

Previously would've required a temporary variable:

```php
function type() { return Date::class; }

$t= type();
return new Date() instanceof $t;  // true
```
