### PR TITLE
Fold __init() into __static()

### DIFF
--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -239,10 +239,10 @@ class MembersTest extends EmittingTest {
   #[Test]
   public function static_return_type() {
     $t= $this->type('
-      class <T>Base { public function run(): static { return $this; } }
-      class <T> extends <T>Base { }
+      class <T> { public function run(): static { return $this; } }
     ');
-    Assert::equals($t, $t->getMethod('run')->getReturnType());
+    $child= typeof(newinstance($t->literal(), [], []));
+    Assert::equals($child, $child->getMethod('run')->getReturnType());
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/emit/PHP81Test.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PHP81Test.class.php
@@ -22,7 +22,7 @@ class PHP81Test extends EmittingTest {
   public function unit_enum() {
     Assert::equals(
       'enum OS{case WINDOWS;case UNIX;};',
-      preg_replace('/static function __init.+__init\(\);/', '}', $this->emit('enum OS { case WINDOWS; case UNIX; }'))
+      preg_replace('/static function __static.+}}/', '}', $this->emit('enum OS { case WINDOWS; case UNIX; }'))
     );
   }
 
@@ -30,7 +30,7 @@ class PHP81Test extends EmittingTest {
   public function backed_enum() {
     Assert::equals(
       'enum Suit:string{case Hearts="♥";};',
-      preg_replace('/static function __init.+__init\(\);/', '}', $this->emit('enum Suit : string { case Hearts= "♥"; }'))
+      preg_replace('/static function __static.+}}/', '}', $this->emit('enum Suit : string { case Hearts= "♥"; }'))
     );
   }
 


### PR DESCRIPTION
This pull request gets rid of the *__init()* method and folds it into the XP Framework's static initializer `__static()`. This has the following effects:

* It makes the classes usable outside of XP Framework, no longer generating fatal errors - other frameworks will not invoke the *__static()* function.
* It reduces code size (*by a small bit*) by not declaring two functions

However, it also moves static initializer code to the bottom of the type declaration, resulting in incorrect line numbers for code executed therein. This will be rare but makes debugging harder.

See also: https://github.com/xp-framework/compiler/issues/116#issuecomment-989832672