### PR TITLE
Refactor rewriting type literals

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,8 @@ XP Compiler ChangeLog
 
 ## 5.5.0 / 2020-11-15
 
-* Changed types emitter implementation:
+* Merged PR #91 - Refactor rewriting type literals:
+  - Changed implementation to be easier to maintain
   - Emit function types as `callable` in all PHP versions
   - Emit union types as syntax in PHP 8+
   (@thekid)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,9 +3,12 @@ XP Compiler ChangeLog
 
 ## ?.?.? / ????-??-??
 
-## 5.5.0 / 2020-11-14
+## 5.5.0 / 2020-11-15
 
-* Emit union types as syntax in PHP 8 - @thekid
+* Changed types emitter implementation:
+  - Emit function types as `callable` in all PHP versions
+  - Emit union types as syntax in PHP 8+
+  (@thekid)
 
 ## 5.4.1 / 2020-10-09
 

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\nodes\{InstanceExpression, ScopeExpression, Variable};
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable};
+use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap};
 use lang\ast\{Emitter, Node, Type};
 
 abstract class PHP extends Emitter {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -30,16 +30,19 @@ abstract class PHP extends Emitter {
     return null === $type ? null : $this->literals[get_class($type)]($type);
   }
 
-  // See https://wiki.php.net/rfc/typed_properties_v2#supported_types
+  /**
+   * As of PHP 7.4: Property type declarations support all type declarations
+   * supported by PHP with the exception of void and callable.
+   *
+   * @see    https://wiki.php.net/rfc/typed_properties_v2#supported_types
+   * @param  ?lang.ast.Type $type
+   * @return ?string
+   */
   protected function propertyType($type) {
-    if (null === $type || $type instanceof IsUnion || $type instanceof IsFunction) {
-      return '';
-    } else if ($type instanceof IsArray || $type instanceof IsMap) {
-      return 'array';
-    } else if ('callable' === $type->literal() || 'void' === $type->literal()) {
-      return '';
+    if (null === $type || $type instanceof IsFunction || 'callable' === $type->literal()) {
+      return null;
     } else {
-      return $type->literal();
+      return $this->literal($type);
     }
   }
 

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -21,10 +21,10 @@ abstract class PHP extends Emitter {
   }
 
   /**
-   * Emit type literal
+   * Emit type literal or NULL if no type should be emitted
    *
-   * @param  ?lang.ast.types.Type $type
-   * @return string
+   * @param  ?lang.ast.Type $type
+   * @return ?string
    */
   protected function literal($type) {
     return null === $type ? null : $this->literals[get_class($type)]($type);

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -8,7 +8,6 @@ abstract class PHP extends Emitter {
   const PROPERTY = 0;
   const METHOD   = 1;
 
-  protected $unsupported= [];
   protected $literals= [];
 
   /**

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -14,12 +14,12 @@ class PHP70 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsUnion::class    => function($t) { return null; },
-      IsFunction::class => function($t) { return null; },
-      IsNullable::class => function($t) { return null; },
+      IsFunction::class => function($t) { return 'callable'; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
       IsValue::class    => function($t) { return $t->literal(); },
+      IsNullable::class => function($t) { return null; },
+      IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
         return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l) ? null : $l;

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+
 /**
  * PHP 7.0 syntax
  *
@@ -9,10 +11,19 @@ class PHP70 extends PHP {
   use OmitPropertyTypes, OmitConstModifiers;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch, RewriteClassOnObjects;
 
-  protected $unsupported= [
-    'object'   => 72,
-    'void'     => 71,
-    'iterable' => 71,
-    'mixed'    => null,
-  ];
+  /** Sets up type => literal mappings */
+  public function __construct() {
+    $this->literals= [
+      IsUnion::class    => function($t) { return null; },
+      IsFunction::class => function($t) { return null; },
+      IsNullable::class => function($t) { return null; },
+      IsArray::class    => function($t) { return 'array'; },
+      IsMap::class      => function($t) { return 'array'; },
+      IsValue::class    => function($t) { return $t->literal(); },
+      IsLiteral::class  => function($t) {
+        $l= $t->literal();
+        return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l) ? null : $l;
+      },
+    ];
+  }
 }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+
 /**
  * PHP 7.1 syntax
  *
@@ -9,8 +11,19 @@ class PHP71 extends PHP {
   use OmitPropertyTypes;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects;
 
-  protected $unsupported= [
-    'object'   => 72,
-    'mixed'    => null,
-  ];
+  /** Sets up type => literal mappings */
+  public function __construct() {
+    $this->literals= [
+      IsUnion::class    => function($t) { return null; },
+      IsFunction::class => function($t) { return null; },
+      IsArray::class    => function($t) { return 'array'; },
+      IsMap::class      => function($t) { return 'array'; },
+      IsValue::class    => function($t) { return $t->literal(); },
+      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsLiteral::class  => function($t) {
+        $l= $t->literal();
+        return ('object' === $l || 'mixed' === $l) ? null : $l;
+      },
+    ];
+  }
 }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -14,12 +14,12 @@ class PHP71 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsUnion::class    => function($t) { return null; },
-      IsFunction::class => function($t) { return null; },
+      IsFunction::class => function($t) { return 'callable'; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
       IsValue::class    => function($t) { return $t->literal(); },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
         return ('object' === $l || 'mixed' === $l) ? null : $l;

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+
 /**
  * PHP 7.2 syntax
  *
@@ -9,7 +11,19 @@ class PHP72 extends PHP {
   use OmitPropertyTypes;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects;
 
-  protected $unsupported= [
-    'mixed'    => null,
-  ];
+  /** Sets up type => literal mappings */
+  public function __construct() {
+    $this->literals= [
+      IsUnion::class    => function($t) { return null; },
+      IsFunction::class => function($t) { return null; },
+      IsArray::class    => function($t) { return 'array'; },
+      IsMap::class      => function($t) { return 'array'; },
+      IsValue::class    => function($t) { return $t->literal(); },
+      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsLiteral::class  => function($t) {
+        $l= $t->literal();
+        return 'mixed' === $l ? null : $l;
+      },
+    ];
+  }
 }

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -14,12 +14,12 @@ class PHP72 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsUnion::class    => function($t) { return null; },
-      IsFunction::class => function($t) { return null; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
+      IsFunction::class => function($t) { return 'callable'; },
       IsValue::class    => function($t) { return $t->literal(); },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
         return 'mixed' === $l ? null : $l;

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable};
+
 /**
  * PHP 7.4 syntax
  *
@@ -8,7 +10,19 @@
 class PHP74 extends PHP {
   use RewriteBlockLambdaExpressions, RewriteClassOnObjects;
 
-  protected $unsupported= [
-    'mixed'    => null,
-  ];
+  /** Sets up type => literal mappings */
+  public function __construct() {
+    $this->literals= [
+      IsUnion::class    => function($t) { return null; },
+      IsFunction::class => function($t) { return null; },
+      IsArray::class    => function($t) { return 'array'; },
+      IsMap::class      => function($t) { return 'array'; },
+      IsValue::class    => function($t) { return $t->literal(); },
+      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsLiteral::class  => function($t) {
+        $l= $t->literal();
+        return 'mixed' === $l ? null : $l;
+      },
+    ];
+  }
 }

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable};
+use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 7.4 syntax
@@ -13,12 +13,12 @@ class PHP74 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsUnion::class    => function($t) { return null; },
-      IsFunction::class => function($t) { return null; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
+      IsFunction::class => function($t) { return 'callable'; },
       IsValue::class    => function($t) { return $t->literal(); },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
         return 'mixed' === $l ? null : $l;

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -14,17 +14,18 @@ class PHP80 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsFunction::class => function($t) { return null; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
+      IsFunction::class => function($t) { return 'callable'; },
       IsValue::class    => function($t) { return $t->literal(); },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
       IsUnion::class    => function($t) {
-        $l= '';
+        $u= '';
         foreach ($t->components as $component) {
-          $l.= '|'.$this->literal($component);
+          if (null === ($l= $this->literal($component))) return null;
+          $u.= '|'.$l;
         }
-        return substr($l, 1);
+        return substr($u, 1);
       },
       IsLiteral::class  => function($t) { return $t->literal(); }
     ];

--- a/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\{ArrayType, MapType, Primitive, Type, Value, XPClass};
-use unittest\{Assert, Test, Values};
+use unittest\actions\RuntimeVersion;
+use unittest\{Assert, Test, Values, Action};
 
 class ParameterTest extends EmittingTest {
 
@@ -69,6 +70,11 @@ class ParameterTest extends EmittingTest {
   #[Test]
   public function nullable_string_type() {
     Assert::equals(Primitive::$STRING, $this->param('?string $param')->getType());
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  public function nullable_string_type_restriction() {
+    Assert::equals(Primitive::$STRING, $this->param('?string $param')->getTypeRestriction());
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
+use lang\ast\Code;
 use lang\ast\nodes\{Method, Signature};
-use lang\ast\{Code, Type};
+use lang\ast\types\IsLiteral;
 use unittest\{Assert, Before, Test, Values};
 
 class TransformationsTest extends EmittingTest {
@@ -14,7 +15,7 @@ class TransformationsTest extends EmittingTest {
         $class->declare(new Method(
           ['public'],
           'toString',
-          new Signature([], new Type('string')),
+          new Signature([], new IsLiteral('string')),
           [new Code('return "T@".\util\Objects::stringOf(get_object_vars($this))')]
         ));
       }

--- a/src/test/php/lang/ast/unittest/emit/UnionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UnionTypesTest.class.php
@@ -60,6 +60,18 @@ class UnionTypesTest extends EmittingTest {
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.0.0-dev")')]
+  public function parameter_function_type_restriction_with_php8() {
+    $t= $this->type('class <T> {
+      public function test(): string|(function(): string) { }
+    }');
+
+    Assert::equals(
+      new TypeUnion([Primitive::$STRING, Type::$CALLABLE]),
+      $t->getMethod('test')->getReturnTypeRestriction()
+    );
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.0.0-dev")')]
   public function return_type_restriction_with_php8() {
     $t= $this->type('class <T> {
       public function test(): int|string|array<string> { }


### PR DESCRIPTION
Create a visitor-like pattern using a map of type classes to emitter functions, held together in `lang.ast.emit.PHP::literal()`.

Outside effect:

* Function types are now emitted as `callable` in all PHP versions
* Union types are now emitted as native syntax in PHP 8+
