### PR TITLE
Implement first-class callable syntax

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,13 @@ XP Compiler ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* Merged PR #114: Implements first-class callable syntax: `strlen(...)`
+  now returns a closure which if invoked with a string argument, returns
+  its length. Includes support for static and instance methods as well as
+  indirect references like `$closure(...)` and `self::{$expression}(...)`,
+  see https://wiki.php.net/rfc/first_class_callable_syntax
+  (@thekid)
+
 ## 6.5.0 / 2021-05-22
 
 * Merged PR #111: Add support for directives using declare - @thekid

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "^7.3",
+    "xp-framework/ast": "dev-feature/first_class_callable_syntax as 7.4.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "dev-feature/first_class_callable_syntax as 7.4.0",
+    "xp-framework/ast": "^7.4",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -27,9 +27,9 @@ trait CallablesAsClosures {
     // Create closure
     $t= $result->temp();
     $result->out->write('function(...'.$t.')');
-    $use && $result->out->write('use($'.implode(', $', array_keys($use)).')');
+    $use && $result->out->write('use($'.implode(',$', array_keys($use)).')');
     $result->out->write('{ return ');
     $this->emitOne($result, $callable->expression);
-    $result->out->write('(... '.$t.'); }');
+    $result->out->write('(...'.$t.'); }');
   }
 }

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -1,0 +1,34 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites callable expressions to regular closures
+ *
+ * @see  https://wiki.php.net/rfc/first_class_callable_syntax
+ */
+trait CallablesAsClosures {
+
+  protected function emitCallable($result, $callable) {
+
+    // Use variables in the following cases:
+    //
+    // $closure(...);                => use ($closure)
+    // $obj->method(...);            => use ($obj)
+    // $obj->$method(...);           => use ($obj, $method)
+    // ($obj->property)(...);        => use ($obj)
+    // $class::$method(...);         => use ($class, $method)
+    // [$obj, 'method'](...);        => use ($obj)
+    // [Foo::class, $method](...);   => use ($method)
+    $use= [];
+    foreach ($result->codegen->search($callable, 'variable') as $var) {
+      'this' === $var->name || $use[$var->name]= true;
+    }
+
+    // Create closure
+    $t= $result->temp();
+    $result->out->write('function(...'.$t.')');
+    $use && $result->out->write('use($'.implode(', $', array_keys($use)).')');
+    $result->out->write('{ return ');
+    $this->emitOne($result, $callable->expression);
+    $result->out->write('(... '.$t.'); }');
+  }
+}

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -1,35 +1,54 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Node;
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
+
 /**
- * Rewrites callable expressions to regular closures
+ * Rewrites callable expressions to `Callable::fromClosure()`
  *
  * @see  https://wiki.php.net/rfc/first_class_callable_syntax
  */
 trait CallablesAsClosures {
 
   protected function emitCallable($result, $callable) {
+    $result->out->write('\Closure::fromCallable(');
+    if ($callable->expression instanceof Literal) {
 
-    // Use variables in the following cases:
-    //
-    // $closure(...);                => use ($closure)
-    // $obj->method(...);            => use ($obj)
-    // $obj->$method(...);           => use ($obj, $method)
-    // ($obj->property)(...);        => use ($obj)
-    // $class::$method(...);         => use ($class, $method)
-    // [$obj, 'method'](...);        => use ($obj)
-    // [Foo::class, $method](...);   => use ($method)
-    $use= [];
-    foreach ($result->codegen->search($callable, 'variable') as $var) {
-      $use[$var->name]= true;
+      // Rewrite f() => "f"
+      $result->out->write('"'.trim($callable->expression->expression, '"\'').'"');
+    } else if ($callable->expression instanceof InstanceExpression) {
+
+      // Rewrite $this->f => [$this, "f"]
+      $result->out->write('[');
+      $this->emitOne($result, $callable->expression->expression);
+      if ($callable->expression->member instanceof Literal) {
+        $result->out->write(',"'.trim($callable->expression->member, '"\'').'"');
+      } else {
+        $result->out->write(',');
+        $this->emitOne($result, $callable->expression->member);
+      }
+      $result->out->write(']');
+    } else if ($callable->expression instanceof ScopeExpression) {
+
+      // Rewrite self::f => ["self", "f"]
+      $result->out->write('[');
+      if ($callable->expression->type instanceof Node) {
+        $this->emitOne($result, $callable->expression->type);
+      } else {
+        $result->out->write('"'.$callable->expression->type.'"');
+      }
+      if ($callable->expression->member instanceof Literal) {
+        $result->out->write(',"'.trim($callable->expression->member, '"\'').'"');
+      } else {
+        $result->out->write(',');
+        $this->emitOne($result, $callable->expression->member);
+      }
+      $result->out->write(']');
+    } else {
+
+      // Emit other expressions as-is
+      $this->emitOne($result, $callable->expression);
     }
-    unset($use['this']);
-
-    // Create closure
-    $t= $result->temp();
-    $result->out->write('function(...'.$t.')');
-    $use && $result->out->write('use($'.implode(',$', array_keys($use)).')');
-    $result->out->write('{ return ');
-    $this->emitOne($result, $callable->expression);
-    $result->out->write('(...'.$t.'); }');
+    $result->out->write(')');
   }
 }

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -20,8 +20,9 @@ trait CallablesAsClosures {
     // [Foo::class, $method](...);   => use ($method)
     $use= [];
     foreach ($result->codegen->search($callable, 'variable') as $var) {
-      'this' === $var->name || $use[$var->name]= true;
+      $use[$var->name]= true;
     }
+    unset($use['this']);
 
     // Create closure
     $t= $result->temp();

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -527,10 +527,9 @@ abstract class PHP extends Emitter {
       $this->emitOne($result, $member);
       $result->out->write("\n");
     }
+    $result->out->write('}');
 
-    $result->out->write('static function __init() {');
     $this->emitMeta($result, $trait->name, $trait->annotations, $trait->comment);
-    $result->out->write('}} '.$trait->name.'::__init();');
   }
 
   protected function emitUse($result, $use) {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -988,6 +988,13 @@ abstract class PHP extends Emitter {
     array_shift($result->type);
   }
 
+  protected function emitCallable($result, $callable) {
+    $t= $result->temp();
+    $result->out->write('fn(...'.$t.') => ');
+    $this->emitOne($result, $callable->expression);
+    $result->out->write('(... '.$t.')');
+  }
+
   protected function emitInvoke($result, $invoke) {
     $this->emitOne($result, $invoke->expression);
     $result->out->write('(');

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -990,9 +990,9 @@ abstract class PHP extends Emitter {
 
   protected function emitCallable($result, $callable) {
     $t= $result->temp();
-    $result->out->write('fn(...'.$t.') => ');
+    $result->out->write('fn(...'.$t.')=>');
     $this->emitOne($result, $callable->expression);
-    $result->out->write('(... '.$t.')');
+    $result->out->write('(...'.$t.')');
   }
 
   protected function emitInvoke($result, $invoke) {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -989,10 +989,8 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitCallable($result, $callable) {
-    $t= $result->temp();
-    $result->out->write('fn(...'.$t.')=>');
     $this->emitOne($result, $callable->expression);
-    $result->out->write('(...'.$t.')');
+    $result->out->write('(...)');
   }
 
   protected function emitInvoke($result, $invoke) {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_70
  */
 class PHP70 extends PHP {
-  use OmitPropertyTypes, OmitConstModifiers;
+  use OmitPropertyTypes, OmitConstModifiers, CallablesAsClosures;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Node;
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
 use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
@@ -8,7 +10,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_70
  */
 class PHP70 extends PHP {
-  use OmitPropertyTypes, OmitConstModifiers, CallablesAsClosures;
+  use OmitPropertyTypes, OmitConstModifiers;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */
@@ -25,5 +27,52 @@ class PHP70 extends PHP {
         return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l || 'never' === $l) ? null : $l;
       },
     ];
+  }
+
+  protected function emitCallable($result, $callable) {
+    $t= $result->temp();
+    $result->out->write('(is_callable('.$t.'=');
+    if ($callable->expression instanceof Literal) {
+
+      // Rewrite f() => "f"
+      $result->out->write('"'.trim($callable->expression->expression, '"\'').'"');
+    } else if ($callable->expression instanceof InstanceExpression) {
+
+      // Rewrite $this->f => [$this, "f"]
+      $result->out->write('[');
+      $this->emitOne($result, $callable->expression->expression);
+      if ($callable->expression->member instanceof Literal) {
+        $result->out->write(',"'.trim($callable->expression->member, '"\'').'"');
+      } else {
+        $result->out->write(',');
+        $this->emitOne($result, $callable->expression->member);
+      }
+      $result->out->write(']');
+    } else if ($callable->expression instanceof ScopeExpression) {
+
+      // Rewrite self::f => [self::class, "f"]
+      $result->out->write('[');
+      if ($callable->expression->type instanceof Node) {
+        $this->emitOne($result, $callable->expression->type);
+      } else {
+        $result->out->write($callable->expression->type.'::class');
+      }
+      if ($callable->expression->member instanceof Literal) {
+        $result->out->write(',"'.trim($callable->expression->member, '"\'').'"');
+      } else {
+        $result->out->write(',');
+        $this->emitOne($result, $callable->expression->member);
+      }
+      $result->out->write(']');
+    } else {
+
+      // Emit other expressions as-is
+      $this->emitOne($result, $callable->expression);
+    }
+
+    // Emit equivalent of Closure::fromCallable() which doesn't exist until PHP 7.1
+    $a= $result->temp();
+    $result->out->write(')?function(...'.$a.') use('.$t.') { return '.$t.'(...'.$a.'); }:');
+    $result->out->write('(function() { throw new \Error("Given argument is not callable"); })())');
   }
 }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_71
  */
 class PHP71 extends PHP {
-  use OmitPropertyTypes;
+  use OmitPropertyTypes, CallablesAsClosures;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_72
  */
 class PHP72 extends PHP {
-  use OmitPropertyTypes;
+  use OmitPropertyTypes, CallablesAsClosures;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_74
  */
 class PHP74 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals;
+  use RewriteBlockLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals, CallablesAsClosures;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteExplicitOctals;
+  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, CallablesAsClosures;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, Is
  * @see  https://wiki.php.net/rfc#php_81
  */
 class PHP81 extends PHP {
-  use RewriteBlockLambdaExpressions;
+  use RewriteBlockLambdaExpressions, CallablesAsClosures;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test, Values};
+use lang\Error;
+use unittest\{Assert, Expect, Test, Values};
 
 /**
  * Tests for first-class callable syntax
@@ -135,6 +136,17 @@ class CallableSyntaxTest extends EmittingTest {
     $this->verify('class <T> {
       public static function length($arg) { return strlen($arg); }
       public function run() { return [self::class, "length"](...); }
+    }');
+  }
+
+  #[Test, Expect(Error::class), Values(['nonexistant', '$this->nonexistant', 'self::nonexistant', '$nonexistant', '$null'])]
+  public function non_existant($expr) {
+    $this->run('class <T> {
+      public function run() {
+        $null= null;
+        $nonexistant= "nonexistant";
+        return '.$expr.'(...);
+      }
     }');
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -2,100 +2,100 @@
 
 use unittest\{Assert, Test, Values};
 
+/**
+ * Tests for first-class callable syntax
+ *
+ * @see   https://wiki.php.net/rfc/first_class_callable_syntax#proposal
+ */
 class CallableSyntaxTest extends EmittingTest {
+
+  /**
+   * Verification helper
+   *
+   * @param  string $code
+   * @return void
+   * @throws unittest.AssertionFailedError
+   */
+  private function verify($code) {
+    Assert::equals(4, $this->run($code)('Test'));
+  }
 
   #[Test]
   public function native_function() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public function run() { return strlen(...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function instance_method() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public function length($arg) { return strlen($arg); }
       public function run() { return $this->length(...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function class_method() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public static function length($arg) { return strlen($arg); }
       public function run() { return self::length(...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function private_method() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       private function length($arg) { return strlen($arg); }
       public function run() { return $this->length(...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function variable_function() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public function run() {
         $func= "strlen";
         return $func(...);
       }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function instance_method_reference() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       private $func= "strlen";
       public function run() {
         return ($this->func)(...);
       }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test, Values(['$this->$func(...)', '$this->{$func}(...)'])]
   public function variable_instance_method($expr) {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       private function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
         return '.$expr.';
       }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test, Values(['self::$func(...)', 'self::{$func}(...)'])]
   public function variable_class_method($expr) {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       private static function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
         return '.$expr.';
       }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function variable_class_method_with_variable_class() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       private static function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
@@ -103,36 +103,28 @@ class CallableSyntaxTest extends EmittingTest {
         return $class::$func(...);
       }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function string_function_reference() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public function run() { return "strlen"(...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function array_instance_method_reference() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public function length($arg) { return strlen($arg); }
       public function run() { return [$this, "length"](...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 
   #[Test]
   public function array_class_method_reference() {
-    $f= $this->run('class <T> {
+    $this->verify('class <T> {
       public static function length($arg) { return strlen($arg); }
       public function run() { return [self::class, "length"](...); }
     }');
-
-    Assert::equals(4, $f('Test'));
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -1,7 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Test, Values};
+use unittest\{Assert, Test};
 
 class CallableSyntaxTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -1,0 +1,139 @@
+<?php namespace lang\ast\unittest\emit;
+
+use unittest\actions\RuntimeVersion;
+use unittest\{Action, Assert, Test, Values};
+
+class CallableSyntaxTest extends EmittingTest {
+
+  #[Test]
+  public function native_function() {
+    $f= $this->run('class <T> {
+      public function run() { return strlen(...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function instance_method() {
+    $f= $this->run('class <T> {
+      public function length($arg) { return strlen($arg); }
+      public function run() { return $this->length(...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function class_method() {
+    $f= $this->run('class <T> {
+      public static function length($arg) { return strlen($arg); }
+      public function run() { return self::length(...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function private_method() {
+    $f= $this->run('class <T> {
+      private function length($arg) { return strlen($arg); }
+      public function run() { return $this->length(...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function variable_function() {
+    $f= $this->run('class <T> {
+      public function run() {
+        $func= "strlen";
+        return $func(...);
+      }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function instance_method_reference() {
+    $f= $this->run('class <T> {
+      private $func= "strlen";
+      public function run() {
+        return ($this->func)(...);
+      }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function variable_instance_method() {
+    $f= $this->run('class <T> {
+      private function length($arg) { return strlen($arg); }
+      public function run() {
+        $func= "length";
+        return $this->$func(...);
+      }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function variable_class_method() {
+    $f= $this->run('class <T> {
+      private static function length($arg) { return strlen($arg); }
+      public function run() {
+        $func= "length";
+        return self::$func(...);
+      }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function variable_class_method_with_variable_class() {
+    $f= $this->run('class <T> {
+      private static function length($arg) { return strlen($arg); }
+      public function run() {
+        $func= "length";
+        $class= __CLASS__;
+        return $class::$func(...);
+      }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function string_function_reference() {
+    $f= $this->run('class <T> {
+      public function run() { return "strlen"(...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function array_instance_method_reference() {
+    $f= $this->run('class <T> {
+      public function length($arg) { return strlen($arg); }
+      public function run() { return [$this, "length"](...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+
+  #[Test]
+  public function array_class_method_reference() {
+    $f= $this->run('class <T> {
+      public static function length($arg) { return strlen($arg); }
+      public function run() { return [self::class, "length"](...); }
+    }');
+
+    Assert::equals(4, $f('Test'));
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -52,7 +52,7 @@ class CallableSyntaxTest extends EmittingTest {
   }
 
   #[Test]
-  public function variable_function() {
+  public function string_reference() {
     $this->verify('class <T> {
       public function run() {
         $func= "strlen";
@@ -62,7 +62,17 @@ class CallableSyntaxTest extends EmittingTest {
   }
 
   #[Test]
-  public function instance_method_reference() {
+  public function fn_reference() {
+    $this->verify('class <T> {
+      public function run() {
+        $func= fn($arg) => strlen($arg);
+        return $func(...);
+      }
+    }');
+  }
+
+  #[Test]
+  public function instance_property_reference() {
     $this->verify('class <T> {
       private $func= "strlen";
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use unittest\{Assert, Test, Values};
 
 class CallableSyntaxTest extends EmittingTest {
 
@@ -67,26 +67,26 @@ class CallableSyntaxTest extends EmittingTest {
     Assert::equals(4, $f('Test'));
   }
 
-  #[Test]
-  public function variable_instance_method() {
+  #[Test, Values(['$this->$func(...)', '$this->{$func}(...)'])]
+  public function variable_instance_method($expr) {
     $f= $this->run('class <T> {
       private function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
-        return $this->$func(...);
+        return '.$expr.';
       }
     }');
 
     Assert::equals(4, $f('Test'));
   }
 
-  #[Test]
-  public function variable_class_method() {
+  #[Test, Values(['self::$func(...)', 'self::{$func}(...)'])]
+  public function variable_class_method($expr) {
     $f= $this->run('class <T> {
       private static function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
-        return self::$func(...);
+        return '.$expr.';
       }
     }');
 


### PR DESCRIPTION
## Examples

```php
// Old code without checks whether any of these are actually callable
$length= function(... $args) { return strlen(...$args); };
$run= function(... $args) use($instance) { return $instance->run(...$args); };
$of= function(... $args) { return Enum::valueOf(...$args); };

// Old code, requires PHP 7.1
$length= Closure::fromCallable('strlen');
$run= Closure::fromCallable([$instance, 'run']);
$of= Closure::fromCallable([Enum::class, 'valueOf']);

// Now possible, works on all PHP versions w/ XP Compiler
$length= strlen(...);
$run= $instance->run(...)
$of= Enum::valueOf(...);
```

## See also

* https://wiki.php.net/rfc/closurefromcallable
* https://wiki.php.net/rfc/first_class_callable_syntax
* php/php-src/pull/7019
* xp-framework/ast#27
