### PR TITLE
Add support for directives using `declare`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "^7.2",
+    "xp-framework/ast": "dev-feature/declare as 7.3.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -157,6 +157,15 @@ abstract class PHP extends Emitter {
     }
   }
 
+  protected function emitDirectives($result, $directives) {
+    $result->out->write('declare(');
+    foreach ($directives->declare as $directive => $value) {
+      $result->out->write($directive.'=');
+      $this->emitOne($result, $value);
+    }
+    $result->out->write(')');
+  }
+
   protected function emitNamespace($result, $declaration) {
     $result->out->write('namespace '.$declaration->name);
   }

--- a/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
@@ -21,7 +21,7 @@ class DeclareTest extends EmittingTest {
     }'));
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/must be of type int, float given/')]
+  #[Test, Expect(class: Error::class, withMessage: '/must be of (the )?type int(eger)?, float given/')]
   public function strict_types_on() {
     $this->run('declare(strict_types = 1); class <T> {
       public static function number(int $n) { return $n; }

--- a/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
@@ -1,0 +1,31 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\Error;
+use unittest\{Assert, AssertionFailedError, Test};
+
+class DeclareTest extends EmittingTest {
+
+  #[Test]
+  public function no_strict_types() {
+    Assert::equals(1, $this->run('class <T> {
+      public static function number(int $n) { return $n; }
+      public function run() { return self::number(1.5); }
+    }'));
+  }
+
+  #[Test]
+  public function strict_types_off() {
+    Assert::equals(1, $this->run('declare(strict_types = 0); class <T> {
+      public static function number(int $n) { return $n; }
+      public function run() { return self::number(1.5); }
+    }'));
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/must be of type int, float given/')]
+  public function strict_types_on() {
+    $this->run('declare(strict_types = 1); class <T> {
+      public static function number(int $n) { return $n; }
+      public function run() { return self::number(1.5); }
+    }');
+  }
+}


### PR DESCRIPTION
Example:

```php
declare(strict_types = 1);

class T {
  public function number(int $n) { ... }
}

T::number(1.5); // Throws a TypeError, without strict_types, coerces to int(1)
```

Depends on xp-framework/ast#25. See https://www.php.net/manual/en/control-structures.declare.php and https://www.php.net/manual/en/language.types.declarations.php