### PR TITLE
Match without expression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "^6.0 | ^5.2",
+    "xp-framework/ast": "dev-feature/match_without_expression as 6.1.0 | ^6.0 | ^5.2",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "dev-feature/match_without_expression as 6.1.0 | ^6.0 | ^5.2",
+    "xp-framework/ast": "dev-feature/match_without_expression as 6.1.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -561,8 +561,12 @@ abstract class PHP extends Emitter {
 
   protected function emitMatch($result, $match) {
     $t= $result->temp();
-    $result->out->write('('.$t.'=');
-    $this->emitOne($result, $match->expression);
+    if (null === $match->expression) {
+      $result->out->write('('.$t.'=true');
+    } else {
+      $result->out->write('('.$t.'=');
+      $this->emitOne($result, $match->expression);
+    }
     $result->out->write(')');
 
     $b= 0;

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -562,12 +562,12 @@ abstract class PHP extends Emitter {
   protected function emitMatch($result, $match) {
     $t= $result->temp();
     if (null === $match->expression) {
-      $result->out->write('('.$t.'=true');
+      $result->out->write('('.$t.'=true)');
     } else {
       $result->out->write('('.$t.'=');
       $this->emitOne($result, $match->expression);
+      $result->out->write(')');
     }
-    $result->out->write(')');
 
     $b= 0;
     foreach ($match->cases as $case) {

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -55,9 +55,13 @@ class PHP80 extends PHP {
   }
 
   protected function emitMatch($result, $match) {
-    $result->out->write('match (');
-    $this->emitOne($result, $match->expression);
-    $result->out->write(') {');
+    if (null === $match->expression) {
+      $result->out->write('match (true) {');
+    } else {
+      $result->out->write('match (');
+      $this->emitOne($result, $match->expression);
+      $result->out->write(') {');
+    }
 
     foreach ($match->cases as $case) {
       $b= 0;

--- a/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
@@ -84,6 +84,22 @@ class ControlStructuresTest extends EmittingTest {
     Assert::equals($expected, $r);
   }
 
+  #[Test]
+  public function match_allows_dropping_true() {
+    $r= $this->run('class <T> {
+      public function run($arg) {
+        return match {
+          $arg >= 10 => "10+ items",
+          $arg === 1 => "one item",
+          $arg === 0 => "no items",
+          default    => $arg." items",
+        };
+      }
+    }', 10);
+
+    Assert::equals('10+ items', $r);
+  }
+
   #[Test, Expect(['class' => Throwable::class, 'withMessage' => '/Unhandled match value of type .+/'])]
   public function unhandled_match() {
     $this->run('class <T> {


### PR DESCRIPTION
Allow dropping expression from match, see https://externals.io/message/111402 and https://wiki.php.net/rfc/match_expression_v2#allow_dropping_true:

```php
$result = match { ... };
// Equivalent to
$result = match (true) { ... };
```