### PR TITLE
Emit named arguments for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/tokenize": "^9.0 | ^8.1",
-    "xp-framework/ast": "^5.0",
+    "xp-framework/ast": "^5.2",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -712,9 +712,10 @@ abstract class PHP extends Emitter {
 
   protected function emitArguments($result, $arguments) {
     $s= sizeof($arguments) - 1;
-    foreach ($arguments as $i => $argument) {
+    $i= 0;
+    foreach ($arguments as $argument) {
       $this->emitOne($result, $argument);
-      if ($i < $s) $result->out->write(', ');
+      if ($i++ < $s) $result->out->write(', ');
     }
   }
 

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -12,6 +12,16 @@ class PHP80 extends PHP {
 
   protected $unsupported= [];
 
+  protected function emitArguments($result, $arguments) {
+    $s= sizeof($arguments) - 1;
+    $i= 0;
+    foreach ($arguments as $name => $argument) {
+      if (is_string($name)) $result->out->write($name.':');
+      $this->emitOne($result, $argument);
+      if ($i++ < $s) $result->out->write(', ');
+    }
+  }
+
   protected function emitNew($result, $new) {
     if ($new->type instanceof Node) {
       $result->out->write('new (');


### PR DESCRIPTION
First step for #13 - full named arguments support in PHP 7 would require knowledge about the underlying invokeable at compile time *or* deferring this to runtime - both of which require more fundamental changes.

* [x] Requires xp-framework/ast#13 to be merged to make it functional -> 5.2.0