### PR TITLE
Implement typed properties for PHP < 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
     - name: Configure git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       run: >
         curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run &&
         composer install --prefer-dist &&
+        cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 git@github.com:thekid/core.git &&
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       run: >
         curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run &&
         composer install --prefer-dist &&
-        cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 git@github.com:thekid/core.git &&
+        cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 https://github.com/thekid/core.git &&
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       run: >
         curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run &&
         composer install --prefer-dist &&
-        cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 https://github.com/thekid/core.git &&
+        cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 --depth 1 https://github.com/thekid/core.git && cd ../.. &&
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 before_script:
   - curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run
   - composer install --prefer-dist
-  - cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 git@github.com:thekid/core.git
+  - cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 https://github.com/thekid/core.git
   - echo "vendor/autoload.php" > composer.pth
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 before_script:
   - curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run
   - composer install --prefer-dist
-  - cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 https://github.com/thekid/core.git
+  - cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 --depth 1 https://github.com/thekid/core.git && cd ../..
   - echo "vendor/autoload.php" > composer.pth
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
 before_script:
   - curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.5.1.sh > xp-run
   - composer install --prefer-dist
+  - cd vendor/xp-framework && rm -rf core && git clone -b rfc/340 git@github.com:thekid/core.git
   - echo "vendor/autoload.php" > composer.pth
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "XP Compiler",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "dev-rfc/340 as 10.12.0",
+    "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/ast": "^7.4",
     "php" : ">=7.0.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "XP Compiler",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
+    "xp-framework/core": "dev-rfc/340 as 10.12.0",
     "xp-framework/ast": "^7.4",
     "php" : ">=7.0.0"
   },

