### PR TITLE
Support for intersection types in PHP 8.1

### DIFF
--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\Node;
 use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 7.0 syntax
@@ -16,13 +16,14 @@ class PHP70 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsFunction::class => function($t) { return 'callable'; },
-      IsArray::class    => function($t) { return 'array'; },
-      IsMap::class      => function($t) { return 'array'; },
-      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class => function($t) { return null; },
-      IsUnion::class    => function($t) { return null; },
-      IsLiteral::class  => function($t) {
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
+      IsNullable::class     => function($t) { return null; },
+      IsUnion::class        => function($t) { return null; },
+      IsIntersection::class => function($t) { return null; },
+      IsLiteral::class      => function($t) {
         $l= $t->literal();
         return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l || 'never' === $l) ? null : $l;
       },

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 7.1 syntax
@@ -14,13 +14,14 @@ class PHP71 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsFunction::class => function($t) { return 'callable'; },
-      IsArray::class    => function($t) { return 'array'; },
-      IsMap::class      => function($t) { return 'array'; },
-      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
-      IsUnion::class    => function($t) { return null; },
-      IsLiteral::class  => function($t) {
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsUnion::class        => function($t) { return null; },
+      IsIntersection::class => function($t) { return null; },
+      IsLiteral::class      => function($t) {
         $l= $t->literal();
         return ('object' === $l || 'mixed' === $l) ? null : ('never' === $l ? 'void' : $l);
       },

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 7.2 syntax
@@ -14,13 +14,14 @@ class PHP72 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsArray::class    => function($t) { return 'array'; },
-      IsMap::class      => function($t) { return 'array'; },
-      IsFunction::class => function($t) { return 'callable'; },
-      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
-      IsUnion::class    => function($t) { return null; },
-      IsLiteral::class  => function($t) {
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsUnion::class        => function($t) { return null; },
+      IsIntersection::class => function($t) { return null; },
+      IsLiteral::class      => function($t) {
         $l= $t->literal();
         return 'mixed' === $l ? null : ('never' === $l ? 'void' : $l);
       },

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 7.4 syntax
@@ -13,13 +13,14 @@ class PHP74 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsArray::class    => function($t) { return 'array'; },
-      IsMap::class      => function($t) { return 'array'; },
-      IsFunction::class => function($t) { return 'callable'; },
-      IsValue::class    => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
-      IsUnion::class    => function($t) { return null; },
-      IsLiteral::class  => function($t) {
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsUnion::class        => function($t) { return null; },
+      IsIntersection::class => function($t) { return null; },
+      IsLiteral::class      => function($t) {
         $l= $t->literal();
         return 'mixed' === $l ? null : ('never' === $l ? 'void' : $l);
       },

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 8.0 syntax
@@ -14,12 +14,13 @@ class PHP80 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsArray::class    => function($t) { return 'array'; },
-      IsMap::class      => function($t) { return 'array'; },
-      IsFunction::class => function($t) { return 'callable'; },
-      IsValue::class    => function($t) { return $t->literal(); },
-      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
-      IsUnion::class    => function($t) {
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsValue::class        => function($t) { return $t->literal(); },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsIntersection::class => function($t) { return null; },
+      IsUnion::class        => function($t) {
         $u= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
@@ -27,7 +28,7 @@ class PHP80 extends PHP {
         }
         return substr($u, 1);
       },
-      IsLiteral::class  => function($t) {
+      IsLiteral::class      => function($t) {
         $l= $t->literal();
         return 'never' === $l ? 'void' : $l;
       }

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
  * PHP 8.1 syntax
@@ -14,12 +14,20 @@ class PHP81 extends PHP {
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [
-      IsArray::class    => function($t) { return 'array'; },
-      IsMap::class      => function($t) { return 'array'; },
-      IsFunction::class => function($t) { return 'callable'; },
-      IsValue::class    => function($t) { return $t->literal(); },
-      IsNullable::class => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
-      IsUnion::class    => function($t) {
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsValue::class        => function($t) { return $t->literal(); },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsIntersection::class => function($t) {
+        $i= '';
+        foreach ($t->components as $component) {
+          if (null === ($l= $this->literal($component))) return null;
+          $i.= '&'.$l;
+        }
+        return substr($i, 1);
+      },
+      IsUnion::class        => function($t) {
         $u= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
@@ -27,7 +35,7 @@ class PHP81 extends PHP {
         }
         return substr($u, 1);
       },
-      IsLiteral::class  => function($t) { return $t->literal(); }
+      IsLiteral::class      => function($t) { return $t->literal(); }
     ];
   }
 

--- a/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
@@ -136,7 +136,7 @@ class ControlStructuresTest extends EmittingTest {
     Assert::equals('10+ items', $r);
   }
 
-  #[Test, Expect(class: Throwable::class, withMessage: '/Unhandled match value of type .+/')]
+  #[Test, Expect(class: Throwable::class, withMessage: '/Unhandled match (value of type .+|case .+)/')]
   public function unhandled_match() {
     $this->run('class <T> {
       public function run($arg) {

--- a/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
@@ -60,7 +60,7 @@ class IntersectionTypesTest extends EmittingTest {
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
-  public function parameter_function_type_restriction_with_php81() {
+  public function parameter_type_restriction_with_php81() {
     $t= $this->type('class <T> {
       public function test(): Traversable&Countable { }
     }');

--- a/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
@@ -48,6 +48,18 @@ class IntersectionTypesTest extends EmittingTest {
   }
 
   #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  public function field_type_restriction_with_php81() {
+    $t= $this->type('class <T> {
+      private Traversable&Countable $test;
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getField('test')->getTypeRestriction()
+    );
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
   public function parameter_type_restriction_with_php81() {
     $t= $this->type('class <T> {
       public function test(Traversable&Countable $arg) { }
@@ -56,18 +68,6 @@ class IntersectionTypesTest extends EmittingTest {
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
       $t->getMethod('test')->getParameter(0)->getTypeRestriction()
-    );
-  }
-
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
-  public function parameter_type_restriction_with_php81() {
-    $t= $this->type('class <T> {
-      public function test(): Traversable&Countable { }
-    }');
-
-    Assert::equals(
-      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getMethod('test')->getReturnTypeRestriction()
     );
   }
 

--- a/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
@@ -1,0 +1,85 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\{Primitive, XPClass, TypeIntersection};
+use unittest\actions\RuntimeVersion;
+use unittest\{Assert, Test, Action};
+
+/**
+ * Intersection types
+ *
+ * @see  https://wiki.php.net/rfc/pure-intersection-types
+ */
+class IntersectionTypesTest extends EmittingTest {
+
+  #[Test]
+  public function field_type() {
+    $t= $this->type('class <T> {
+      private Traversable&Countable $test;
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getField('test')->getType()
+    );
+  }
+
+  #[Test]
+  public function parameter_type() {
+    $t= $this->type('class <T> {
+      public function test(Traversable&Countable $arg) { }
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getMethod('test')->getParameter(0)->getType()
+    );
+  }
+
+  #[Test]
+  public function return_type() {
+    $t= $this->type('class <T> {
+      public function test(): Traversable&Countable { }
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getMethod('test')->getReturnType()
+    );
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  public function parameter_type_restriction_with_php81() {
+    $t= $this->type('class <T> {
+      public function test(Traversable&Countable $arg) { }
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getMethod('test')->getParameter(0)->getTypeRestriction()
+    );
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  public function parameter_function_type_restriction_with_php81() {
+    $t= $this->type('class <T> {
+      public function test(): Traversable&Countable { }
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getMethod('test')->getReturnTypeRestriction()
+    );
+  }
+
+  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  public function return_type_restriction_with_php81() {
+    $t= $this->type('class <T> {
+      public function test(): Traversable&Countable { }
+    }');
+
+    Assert::equals(
+      new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
+      $t->getMethod('test')->getReturnTypeRestriction()
+    );
+  }
+}


### PR DESCRIPTION
```php
function fixture(Countable&Traversable $t) { ... }
```

See xp-framework/compiler#117 and https://wiki.php.net/rfc/pure-intersection-types

*:warning: Unchecked for all other PHP versions at the moment*