### PR TITLE
Support `new T(...)` callable syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "dev-feature/new-callable as 7.7.0",
+    "xp-framework/ast": "^7.7",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/ast": "^7.6",
+    "xp-framework/ast": "dev-feature/new-callable as 7.7.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClassExpression, Literal};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClassExpression, UnpackExpression, Literal};
 
 /**
  * Rewrites callable expressions to `Callable::fromClosure()`
@@ -12,7 +12,8 @@ trait CallablesAsClosures {
 
   protected function emitCallable($result, $callable) {
     if ($callable->expression instanceof NewExpression || $callable->expression instanceof NewClassExpression) {
-      $result->out->write('fn(...$_args) => ');
+      $unpack= cast($callable->expression->arguments[0], UnpackExpression::class);
+      $result->out->write('fn(...$'.$unpack->expression->name.') => ');
       $this->emitOne($result, $callable->expression);
       return;
     }

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClassExpression, UnpackExpression, Literal};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
 
 /**
  * Rewrites callable expressions to `Callable::fromClosure()`

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -13,8 +13,9 @@ trait CallablesAsClosures {
   protected function emitCallable($result, $callable) {
     if ($callable->expression instanceof NewExpression || $callable->expression instanceof NewClassExpression) {
       $unpack= cast($callable->expression->arguments[0], UnpackExpression::class);
-      $result->out->write('fn(...$'.$unpack->expression->name.') => ');
+      $result->out->write('function(...$'.$unpack->expression->name.') { return ');
       $this->emitOne($result, $callable->expression);
+      $result->out->write(';}');
       return;
     }
 

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -11,14 +11,6 @@ use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClass
 trait CallablesAsClosures {
 
   protected function emitCallable($result, $callable) {
-    if ($callable->expression instanceof NewExpression || $callable->expression instanceof NewClassExpression) {
-      $unpack= cast($callable->expression->arguments[0], UnpackExpression::class);
-      $result->out->write('function(...$'.$unpack->expression->name.') { return ');
-      $this->emitOne($result, $callable->expression);
-      $result->out->write(';}');
-      return;
-    }
-
     $result->out->write('\Closure::fromCallable(');
     if ($callable->expression instanceof Literal) {
 

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClassExpression, Literal};
 
 /**
  * Rewrites callable expressions to `Callable::fromClosure()`
@@ -11,6 +11,12 @@ use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
 trait CallablesAsClosures {
 
   protected function emitCallable($result, $callable) {
+    if ($callable->expression instanceof NewExpression || $callable->expression instanceof NewClassExpression) {
+      $result->out->write('fn(...$_args) => ');
+      $this->emitOne($result, $callable->expression);
+      return;
+    }
+
     $result->out->write('\Closure::fromCallable(');
     if ($callable->expression instanceof Literal) {
 

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -6,6 +6,7 @@ use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
 /**
  * Rewrites callable expressions to `Callable::fromClosure()`
  *
+ * @see  https://www.php.net/manual/de/closure.fromcallable.php
  * @see  https://wiki.php.net/rfc/first_class_callable_syntax
  */
 trait CallablesAsClosures {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Code;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, BinaryExpression, Variable, Literal, ArrayLiteral, Block, Property};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, BinaryExpression, UnpackExpression, Variable, Literal, ArrayLiteral, Block, Property};
 use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap};
 use lang\ast\{Emitter, Node, Type};
 
@@ -972,6 +972,17 @@ abstract class PHP extends Emitter {
   protected function emitCallable($result, $callable) {
     $this->emitOne($result, $callable->expression);
     $result->out->write('(...)');
+  }
+
+  protected function emitCallableNew($result, $callable) {
+    $t= $result->temp();
+    $result->out->write("function(...{$t}) { return ");
+
+    $callable->type->arguments= [new UnpackExpression(new Variable(substr($t, 1)), $callable->line)];
+    $this->emitOne($result, $callable->type);
+    $callable->type->arguments= null;
+
+    $result->out->write("; }");
   }
 
   protected function emitInvoke($result, $invoke) {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -31,14 +31,6 @@ class PHP70 extends PHP {
   }
 
   protected function emitCallable($result, $callable) {
-    if ($callable->expression instanceof NewExpression || $callable->expression instanceof NewClassExpression) {
-      $unpack= cast($callable->expression->arguments[0], UnpackExpression::class);
-      $result->out->write('function(...$'.$unpack->expression->name.') { return ');
-      $this->emitOne($result, $callable->expression);
-      $result->out->write(';}');
-      return;
-    }
-
     $t= $result->temp();
     $result->out->write('(is_callable('.$t.'=');
     if ($callable->expression instanceof Literal) {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClassExpression, UnpackExpression, Literal};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
 use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, NewExpression, NewClassExpression, UnpackExpression, Literal};
 use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral};
 
 /**
@@ -31,6 +31,14 @@ class PHP70 extends PHP {
   }
 
   protected function emitCallable($result, $callable) {
+    if ($callable->expression instanceof NewExpression || $callable->expression instanceof NewClassExpression) {
+      $unpack= cast($callable->expression->arguments[0], UnpackExpression::class);
+      $result->out->write('function(...$'.$unpack->expression->name.') { return ');
+      $this->emitOne($result, $callable->expression);
+      $result->out->write(';}');
+      return;
+    }
+
     $t= $result->temp();
     $result->out->write('(is_callable('.$t.'=');
     if ($callable->expression instanceof Literal) {

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -165,11 +165,11 @@ class CallableSyntaxTest extends EmittingTest {
     $f= $this->run('class <T> {
       public function run() {
         return new class(...) {
-          public function __construct(private $value) { }
-          public function value() { return $this->value; }
+          public $value;
+          public function __construct($value) { $this->value= $value; }
         };
       }
     }');
-    Assert::equals($this, $f($this)->value());
+    Assert::equals($this, $f($this)->value);
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -149,4 +149,14 @@ class CallableSyntaxTest extends EmittingTest {
       }
     }');
   }
+
+  #[Test]
+  public function instantiation() {
+    $f= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        return new Handle(...);
+      }
+    }');
+    Assert::equals(new Handle(1), $f(1));
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -161,6 +161,16 @@ class CallableSyntaxTest extends EmittingTest {
   }
 
   #[Test]
+  public function instantiation_in_map() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        return array_map(new Handle(...), [0, 1, 2]);
+      }
+    }');
+    Assert::equals([new Handle(0), new Handle(1), new Handle(2)], $r);
+  }
+
+  #[Test]
   public function anonymous_instantiation() {
     $f= $this->run('class <T> {
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -159,4 +159,17 @@ class CallableSyntaxTest extends EmittingTest {
     }');
     Assert::equals(new Handle(1), $f(1));
   }
+
+  #[Test]
+  public function anonymous_instantiation() {
+    $f= $this->run('class <T> {
+      public function run() {
+        return new class(...) {
+          public function __construct(private $value) { }
+          public function value() { return $this->value; }
+        };
+      }
+    }');
+    Assert::equals($this, $f($this)->value());
+  }
 }


### PR DESCRIPTION
In a nutshell, allows the following:

```php
$create= new T(...);

// Equivalent PHP syntax
$create= fn(... $args) => new T(...$args);
```

Usecase:

```php
$handles= array_map(new Handle(...), [0, 1, 2]);
// [Handle<STDIN>, Handle<STDOUT>, Handle<STDOUT>]
```

See https://wiki.php.net/rfc/first_class_callable_syntax#object_creation
Depends on xp-framework/ast#32