### PR TITLE
Add support for readonly properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "XP Compiler",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "dev-rfc/340 as 10.13.0",
+    "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/ast": "^7.5",
     "php" : ">=7.0.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "XP Compiler",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
+    "xp-framework/core": "dev-rfc/340 as 10.13.0",
     "xp-framework/ast": "^7.5",
     "php" : ">=7.0.0"
   },

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_70
  */
 class PHP70 extends PHP {
-  use OmitPropertyTypes, OmitConstModifiers;
+  use OmitPropertyTypes, OmitConstModifiers, ReadonlyProperties;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteMultiCatch, RewriteClassOnObjects, RewriteExplicitOctals, RewriteEnums;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_71
  */
 class PHP71 extends PHP {
-  use OmitPropertyTypes, CallablesAsClosures;
+  use OmitPropertyTypes, CallablesAsClosures, ReadonlyProperties;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals, RewriteEnums;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_72
  */
 class PHP72 extends PHP {
-  use OmitPropertyTypes, CallablesAsClosures;
+  use OmitPropertyTypes, CallablesAsClosures, ReadonlyProperties;
   use RewriteNullCoalesceAssignment, RewriteLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals, RewriteEnums;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -8,7 +8,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_74
  */
 class PHP74 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals, RewriteEnums, CallablesAsClosures;
+  use RewriteBlockLambdaExpressions, RewriteClassOnObjects, RewriteExplicitOctals, RewriteEnums, CallablesAsClosures, ReadonlyProperties;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, RewriteEnums, CallablesAsClosures;
+  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, RewriteEnums, ReadonlyProperties, CallablesAsClosures;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
@@ -1,0 +1,35 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Creates __get() and __set() overloads for readonly properties
+ *
+ * @see  https://github.com/xp-framework/compiler/issues/115
+ * @see  https://wiki.php.net/rfc/readonly_properties_v2
+ */
+trait ReadonlyProperties {
+
+  protected function emitProperty($result, $property) {
+    $p= array_search('readonly', $property->modifiers);
+    if (false === $p) return parent::emitProperty($result, $property);
+
+    $result->meta[0][self::PROPERTY][$property->name]= [
+      DETAIL_RETURNS     => $property->type ? $property->type->name() : 'var',
+      DETAIL_ANNOTATIONS => $property->annotations,
+      DETAIL_COMMENT     => $property->comment,
+      DETAIL_TARGET_ANNO => [],
+      DETAIL_ARGUMENTS   => [MODIFIER_READONLY]
+    ];
+    $result->locals[2][$property->name]= null;
+
+    if (isset($property->expression)) {
+      if ($this->isConstant($result, $property->expression)) {
+        $result->out->write('=');
+        $this->emitOne($result, $property->expression);
+      } else if (in_array('static', $property->modifiers)) {
+        $result->locals[0]['self::$'.$property->name]= $property->expression;
+      } else {
+        $result->locals[1]['$this->'.$property->name]= $property->expression;
+      }
+    }
+  }
+}

--- a/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
@@ -22,11 +22,11 @@ trait ReadonlyProperties {
       DETAIL_ARGUMENTS   => [MODIFIER_READONLY]
     ];
 
-    // Create virtual property
+    // Create virtual property implementing the readonly semantics
     $result->locals[2][$property->name]= [
-      new Code('return $this->__virtual[$name][0] ?? null;'),
+      new Code('return $this->__virtual["'.$property->name.'"][0] ?? null;'),
       new Code('
-        if (isset($this->__virtual[$name])) {
+        if (isset($this->__virtual["'.$property->name.'"])) {
           throw new \\Error("Cannot modify readonly property ".__CLASS__."::{$name}");
         }
         $caller= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
@@ -37,7 +37,7 @@ trait ReadonlyProperties {
             : "global scope"
           ));
         }
-        $this->__virtual[$name]= [$value];
+        $this->__virtual["'.$property->name.'"]= [$value];
       '),
     ];
 

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyPropertiesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyPropertiesTest.class.php
@@ -1,0 +1,69 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\Error;
+use unittest\{Assert, Test};
+
+/**
+ * Readonly properties
+ *
+ * @see  https://wiki.php.net/rfc/readonly_properties_v2
+ */
+class ReadonlyPropertiesTest extends EmittingTest {
+
+  #[Test]
+  public function declaration() {
+    $t= $this->type('class <T> {
+      public readonly int $fixture;
+    }');
+
+    Assert::equals(
+      sprintf('public readonly int %s::$fixture', $t->getName()),
+      $t->getField('fixture')->toString()
+    );
+  }
+
+  #[Test]
+  public function with_constructor_argument_promotion() {
+    $t= $this->type('class <T> {
+      public function __construct(public readonly string $fixture) { }
+    }');
+
+    Assert::equals('Test', $t->newInstance('Test')->fixture);
+  }
+
+  #[Test]
+  public function reading() {
+    $t= $this->type('class <T> {
+      public function __construct(public readonly string $fixture) { }
+    }');
+    Assert::equals('Test', $t->newInstance('Test')->fixture);
+  }
+
+  #[Test]
+  public function assigning_inside_constructor() {
+    $t= $this->type('class <T> {
+      public readonly string $fixture;
+      public function __construct($fixture) { $this->fixture= $fixture; }
+    }');
+    Assert::equals('Test', $t->newInstance('Test')->fixture);
+  }
+
+  #[Test]
+  public function can_be_assigned_via_reflection() {
+    $t= $this->type('class <T> {
+      public readonly string $fixture;
+    }');
+    $i= $t->newInstance();
+    $t->getField('fixture')->setAccessible(true)->set($i, 'Test');
+
+    Assert::equals('Test', $i->fixture);
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot modify readonly property .+fixture/')]
+  public function cannot_be_set_after_initialization() {
+    $t= $this->type('class <T> {
+      public function __construct(public readonly string $fixture) { }
+    }');
+    $t->newInstance('Test')->fixture= 'Modified';
+  }
+}


### PR DESCRIPTION
Use native `readonly` modifier in PHP 8.1, simulated via virtual properties for PHP 7.X and PHP 8.0, see https://github.com/xp-framework/compiler/issues/115