### PR TITLE
Allow chaining scope resolution operator `::`

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -717,8 +717,21 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitScope($result, $scope) {
-    $result->out->write($scope->type.'::');
-    $this->emitOne($result, $scope->member);
+    if ($scope->type instanceof Variable) {
+      $this->emitOne($result, $scope->type);
+      $result->out->write('::');
+      $this->emitOne($result, $scope->member);
+    } else if ($scope->type instanceof Node) {
+      $t= $result->temp();
+      $result->out->write('('.$t.'=');
+      $this->emitOne($result, $scope->type);
+      $result->out->write(')?'.$t.'::');
+      $this->emitOne($result, $scope->member);
+      $result->out->write(':null');
+    } else {
+      $result->out->write($scope->type.'::');
+      $this->emitOne($result, $scope->member);
+    }
   }
 
   protected function emitInstance($result, $instance) {

--- a/src/main/php/lang/ast/syntax/PHP.class.php
+++ b/src/main/php/lang/ast/syntax/PHP.class.php
@@ -138,7 +138,7 @@ class PHP extends Language {
     });
 
     $this->infix('::', 100, function($parse, $token, $left) {
-      $scope= $parse->scope->resolve($left->expression);
+      $scope= $left instanceof Literal ? $parse->scope->resolve($left->expression) : $left;
 
       if ('variable' === $parse->token->kind) {
         $expr= new Variable($parse->token->value, $parse->token->line);
@@ -150,6 +150,13 @@ class PHP extends Language {
       }
 
       $parse->forward();
+      if ('(' === $parse->token->value) {
+        $parse->expecting('(', 'invoke expression');
+        $arguments= $this->expressions($parse);
+        $parse->expecting(')', 'invoke expression');
+        $expr= new InvokeExpression($expr, $arguments, $token->line);
+      }
+
       return new ScopeExpression($scope, $expr, $token->line);
     });
 

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -44,6 +44,48 @@ class MembersTest extends EmittingTest {
   }
 
   #[@test]
+  public function dynamic_class_property() {
+    $r= $this->run('class <T> {
+      private static $MEMBER= "Test";
+
+      public function run() {
+        $class= self::class;
+        return $class::$MEMBER;
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[@test]
+  public function dynamic_class_method() {
+    $r= $this->run('class <T> {
+      private static function member() { return "Test"; }
+
+      public function run() {
+        $class= self::class;
+        return $class::member();
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[@test]
+  public function dynamic_class_constant() {
+    $r= $this->run('class <T> {
+      private const MEMBER = "Test";
+
+      public function run() {
+        $class= self::class;
+        return $class::MEMBER;
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[@test]
   public function instance_property() {
     $r= $this->run('class <T> {
       private $member= "Test";
@@ -121,5 +163,25 @@ class MembersTest extends EmittingTest {
     }');
 
     Assert::null($r);
+  }
+
+  #[@test]
+  public function chaining_sccope_operators() {
+    $r= $this->run('class <T> {
+      private const TYPE = self::class;
+
+      private const NAME = "Test";
+
+      private static $name = "Test";
+
+      private static function name() { return "Test"; }
+
+      public function run() {
+        $name= "name";
+        return [self::TYPE::NAME, self::TYPE::$name, self::TYPE::name(), self::TYPE::$name()];
+      }
+    }');
+
+    Assert::equals(['Test', 'Test', 'Test', 'Test'], $r);
   }
 }

--- a/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/parse/MembersTest.class.php
@@ -188,9 +188,9 @@ class MembersTest extends ParseTest {
   #[@test]
   public function static_method_invocation() {
     $this->assertParsed(
-      [new InvokeExpression(
-        new ScopeExpression('\\A', new Literal('member', self::LINE), self::LINE),
-        [new Literal('1', self::LINE)],
+      [new ScopeExpression(
+        '\\A',
+        new InvokeExpression(new Literal('member', self::LINE), [new Literal('1', self::LINE)], self::LINE),
         self::LINE
       )],
       'A::member(1);'


### PR DESCRIPTION
See php/php-src#5061

```php
class T {
  const TYPE = self::class;

  public static function new() { return new self(); }
}

$t= T::TYPE::new();  // a T instance
```

Previously, this would have required a temporary variable:

```php
$type= T::TYPE;
$t= $type::new();  // a T instance
```