### PR TITLE
Add support for explicit octal integer literal notation

### DIFF
--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  */
 class PHP70 extends PHP {
   use OmitPropertyTypes, OmitConstModifiers;
-  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch, RewriteClassOnObjects;
+  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  */
 class PHP71 extends PHP {
   use OmitPropertyTypes;
-  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects;
+  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  */
 class PHP72 extends PHP {
   use OmitPropertyTypes;
-  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects;
+  use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_74
  */
 class PHP74 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteClassOnObjects;
+  use RewriteBlockLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions;
+  use RewriteBlockLambdaExpressions, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/RewriteExplicitOctals.class.php
+++ b/src/main/php/lang/ast/emit/RewriteExplicitOctals.class.php
@@ -8,7 +8,7 @@
 trait RewriteExplicitOctals {
 
   protected function emitLiteral($result, $literal) {
-    if (0 === strncasecmp($literal->expression, '0o', 2)) {
+    if ('0' === $literal->expression[0] && ($c= $literal->expression[1] ?? null) && ('o' === $c || 'O' === $c)) {
       $result->out->write('0'.substr($literal->expression, 2));
     } else {
       $result->out->write($literal->expression);

--- a/src/main/php/lang/ast/emit/RewriteExplicitOctals.class.php
+++ b/src/main/php/lang/ast/emit/RewriteExplicitOctals.class.php
@@ -1,0 +1,17 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites explicit octal notations: `0o16` => `016`.
+ *
+ * @see  https://wiki.php.net/rfc/explicit_octal_notation
+ */
+trait RewriteExplicitOctals {
+
+  protected function emitLiteral($result, $literal) {
+    if (0 === strncasecmp($literal->expression, '0o', 2)) {
+      $result->out->write('0'.substr($literal->expression, 2));
+    } else {
+      $result->out->write($literal->expression);
+    }
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
@@ -4,8 +4,18 @@ use unittest\{Assert, Test, Values};
 
 class ScalarsTest extends EmittingTest {
 
-  #[Test, Values([['0', 0], ['1', 1], ['-1', -1], ['0xff', 255], ['0755', 493], ['1.5', 1.5], ['-1.5', -1.5],])]
+  #[Test, Values([['0', 0], ['1', 1], ['-1', -1], ['1.5', 1.5], ['-1.5', -1.5],])]
   public function numbers($literal, $result) {
+    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+  }
+
+  #[Test, Values([['0x0', 0], ['0xff', 255], ['0xFF', 255], ['0XFF', 255]])]
+  public function hexadecimal_numbers($literal, $result) {
+    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+  }
+
+  #[Test, Values([['0755', 493], ['0o16', 14], ['0O16', 14]])]
+  public function octal_numbers($literal, $result) {
     Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
   }
 

--- a/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
@@ -9,6 +9,11 @@ class ScalarsTest extends EmittingTest {
     Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
   }
 
+  #[Test, Values([['0b0', 0], ['0b10', 2], ['0B10', 2]])]
+  public function binary_numbers($literal, $result) {
+    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+  }
+
   #[Test, Values([['0x0', 0], ['0xff', 255], ['0xFF', 255], ['0XFF', 255]])]
   public function hexadecimal_numbers($literal, $result) {
     Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));


### PR DESCRIPTION
See https://wiki.php.net/rfc/explicit_octal_notation - targeted at PHP 8.1

*Performance impact is not measurable 🙂*