### PR TITLE
Support arbitrary expressions in property initializations and parameter defaults

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -185,8 +185,13 @@ abstract class PHP extends Emitter {
     foreach ($static->initializations as $variable => $initial) {
       $result->out->write('static $'.$variable);
       if ($initial) {
-        $result->out->write('=');
-        $this->emitOne($result, $initial);
+        if ($this->staticScalar($initial)) {
+          $result->out->write('=');
+          $this->emitOne($result, $initial);
+        } else {
+          $result->out->write('= null; null === $'.$variable.' && $'.$variable.'= ');
+          $this->emitOne($result, $initial);
+        }
       }
       $result->out->write(';');
     }

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Code;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, Variable, Literal, ArrayLiteral, Block};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, BinaryExpression, Variable, Literal, ArrayLiteral, Block};
 use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap};
 use lang\ast\{Emitter, Node, Type};
 
@@ -37,8 +37,9 @@ abstract class PHP extends Emitter {
    * - Any literal
    * - Arrays where all members are literals
    * - Scope expressions with literal members (self::class, T::const)
+   * - Binary expression where left- and right hand side are literals
    *
-   * @see    https://wiki.php.net/rfc/new_in_initializers
+   * @see    https://wiki.php.net/rfc/const_scalar_exprs
    * @param  lang.ast.Node $node
    * @return bool
    */
@@ -52,6 +53,8 @@ abstract class PHP extends Emitter {
       return true;
     } else if ($node instanceof ScopeExpression) {
       return $node->member instanceof Literal;
+    } else if ($node instanceof BinaryExpression) {
+      return $this->isConstant($node->left) && $this->isConstant($node->right);
     }
     return false;
   }

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -32,7 +32,7 @@ abstract class PHP extends Emitter {
   }
 
   /**
-   * Returns whether a given node is a so-called "static scalar" expression:
+   * Returns whether a given node is a constant expression:
    *
    * - Any literal
    * - Arrays where all members are literals
@@ -42,12 +42,12 @@ abstract class PHP extends Emitter {
    * @param  lang.ast.Node $node
    * @return bool
    */