--- a/src/main/php/lang/ast/emit/OmitPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/OmitPropertyTypes.class.php
@@ -1,9 +1,12 @@
 <?php namespace lang\ast\emit;
 
 /**
- * Removes type hints for PHP versions that do not support typed
- * properties - everything below PHP 7.4
+ * Removes type hints for PHP versions and generates virtual instance
+ * properties for PHP runtimes that that do not support typed properties,
+ * which is everything below PHP 7.4.
  *
+ * @see  https://bugs.php.net/bug.php?id=52225
+ * @see  https://github.com/xp-framework/rfc/issues/340
  * @see  https://wiki.php.net/rfc/typed_properties_v2
  */
 trait OmitPropertyTypes {
@@ -15,4 +18,20 @@ trait OmitPropertyTypes {
    * @return string
    */
   protected function propertyType($type) { return ''; }
+
+  protected function emitProperty($result, $property) {
+    if (null === $property->type || in_array('static', $property->modifiers)) {
+      return parent::emitProperty($result, $property);
+    }
+
+    // Only track meta information, push property to virtual locals
+    $result->meta[0][self::PROPERTY][$property->name]= [
+      DETAIL_RETURNS     => $property->type ? $property->type->name() : 'var',
+      DETAIL_ANNOTATIONS => $property->annotations,
+      DETAIL_COMMENT     => $property->comment,
+      DETAIL_TARGET_ANNO => [],
+      DETAIL_ARGUMENTS   => []
+    ];
+    $result->locals[2][]= $property;
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/PropertiesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PropertiesTest.class.php
@@ -1,0 +1,102 @@
+<?php namespace lang\ast\unittest\emit;
+
+use unittest\actions\RuntimeVersion;
+use unittest\{Assert, Action, Test, Values};
+
+class PropertiesTest extends EmittingTest {
+
+  /**
+   * Helper to create a class with a property restricted to a given type
+   *
+   * @param  string $property
+   * @return lang.XPClass
+   */
+  private function fixtureWith($property) {
+    return $this->type('use lang\ast\unittest\emit\Handle; class <T> {
+      '.$property.'
+      public function __construct($input) { $this->property= $input; }
+    }');
+  }
+
+  #[Test, Values([null, 'Test', 1, 1.5, true, false, [[1, 2, 3]]])]
+  public function without_type($arg) {
+    Assert::equals($arg, $this->fixtureWith('public $property;')->newInstance($arg)->property);
+  }
+
+  #[Test, Values(['', 'Test'])]
+  public function use_string($arg) {
+    Assert::equals($arg, $this->fixtureWith('public string $property;')->newInstance($arg)->property);
+  }
+
+  #[Test, Values([[null], [[1, 2, 3]]])]
+  public function cannot_assing_string_from($arg) {
+    Assert::throws(\TypeError::class, function() use($arg) {
+      $this->fixtureWith('public string $property;')->newInstance($arg);
+    });
+  }
+
+  #[Test, Values([1, 1.5, true, false])]
+  public function string_type_coerces_primitive($arg) {
+    Assert::equals((string)$arg, $this->fixtureWith('public string $property;')->newInstance($arg)->property);
+  }
+
+  #[Test]
+  public function initial_value() {
+    $t= $this->type('class <T> {
+      public string $property= "Test";
+    }');
+
+    Assert::equals('Test', $t->newInstance()->property);
+  }
+
+  #[Test]
+  public function initial_expression() {
+    $t= $this->type('use lang\ast\unittest\emit\Handle; class <T> {
+      public Handle $property= new Handle(1);
+    }');
+
+    Assert::equals(new Handle(1), $t->newInstance()->property);
+  }
+
+  #[Test, Values(eval: '[null, new Handle(1)]')]
+  public function use_nullable($arg) {
+    Assert::equals($arg, $this->fixtureWith('public ?Handle $property;')->newInstance($arg)->property);
+  }
+
+  #[Test, Values([1, 'Test', false])]
+  public function cannot_assign_handle_from($arg) {
+    Assert::throws(\TypeError::class, function() use($arg) {
+      $this->fixtureWith('public ?Handle $property;')->newInstance($arg);
+    });
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion("<=7.4")')]
+  public function static_properties_left_untyped() {
+    $t= $this->type('class <T> {
+      public static string $member;
+      public static function violate() { self::$member= ["Test"]; }
+    }');
+
+    // Since PHP does not have __get and __set for static members, we degrade
+    // to untyped properties. See https://bugs.php.net/bug.php?id=52225
+    $t->getMethod('violate')->invoke(null, []);
+    Assert::equals(['Test'], $t->getField('member')->get(null));
+  }
+
+  #[Test]
+  public function reading_from_undefined_members_raises_error() {
+    set_error_handler(function($error, $message, $file, $line) use(&$caught) { $caught= $message; });
+    try {
+      $t= $this->type('class <T> {
+        private string $name= "Test";
+        public function run() { return [$this->id, $this->name]; }
+      }');
+      $result= $t->getMethod('run')->invoke($t->newInstance());
+
+      Assert::equals([null, 'Test'], $result);
+      Assert::equals('Undefined property: '.$t->getName().'::$id', $caught);
+    } finally {
+      restore_error_handler();
+    }
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
@@ -16,7 +16,11 @@ class TransformationsTest extends EmittingTest {
           ['public'],
           'toString',
           new Signature([], new IsLiteral('string')),
-          [new Code('return "T@".\util\Objects::stringOf(get_object_vars($this))')]
+          [new Code('return "T@".\util\Objects::stringOf(array_filter(
+            get_object_vars($this),
+            function($e, $n) { return 0 !== strncmp($n, "__", 2); },
+            ARRAY_FILTER_USE_BOTH
+          ))')]
         ));
       }
       return $class;
@@ -51,7 +55,7 @@ class TransformationsTest extends EmittingTest {
   #[Test]
   public function generates_string_representation() {
     $t= $this->type('#[Repr] class <T> {
-      private int $id;
+      private $id;
 
       public function __construct(int $id) {
         $this->id= $id;
@@ -79,7 +83,7 @@ class TransformationsTest extends EmittingTest {
   #[Test]
   public function generates_both() {
     $t= $this->type('#[Repr, Getters] class <T> {
-      private int $id;
+      private $id;
 
       public function __construct(int $id) {
         $this->id= $id;


### PR DESCRIPTION
See https://github.com/xp-framework/compiler/issues/108#issuecomment-886040965. The following example will now throw a *TypeError* for all PHP versions on the last line:

```php
class T {
  public int $id;
}

$t= new T();
$t->id= 'Test';
```

Generates code for virtual properties to make reflection work seamlessly on it, see https://github.com/xp-framework/rfc/issues/340

*⚠️ Restricted to instance properties due to https://bugs.php.net/bug.php?id=52225*