### PR TITLE
Rewrite `never` return type to `void` in PHP < 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "^7.1",
+    "xp-framework/ast": "^7.2",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -22,7 +22,7 @@ class PHP70 extends PHP {
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
-        return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l) ? null : $l;
+        return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l || 'never' === $l) ? null : $l;
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -22,7 +22,7 @@ class PHP71 extends PHP {
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
-        return ('object' === $l || 'mixed' === $l) ? null : $l;
+        return ('object' === $l || 'mixed' === $l) ? null : ('never' === $l ? 'void' : $l);
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -22,7 +22,7 @@ class PHP72 extends PHP {
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
-        return 'mixed' === $l ? null : $l;
+        return 'mixed' === $l ? null : ('never' === $l ? 'void' : $l);
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -21,7 +21,7 @@ class PHP74 extends PHP {
       IsUnion::class    => function($t) { return null; },
       IsLiteral::class  => function($t) {
         $l= $t->literal();
-        return 'mixed' === $l ? null : $l;
+        return 'mixed' === $l ? null : ('never' === $l ? 'void' : $l);
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -27,7 +27,10 @@ class PHP80 extends PHP {
         }
         return substr($u, 1);
       },
-      IsLiteral::class  => function($t) { return $t->literal(); }
+      IsLiteral::class  => function($t) {
+        $l= $t->literal();
+        return 'never' === $l ? 'void' : $l;
+      }
     ];
   }
 

--- a/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest;
 
-use lang\ast\emit\{PHP70, PHP71, PHP72, PHP74, PHP80};
+use lang\ast\emit\{PHP70, PHP71, PHP72, PHP74, PHP80, PHP81};
 use lang\ast\types\{IsLiteral, IsArray, IsFunction, IsMap, IsValue, IsNullable, IsUnion};
 use unittest\{Assert, Test};
 
@@ -24,6 +24,7 @@ class TypeLiteralsTest {
     yield from $this->base();
     yield [new IsLiteral('object'), null];
     yield [new IsLiteral('void'), null];
+    yield [new IsLiteral('never'), null];
     yield [new IsLiteral('iterable'), null];
     yield [new IsLiteral('mixed'), null];
     yield [new IsNullable(new IsLiteral('string')), null];
@@ -39,6 +40,7 @@ class TypeLiteralsTest {
     yield from $this->base();
     yield [new IsLiteral('object'), null];
     yield [new IsLiteral('void'), 'void'];
+    yield [new IsLiteral('never'), 'void'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), null];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
@@ -55,6 +57,7 @@ class TypeLiteralsTest {
     yield from $this->base();
     yield [new IsLiteral('object'), 'object'];
     yield [new IsLiteral('void'), 'void'];
+    yield [new IsLiteral('never'), 'void'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), null];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
@@ -80,6 +83,24 @@ class TypeLiteralsTest {
     yield from $this->base();
     yield [new IsLiteral('object'), 'object'];
     yield [new IsLiteral('void'), 'void'];
+    yield [new IsLiteral('never'), 'void'];
+    yield [new IsLiteral('iterable'), 'iterable'];
+    yield [new IsLiteral('mixed'), 'mixed'];
+    yield [new IsNullable(new IsLiteral('string')), '?string'];
+    yield [new IsNullable(new IsLiteral('object')), '?object'];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), 'string|int'];
+  }
+
+  /**
+   * PHP 8.1 added `never`
+   *
+   * @return iterable
+   */
+  private function php81() {
+    yield from $this->base();
+    yield [new IsLiteral('object'), 'object'];
+    yield [new IsLiteral('void'), 'void'];
+    yield [new IsLiteral('never'), 'never'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), 'mixed'];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
@@ -110,5 +131,10 @@ class TypeLiteralsTest {
   #[Test, Values('php80')]
   public function php80_literals($type, $literal) {
     Assert::equals($literal, (new PHP80())->literal($type));
+  }
+
+  #[Test, Values('php81')]
+  public function php81_literals($type, $literal) {
+    Assert::equals($literal, (new PHP81())->literal($type));
   }
 }


### PR DESCRIPTION
See https://wiki.php.net/rfc/noreturn_type. Implements emitting support for xp-framework/compiler#109

```bash
# For PHP 8 (and lower), `never` is emitted as `void`
$ echo 'function bail(): never { exit(); }' | xp compile -t PHP.8.0 -q -
<?php function bail():void{exit();};

# For PHP 8.1, `never` is emitted as-is
$ echo 'function bail(): never { exit(); }' | xp compile -t PHP.8.1 -q -
<?php function bail():never{exit();};
```