-  protected function staticScalar($node) {
+  protected function isConstant($node) {
     if ($node instanceof Literal) {
       return true;
     } else if ($node instanceof ArrayLiteral) {
       foreach ($node->values as $node) {
-        if (!$this->staticScalar($node)) return false;
+        if (!$this->isConstant($node)) return false;
       }
       return true;
     } else if ($node instanceof ScopeExpression) {
@@ -185,7 +185,7 @@ abstract class PHP extends Emitter {
     foreach ($static->initializations as $variable => $initial) {
       $result->out->write('static $'.$variable);
       if ($initial) {
-        if ($this->staticScalar($initial)) {
+        if ($this->isConstant($initial)) {
           $result->out->write('=');
           $this->emitOne($result, $initial);
         } else {
@@ -281,7 +281,7 @@ abstract class PHP extends Emitter {
       $result->out->write(($parameter->reference ? '&' : '').'$'.$parameter->name);
     }
     if ($parameter->default) {
-      if ($this->staticScalar($parameter->default)) {
+      if ($this->isConstant($parameter->default)) {
         $result->out->write('=');
         $this->emitOne($result, $parameter->default);
       } else {
@@ -513,7 +513,7 @@ abstract class PHP extends Emitter {
 
     $result->out->write(implode(' ', $property->modifiers).' '.$this->propertyType($property->type).' $'.$property->name);
     if (isset($property->expression)) {
-      if ($this->staticScalar($property->expression)) {
+      if ($this->isConstant($property->expression)) {
         $result->out->write('=');
         $this->emitOne($result, $property->expression);
       } else if (in_array('static', $property->modifiers)) {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -554,6 +554,9 @@ abstract class PHP extends Emitter {
 
     $promoted= '';
     foreach ($method->signature->parameters as $param) {
+      $meta[DETAIL_TARGET_ANNO][$param->name]= $param->annotations;
+      $meta[DETAIL_ARGUMENTS][]= $param->type ? $param->type->name() : 'var';
+
       if (isset($param->promote)) {
         $promoted.= $param->promote.' $'.$param->name.';';
         $result->locals[1]['$this->'.$param->name]= new Code(($param->reference ? '&$' : '$').$param->name);
@@ -565,8 +568,10 @@ abstract class PHP extends Emitter {
           DETAIL_ARGUMENTS   => []
         ];
       }
-      $meta[DETAIL_TARGET_ANNO][$param->name]= $param->annotations;
-      $meta[DETAIL_ARGUMENTS][]= $param->type ? $param->type->name() : 'var';
+
+      if (isset($param->default) && !$this->isConstant($param->default)) {
+        $meta[DETAIL_TARGET_ANNO][$param->name]['default']= [$param->default];
+      }
     }
 
     if (null === $method->body) {

--- a/src/test/php/lang/ast/unittest/emit/Handle.class.php
+++ b/src/test/php/lang/ast/unittest/emit/Handle.class.php
@@ -9,6 +9,10 @@ class Handle implements \IDisposable {
 
   public function __construct($id) { $this->id= $id; }
 
+  public function redirect($id) {
+    $this->id= $id;
+  }
+
   public function read($bytes= 8192) {
     self::$called[]= 'read@'.$this->id;
 

--- a/src/test/php/lang/ast/unittest/emit/Handle.class.php
+++ b/src/test/php/lang/ast/unittest/emit/Handle.class.php
@@ -4,8 +4,13 @@ use lang\IllegalArgumentException;
 
 /** Used by `UsingTest` */
 class Handle implements \IDisposable {
+  public static $DEFAULT;
   public static $called= [];
   private $id;
+
+  static function __static() {
+    self::$DEFAULT= new Handle(0);
+  }
 
   public function __construct($id) { $this->id= $id; }
 

--- a/src/test/php/lang/ast/unittest/emit/Handle.class.php
+++ b/src/test/php/lang/ast/unittest/emit/Handle.class.php
@@ -16,6 +16,7 @@ class Handle implements \IDisposable {
 
   public function redirect($id) {
     $this->id= $id;
+    return $this;
   }
 
   public function read($bytes= 8192) {

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -23,12 +23,13 @@ class InitializeWithExpressionsTest extends EmittingTest {
     yield ['self::INITIAL', 'initial'];
     yield ['Handle::$DEFAULT', Handle::$DEFAULT];
     yield ['new Handle(0)', new Handle(0)];
+    yield ['new FileInput(new Handle(0))', new FileInput(new Handle(0))];
     yield ['[new Handle(0)]', [new Handle(0)]];
   }
 
   #[Test, Values('expressions')]
   public function property($declaration, $expected) {
-    Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\Handle; class <T> {
+    Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\{FileInput, Handle}; class <T> {
       const INITIAL= "initial";
       private $h= %s;
 

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -51,6 +51,19 @@ class InitializeWithExpressionsTest extends EmittingTest {
   }
 
   #[Test]
+  public function using_closures_referencing_this() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private $id= 1;
+      private $h= fn() => new Handle($this->id);
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(1), $r());
+  }
+
+  #[Test]
   public function using_anonymous_classes() {
     $r= $this->run('class <T> {
       private $h= new class() { public function pipe($h) { return $h->redirect(1); } };

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -65,6 +65,19 @@ class InitializeWithExpressionsTest extends EmittingTest {
   }
 
   #[Test]
+  public function using_new_referencing_this() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private $id= 1;
+      private $h= new Handle($this->id);
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(1), $r);
+  }
+
+  #[Test]
   public function using_anonymous_classes() {
     $r= $this->run('class <T> {
       private $h= new class() { public function pipe($h) { return $h->redirect(1); } };

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -150,6 +150,16 @@ class InitializeWithExpressionsTest extends EmittingTest {
   }
 
   #[Test]
+  public function parameter_default_reflective_access() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run($h= new Handle(0)) {
+        return typeof($this)->getMethod("run")->getParameter(0)->getDefaultValue();
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
+
+  #[Test]
   public function property_reference_as_parameter_default() {
     $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
       private static $h= new Handle(0);

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -27,7 +27,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
   }
 
   #[Test, Values('expressions')]
-  public function property($code, $expected) {
+  public function property($declaration, $expected) {
     Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\Handle; class <T> {
       const INITIAL= "initial";
       private $h= %s;
@@ -35,18 +35,18 @@ class InitializeWithExpressionsTest extends EmittingTest {
       public function run() {
         return $this->h;
       }
-    }', $code)));
+    }', $declaration)));
   }
 
-  #[Test]
-  public function using_functions() {
-    $r= $this->run('class <T> {
-      private $h= fn($arg) => $arg->redirect(1);
+  #[Test, Values(['fn($arg) => $arg->redirect(1)', 'function($arg) { return $arg->redirect(1); }'])]
+  public function using_closures($declaration) {
+    $r= $this->run(sprintf('class <T> {
+      private $h= %s;
 
       public function run() {
         return $this->h;
       }
-    }');
+    }', $declaration));
     Assert::equals(new Handle(1), $r(new Handle(0)));
   }
 
@@ -61,7 +61,6 @@ class InitializeWithExpressionsTest extends EmittingTest {
     }');
     Assert::equals(new Handle(1), $r->pipe(new Handle(0)));
   }
-
 
   #[Test]
   public function property_initialization_accessible_inside_constructor() {

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -8,6 +8,7 @@ use unittest\{Assert, Test, Values};
  *
  * @see  https://github.com/xp-framework/compiler/pull/104
  * @see  https://wiki.php.net/rfc/new_in_initializers
+ * @see  https://wiki.php.net/rfc/const_scalar_exprs
  * @see  https://wiki.php.net/rfc/calls_in_constant_expressions
  */
 class InitializeWithExpressionsTest extends EmittingTest {

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -4,22 +4,34 @@ use lang\IllegalArgumentException;
 use unittest\{Assert, Expect, Test, Values};
 
 /**
- * New in initializers
+ * Initialize parameters and properties with arbitrary expressions
  *
+ * @see  https://github.com/xp-framework/compiler/pull/104
  * @see  https://wiki.php.net/rfc/new_in_initializers
  */
-class InitializeWithNewTest extends EmittingTest {
+class InitializeWithExpressionsTest extends EmittingTest {
 
-  #[Test]
-  public function property() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
-      private $h= new Handle(0);
+  /** @return iterable */
+  private function expressions() {
+    yield ['"test"', 'test'];
+    yield ['[1, 2, 3]', [1, 2, 3]];
+    yield ['MODIFIER_PUBLIC', MODIFIER_PUBLIC];
+    yield ['self::INITIAL', 'initial'];
+    yield ['Handle::$DEFAULT', Handle::$DEFAULT];
+    yield ['new Handle(0)', new Handle(0)];
+    yield ['[new Handle(0)]', [new Handle(0)]];
+  }
+
+  #[Test, Values('expressions')]
+  public function property($code, $expected) {
+    Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\Handle; class <T> {
+      const INITIAL= "initial";
+      private $h= %s;
 
       public function run() {
         return $this->h;
       }
-    }');
-    Assert::equals(new Handle(0), $r);
+    }', $code)));
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -51,6 +51,19 @@ class InitializeWithExpressionsTest extends EmittingTest {
   }
 
   #[Test]
+  public function using_anonymous_classes() {
+    $r= $this->run('class <T> {
+      private $h= new class() { public function pipe($h) { return $h->redirect(1); } };
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(1), $r->pipe(new Handle(0)));
+  }
+
+
+  #[Test]
   public function property_initialization_accessible_inside_constructor() {
     $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
       private $h= new Handle(0);

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -1,13 +1,14 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use unittest\{Assert, Test, Values};
 
 /**
  * Initialize parameters and properties with arbitrary expressions
  *
  * @see  https://github.com/xp-framework/compiler/pull/104
  * @see  https://wiki.php.net/rfc/new_in_initializers
+ * @see  https://wiki.php.net/rfc/calls_in_constant_expressions
  */
 class InitializeWithExpressionsTest extends EmittingTest {
 
@@ -15,6 +16,8 @@ class InitializeWithExpressionsTest extends EmittingTest {
   private function expressions() {
     yield ['"test"', 'test'];
     yield ['[1, 2, 3]', [1, 2, 3]];
+    yield ['1 << 2', 1 << 2];
+    yield ['strlen("Test")', strlen('Test')];
     yield ['MODIFIER_PUBLIC', MODIFIER_PUBLIC];
     yield ['self::INITIAL', 'initial'];
     yield ['Handle::$DEFAULT', Handle::$DEFAULT];
@@ -32,6 +35,18 @@ class InitializeWithExpressionsTest extends EmittingTest {
         return $this->h;
       }
     }', $code)));
+  }
+
+  #[Test]
+  public function using_functions() {
+    $r= $this->run('class <T> {
+      private $h= fn($arg) => $arg->redirect(1);
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(1), $r(new Handle(0)));
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -39,6 +39,18 @@ class InitializeWithExpressionsTest extends EmittingTest {
     }', $declaration)));
   }
 
+  #[Test, Values('expressions')]
+  public function reflective_access_to_property($declaration, $expected) {
+    Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\{FileInput, Handle}; class <T> {
+      const INITIAL= "initial";
+      private $h= %s;
+
+      public function run() {
+        return typeof($this)->getField("h")->get($this);
+      }
+    }', $declaration)));
+  }
+
   #[Test, Values(['fn($arg) => $arg->redirect(1)', 'function($arg) { return $arg->redirect(1); }'])]
   public function using_closures($declaration) {
     $r= $this->run(sprintf('class <T> {

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithNewTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithNewTest.class.php
@@ -103,4 +103,16 @@ class InitializeWithNewTest extends EmittingTest {
     }');
     Assert::equals(new Handle(0), $r);
   }
+
+  #[Test]
+  public function static_variable() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        static $h= new Handle(0);
+
+        return $h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithNewTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithNewTest.class.php
@@ -81,4 +81,26 @@ class InitializeWithNewTest extends EmittingTest {
     }');
     Assert::equals(new Handle(0), $r);
   }
+
+  #[Test]
+  public function typed_proprety() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private Handle $h= new Handle(0);
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
+
+  #[Test]
+  public function typed_parameter() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run(Handle $h= new Handle(0)) {
+        return $h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithNewTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithNewTest.class.php
@@ -1,0 +1,84 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\IllegalArgumentException;
+use unittest\{Assert, Expect, Test, Values};
+
+/**
+ * New in initializers
+ *
+ * @see  https://wiki.php.net/rfc/new_in_initializers
+ */
+class InitializeWithNewTest extends EmittingTest {
+
+  #[Test]
+  public function property() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private $h= new Handle(0);
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
+
+  #[Test]
+  public function property_initialization_accessible_inside_constructor() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private $h= new Handle(0);
+
+      public function __construct() {
+        $this->h->redirect(1);
+      }
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(1), $r);
+  }
+
+  #[Test]
+  public function promoted_property() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function __construct(private $h= new Handle(0)) { }
+
+      public function run() {
+        return $this->h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
+
+  #[Test]
+  public function parameter_default_when_omitted() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run($h= new Handle(0)) {
+        return $h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
+
+  #[Test]
+  public function parameter_default_when_passed() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run($h= new Handle(0)) {
+        return $h;
+      }
+    }', new Handle(1));
+    Assert::equals(new Handle(1), $r);
+  }
+
+  #[Test]
+  public function property_reference_as_parameter_default() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private static $h= new Handle(0);
+
+      public function run($h= self::$h) {
+        return $h;
+      }
+    }');
+    Assert::equals(new Handle(0), $r);
+  }
+}


### PR DESCRIPTION
Initialization is now supported for properties, static variables, parameter defaults and in combination with property promotion. On top of https://wiki.php.net/rfc/new_in_initializers, this pull request also supports arbitrary expressions in any of these places (as [hinted in the RFC](https://wiki.php.net/rfc/new_in_initializers#future_scope) PHP might do in the future).

The parser already supported expressions in these place, but emitting the code generated compile errors of the kind *Constant expression contains invalid operations*. 

```php
class Parser {
  private static $DEFAULT_SYNTAX= new Syntax('php');

  public function __construct(private $options= new Options()) { }

  public function parse($tokens= new Tokens(), $syntax= self::$DEFAULT_SYNTAX) {
    // TBI
  }
}
```

⚠️ This pull request does not support non-constant expressions for `const`, as there is no way to emit valid PHP 7.X / PHP 8.0 code nor any behind-the-scenes trickery (not even with [runkit](https://www.php.net/manual/de/function.runkit7-constant-add.php)) to achieve this!

Code added to `main` is less than 100 lines:

```bash
$ git diff master src/main/php/ | grep '^-' | wc -l
16
$ git diff master src/main/php/ | grep '^+' | wc -l
98
```

/cc @mikey179