### PR TITLE
Add support for static return type

### DIFF
--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -17,7 +17,7 @@ class PHP70 extends PHP {
       IsFunction::class => function($t) { return 'callable'; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
-      IsValue::class    => function($t) { return $t->literal(); },
+      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
       IsNullable::class => function($t) { return null; },
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -17,7 +17,7 @@ class PHP71 extends PHP {
       IsFunction::class => function($t) { return 'callable'; },
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
-      IsValue::class    => function($t) { return $t->literal(); },
+      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -17,7 +17,7 @@ class PHP72 extends PHP {
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
       IsFunction::class => function($t) { return 'callable'; },
-      IsValue::class    => function($t) { return $t->literal(); },
+      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -16,7 +16,7 @@ class PHP74 extends PHP {
       IsArray::class    => function($t) { return 'array'; },
       IsMap::class      => function($t) { return 'array'; },
       IsFunction::class => function($t) { return 'callable'; },
-      IsValue::class    => function($t) { return $t->literal(); },
+      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
       IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
+use lang\ArrayType;
 use unittest\{Assert, Test, Values};
 
 class MembersTest extends EmittingTest {
@@ -212,5 +213,30 @@ class MembersTest extends EmittingTest {
     }');
 
     Assert::equals(['Test', 'Test', 'Test', 'Test'], $r);
+  }
+
+  #[Test]
+  public function self_return_type() {
+    $t= $this->type('
+      class <T> { public function run(): self { return $this; } }
+    ');
+    Assert::equals($t, $t->getMethod('run')->getReturnType());
+  }
+
+  #[Test]
+  public function static_return_type() {
+    $t= $this->type('
+      class <T>Base { public function run(): static { return $this; } }
+      class <T> extends <T>Base { }
+    ');
+    Assert::equals($t, $t->getMethod('run')->getReturnType());
+  }
+
+  #[Test]
+  public function array_of_self_return_type() {
+    $t= $this->type('
+      class <T> { public function run(): array<self> { return [$this]; } }
+    ');
+    Assert::equals(new ArrayType($t), $t->getMethod('run')->getReturnType());
   }
 }


### PR DESCRIPTION
See https://wiki.php.net/rfc/static_return_type, implemented in PHP 8.0

For PHP 7, emit "self" as return type instead, almost the same. Requires [XP Framework Core v10.4.0](https://github.com/xp-framework/core/releases/tag/v10.4.0)+ to work as expected.