### PR TITLE
Do not emit XP meta information by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ $ xp compile -n src/main/php/
 
 # Target PHP 7.4 (default target is current PHP version)
 $ xp compile -t php:7.4 HelloWorld.php HelloWorld.class.php
+
+# Emit XP meta information (includes lang.ast.emit.php.XpMeta):
+$ xp compile -t php:7.4 -e php:xp-meta -o dist src/main/php
 ```
 
 The -o and -n options accept multiple input sources following them.

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "^7.7",
+    "xp-framework/ast": "dev-master as 8.0.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "dev-master as 8.0.0",
+    "xp-framework/ast": "^8.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast;
 
-use lang\ast\emit\{Reflection, XPMeta};
+use lang\ast\emit\Reflection;
+use lang\ast\emit\php\XpMeta;
 use lang\reflect\Package;
 use lang\{
   ClassFormatException,
@@ -247,7 +248,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return  lang.IClassLoader
    */
   public static function instanceFor($version) {
-    $emit= Emitter::forRuntime($version, [XPMeta::class]);
+    $emit= Emitter::forRuntime($version, [XpMeta::class]);
 
     $id= $emit->getName();
     if (!isset(self::$instance[$id])) {

--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -263,7 +263,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return string
    */
   public function toString() {
-    return 'CompilingCL<'.nameof(Compiled::$emit[$this->version]).'>';
+    return 'CompilingCL<'.$this->version.'>';
   }
 
   /**

--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast;
 
-use lang\ast\emit\Reflection;
+use lang\ast\emit\{Reflection, XPMeta};
 use lang\reflect\Package;
 use lang\{
   ClassFormatException,
@@ -27,7 +27,8 @@ class CompilingClassLoader implements IClassLoader {
 
   /** Creates a new instances with a given PHP runtime */
   private function __construct($emit) {
-    $this->version= $emit->getSimpleName();
+    $this->version= str_replace('⋈', '+', $emit->getSimpleName());
+
     Compiled::$emit[$this->version]= $emit->newInstance();
     stream_wrapper_register($this->version, Compiled::class);
   }
@@ -246,7 +247,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return  lang.IClassLoader
    */
   public static function instanceFor($version) {
-    $emit= Emitter::forRuntime($version);
+    $emit= Emitter::forRuntime($version, [XPMeta::class]);
 
     $id= $emit->getName();
     if (!isset(self::$instance[$id])) {
@@ -261,7 +262,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return string
    */
   public function toString() {
-    return 'CompilingCL<'.$this->version.'>';
+    return 'CompilingCL<'.nameof(Compiled::$emit[$this->version]).'>';
   }
 
   /**

--- a/src/main/php/lang/ast/Result.class.php
+++ b/src/main/php/lang/ast/Result.class.php
@@ -33,6 +33,20 @@ class Result {
   }
 
   /**
+   * Forwards output line to given line number
+   *
+   * @param  int $line
+   * @return self
+   */
+  public function at($line) {
+    if ($line > $this->line) {
+      $this->out->write(str_repeat("\n", $line - $this->line));
+      $this->line= $line;
+    }
+    return $this;
+  }
+
+  /**
    * Looks up a given type 
    *
    * @param  string $type

--- a/src/main/php/lang/ast/emit/AttributesAsComments.class.php
+++ b/src/main/php/lang/ast/emit/AttributesAsComments.class.php
@@ -1,0 +1,39 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Rewrites PHP 8 attributes as comments for PHP 7, ensuring they are
+ * always on a line by themselves. This might break line numbers and
+ * make it harder to debug but guarantees the emitted code is syntactically
+ * correct!
+ *
+ * @see  https://wiki.php.net/rfc/shorter_attribute_syntax_change
+ */
+trait AttributesAsComments {
+
+  protected function emitAnnotation($result, $annotation) {
+    $result->out->write('\\'.$annotation->name);
+    if (empty($annotation->arguments)) return;
+
+    // We can use named arguments here as PHP 8 attributes are parsed
+    // by the XP reflection API when using PHP 7. However, we may not
+    // emit trailing commas here!
+    $result->out->write('(');
+    $i= 0;
+    foreach ($annotation->arguments as $name => $argument) {
+      $i++ > 0 && $result->out->write(',');
+      is_string($name) && $result->out->write("{$name}:");
+      $this->emitOne($result, $argument);
+    }
+    $result->out->write(')');
+  }
+
+  protected function emitAnnotations($result, $annotations) {
+    $result->out->write('#[');
+    foreach ($annotations->named as $annotation) {
+      $this->emitOne($result, $annotation);
+      $result->out->write(',');
+    }
+    $result->out->write("]\n");
+    $result->line++;
+  }
+}

--- a/src/main/php/lang/ast/emit/AttributesAsComments.class.php
+++ b/src/main/php/lang/ast/emit/AttributesAsComments.class.php
@@ -2,9 +2,11 @@
 
 /**
  * Rewrites PHP 8 attributes as comments for PHP 7, ensuring they are
- * always on a line by themselves. This might break line numbers and
- * make it harder to debug but guarantees the emitted code is syntactically
- * correct!
+ * always on a line by themselves *and* never span more than one line.
+ *
+ * This will break line numbers if annotations are on the same line as
+ * the element they belong to and make it harder to debug but guarantees
+ * the emitted code is syntactically correct!
  *
  * @see  https://wiki.php.net/rfc/shorter_attribute_syntax_change
  */
@@ -28,12 +30,18 @@ trait AttributesAsComments {
   }
 
   protected function emitAnnotations($result, $annotations) {
+    $line= $annotations->line;
     $result->out->write('#[');
+
+    $out= $result->out->stream();
+    $result->out->redirect(new Escaping($out, ["\n" => " "]));
     foreach ($annotations->named as $annotation) {
       $this->emitOne($result, $annotation);
       $result->out->write(',');
     }
+    $result->out->redirect($out);
+
     $result->out->write("]\n");
-    $result->line++;
+    $result->line= $line + 1;
   }
 }

--- a/src/main/php/lang/ast/emit/Escaping.class.php
+++ b/src/main/php/lang/ast/emit/Escaping.class.php
@@ -1,0 +1,24 @@
+<?php namespace lang\ast\emit;
+
+use io\streams\OutputStream;
+
+class Escaping implements OutputStream {
+  private $target, $replacements;
+
+  public function __construct(OutputStream $target, array $replacements) {
+    $this->target= $target;
+    $this->replacements= $replacements;
+  }
+
+  public function write($bytes) {
+    $this->target->write(strtr($bytes, $this->replacements));
+  }
+
+  public function flush() {
+    $this->target->flush();
+  }
+
+  public function close() {
+    $this->target->close();
+  }
+}

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -1,7 +1,18 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\emit\Escaping;
-use lang\ast\nodes\{Annotation, InstanceExpression, ScopeExpression, BinaryExpression, UnpackExpression, Variable, Literal, ArrayLiteral, Block};
+use lang\ast\nodes\{
+  Annotation,
+  ArrayLiteral,
+  BinaryExpression,
+  Block,
+  InstanceExpression,
+  Literal,
+  Property,
+  ScopeExpression,
+  UnpackExpression,
+  Variable
+};
 use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap};
 use lang\ast\{Emitter, Node, Type};
 
@@ -595,7 +606,7 @@ abstract class PHP extends Emitter {
     }
 
     foreach ($promoted as $param) {
-      $result->out->write($param->promote.' '.$this->propertyType($param->type).' $'.$param->name.';');
+      $this->emitProperty($result, new Property(explode(' ', $param->promote), $param->name, $param->type));
     }
 
     // Copy any virtual properties inside locals[2] to class scope

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -463,6 +463,10 @@ abstract class PHP extends Emitter {
       $result->out->write('\')');
       return;
     }
+
+    $result->out->write('(');
+    $this->emitArguments($result, $annotation->arguments);
+    $result->out->write(')');
   }
 
   protected function emitAnnotations($result, $annotations) {

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Code;
+use lang\ast\emit\Escaping;
 use lang\ast\nodes\{InstanceExpression, ScopeExpression, BinaryExpression, UnpackExpression, Variable, Literal, ArrayLiteral, Block, Property};
 use lang\ast\types\{IsUnion, IsFunction, IsArray, IsMap};
 use lang\ast\{Emitter, Node, Type};
@@ -432,9 +433,12 @@ abstract class PHP extends Emitter {
         // Found first non-constant argument, enclose in `eval`
         // FIXME Emit more than one argument
         $result->out->write('(eval: \'');
-        foreach ($annotation->arguments as $name => $argument) {
+        $out= $result->out->stream();
+        $result->out->redirect(new Escaping($out, ["'" => "\\'", '\\' => '\\\\']));
+        foreach ($annotation->arguments as $argument) {
           $this->emitOne($result, $argument);
         }
+        $result->out->redirect($out);
         $result->out->write('\')');
         return;
       }

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -13,6 +13,7 @@ class PHP70 extends PHP {
   use 
     ArbitrayNewExpressions,
     ArrayUnpackUsingMerge,
+    AttributesAsComments,
     MatchAsTernaries,
     NullsafeAsTernaries,
     OmitArgumentNames,

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -11,6 +11,7 @@ class PHP71 extends PHP {
   use 
     ArbitrayNewExpressions,
     ArrayUnpackUsingMerge,
+    AttributesAsComments,
     CallablesAsClosures,
     MatchAsTernaries,
     NonCapturingCatchVariables,

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -11,6 +11,7 @@ class PHP72 extends PHP {
   use 
     ArbitrayNewExpressions,
     ArrayUnpackUsingMerge,
+    AttributesAsComments,
     CallablesAsClosures,
     MatchAsTernaries,
     NonCapturingCatchVariables,

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -11,6 +11,7 @@ class PHP74 extends PHP {
   use
     ArbitrayNewExpressions,
     ArrayUnpackUsingMerge,
+    AttributesAsComments,
     CallablesAsClosures,
     MatchAsTernaries,
     NonCapturingCatchVariables,

--- a/src/main/php/lang/ast/emit/Reflection.class.php
+++ b/src/main/php/lang/ast/emit/Reflection.class.php
@@ -6,6 +6,7 @@ class Reflection extends Type {
   private $reflect;
   private static $UNITENUM;
 
+  /** @codeCoverageIgnore */
   static function __static() {
     self::$UNITENUM= interface_exists(\UnitEnum::class, false);  // Compatibility with XP < 10.8.0
   }

--- a/src/main/php/lang/ast/emit/Type.class.php
+++ b/src/main/php/lang/ast/emit/Type.class.php
@@ -3,6 +3,7 @@
 abstract class Type {
   public static $ENUMS;
 
+  /** @codeCoverageIgnore */
   static function __static() {
     self::$ENUMS= PHP_VERSION_ID >= 80100;
   }

--- a/src/main/php/lang/ast/emit/XPMeta.class.php
+++ b/src/main/php/lang/ast/emit/XPMeta.class.php
@@ -1,0 +1,104 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Emit meta information so that the XP reflection API won't have to parse
+ * it. Also omits apidoc comments and annotations from the generated code.
+ *
+ * Code compiled with this optimization in place require using the XP Core!
+ *
+ * @see  https://github.com/xp-framework/rfc/issues/336
+ */
+trait XPMeta {
+
+  /** Stores lowercased, unnamespaced name in annotations for BC reasons! */
+  protected function annotations($result, $annotations) {
+    if (null === $annotations) return [];
+
+    $lookup= [];
+    foreach ($annotations as $name => $arguments) {
+      $p= strrpos($name, '\\');
+      $key= lcfirst(false === $p ? $name : substr($name, $p + 1));
+      $result->out->write("'".$key."' => ");
+      $name === $key || $lookup[$key]= $name;
+
+      if (empty($arguments)) {
+        $result->out->write('null,');
+      } else if (1 === sizeof($arguments) && isset($arguments[0])) {
+        $this->emitOne($result, $arguments[0]);
+        $result->out->write(',');
+      } else {
+        $result->out->write('[');
+        foreach ($arguments as $name => $argument) {
+          is_string($name) && $result->out->write("'".$name."' => ");
+          $this->emitOne($result, $argument);
+          $result->out->write(',');
+        }
+        $result->out->write('],');
+      }
+    }
+    return $lookup;
+  }
+
+  /** Emits annotations in XP format - and mappings for their names */
+  private function attributes($result, $annotations, $target) {
+    $result->out->write('DETAIL_ANNOTATIONS => [');
+    $lookup= $this->annotations($result, $annotations);
+    $result->out->write('], DETAIL_TARGET_ANNO => [');
+    foreach ($target as $name => $annotations) {
+      $result->out->write("'$".$name."' => [");
+      foreach ($this->annotations($result, $annotations) as $key => $value) {
+        $lookup[$key]= $value;
+      }
+      $result->out->write('],');
+    }
+    foreach ($lookup as $key => $value) {
+      $result->out->write("'".$key."' => '".$value."',");
+    }
+    $result->out->write(']');
+  }
+
+  /** Emit comment inside meta information */
+  private function comment($comment) {
+    return null === $comment ? 'null' : var_export($comment->content(), true);
+  }
+
+  /** Emit xp::$meta */
+  protected function emitMeta($result, $name, $annotations, $comment) {
+    if (null === $name) {
+      $result->out->write('\xp::$meta[strtr(self::class, "\\\\", ".")]= [');
+    } else {
+      $result->out->write('\xp::$meta[\''.strtr(ltrim($name, '\\'), '\\', '.').'\']= [');
+    }
+    $result->out->write('"class" => [');
+    $this->attributes($result, $annotations, []);
+    $result->out->write(', DETAIL_COMMENT => '.$this->comment($comment).'],');
+
+    foreach (array_shift($result->meta) as $type => $lookup) {
+      $result->out->write($type.' => [');
+      foreach ($lookup as $key => $meta) {
+        $result->out->write("'".$key."' => [");
+        $this->attributes($result, $meta[DETAIL_ANNOTATIONS], $meta[DETAIL_TARGET_ANNO]);
+        $result->out->write(', DETAIL_RETURNS => \''.$meta[DETAIL_RETURNS].'\'');
+        $result->out->write(', DETAIL_COMMENT => '.$this->comment($meta[DETAIL_COMMENT]));
+        $result->out->write(', DETAIL_ARGUMENTS => ['.($meta[DETAIL_ARGUMENTS]
+          ? "'".implode("', '", $meta[DETAIL_ARGUMENTS])."']],"
+          : ']],'
+        ));
+      }
+      $result->out->write('],');
+    }
+    $result->out->write('];');
+  }
+
+  protected function emitComment($result, $comment) {
+    // Omit from generated code
+  }
+
+  protected function emitAnnotation($result, $annotation) {
+    // Omit from generated code
+  }
+
+  protected function emitAnnotations($result, $annotations) {
+    // Omit from generated code
+  }
+}

--- a/src/main/php/lang/ast/emit/php/XpMeta.class.php
+++ b/src/main/php/lang/ast/emit/php/XpMeta.class.php
@@ -1,4 +1,4 @@
-<?php namespace lang\ast\emit;
+<?php namespace lang\ast\emit\php;
 
 /**
  * Emit meta information so that the XP reflection API won't have to parse
@@ -8,7 +8,7 @@
  *
  * @see  https://github.com/xp-framework/rfc/issues/336
  */
-trait XPMeta {
+trait XpMeta {
 
   /** Stores lowercased, unnamespaced name in annotations for BC reasons! */
   protected function annotations($result, $annotations) {

--- a/src/main/php/lang/ast/emit/php/XpMeta.class.php
+++ b/src/main/php/lang/ast/emit/php/XpMeta.class.php
@@ -4,7 +4,8 @@
  * Emit meta information so that the XP reflection API won't have to parse
  * it. Also omits apidoc comments and annotations from the generated code.
  *
- * Code compiled with this optimization in place require using the XP Core!
+ * Code compiled with this optimization in place requires using the XP Core
+ * as a dependency!
  *
  * @see  https://github.com/xp-framework/rfc/issues/336
  */

--- a/src/main/php/xp/compiler/CompileRunner.class.php
+++ b/src/main/php/xp/compiler/CompileRunner.class.php
@@ -51,6 +51,7 @@ class CompileRunner {
     $target= 'php:'.PHP_VERSION;
     $in= $out= '-';
     $quiet= false;
+    $emitters= [];
     for ($i= 0; $i < sizeof($args); $i++) {
       if ('-t' === $args[$i]) {
         $target= $args[++$i];
@@ -64,6 +65,9 @@ class CompileRunner {
         $out= null;
         $in= array_slice($args, $i + 1);
         break;
+      } else if ('-e' === $args[$i]) {
+        $emitter= $args[++$i];
+        $emitters[]= $emitter;
       } else {
         $in= $args[$i];
         $out= $args[$i + 1] ?? '-';
@@ -72,7 +76,7 @@ class CompileRunner {
     }
 
     $lang= Language::named('PHP');
-    $emit= Emitter::forRuntime($target)->newInstance();
+    $emit= Emitter::forRuntime($target, $emitters)->newInstance();
     foreach ($lang->extensions() as $extension) {
       $extension->setup($lang, $emit);
     }

--- a/src/main/php/xp/compiler/CompileRunner.class.php
+++ b/src/main/php/xp/compiler/CompileRunner.class.php
@@ -1,8 +1,8 @@
 <?php namespace xp\compiler;
 
 use io\Path;
-use lang\Runtime;
 use lang\ast\{CompilingClassloader, Emitter, Errors, Language, Result, Tokens};
+use lang\{Runtime, XPClass};
 use text\StreamTokenizer;
 use util\cmd\Console;
 use util\profiling\Timer;
@@ -35,6 +35,10 @@ use util\profiling\Timer;
  *   ```sh
  *   $ xp compile -t php:7.4 HelloWorld.php HelloWorld.class.php
  *   ```
+ * - Emit XP meta information (includes `lang.ast.emit.php.XpMeta`):
+ *   ```sh
+ *   $ xp compile -t php:7.4 -e php:xp-meta -o dist src/main/php
+ *   ```
  *
  * The *-o* and *-n* options accept multiple input sources following them.
  * The *-q* option suppresses all diagnostic output except for errors.
@@ -43,6 +47,19 @@ use util\profiling\Timer;
  * @see  https://github.com/xp-framework/rfc/issues/299
  */
 class CompileRunner {
+
+  /** Returns an emitter by a given name */
+  private static function emitter(string $name): XPClass {
+    $p= strpos($name, ':');
+    if (false === $p) return XPClass::forName($name);
+
+    // Translate php:xp-meta to lang.ast.emit.php.XpMeta
+    return XPClass::forName(sprintf(
+      'lang.ast.emit.%s.%s',
+      substr($name, 0, $p),
+      implode('', array_map('ucfirst', explode('-', substr($name, $p + 1))))
+    ));
+  }
 
   /** @return int */
   public static function main(array $args) {
@@ -66,8 +83,7 @@ class CompileRunner {
         $in= array_slice($args, $i + 1);
         break;
       } else if ('-e' === $args[$i]) {
-        $emitter= $args[++$i];
-        $emitters[]= $emitter;
+        $emitters[]= self::emitter($args[++$i]);
       } else {
         $in= $args[$i];
         $out= $args[$i + 1] ?? '-';

--- a/src/test/php/lang/ast/unittest/ResultTest.class.php
+++ b/src/test/php/lang/ast/unittest/ResultTest.class.php
@@ -45,7 +45,7 @@ class ResultTest {
   #[Test]
   public function lookup_self() {
     $r= new Result(new StringWriter(new MemoryOutputStream()));
-    $r->type[0]= new ClassDeclaration([], '\\T', null, [], [], [], null, 1);
+    $r->type[0]= new ClassDeclaration([], '\\T', null, [], [], null, null, 1);
 
     Assert::equals(new Declaration($r->type[0], $r), $r->lookup('self'));
   }
@@ -53,7 +53,7 @@ class ResultTest {
   #[Test]
   public function lookup_parent() {
     $r= new Result(new StringWriter(new MemoryOutputStream()));
-    $r->type[0]= new ClassDeclaration([], '\\T', '\\lang\\Value', [], [], [], null, 1);
+    $r->type[0]= new ClassDeclaration([], '\\T', '\\lang\\Value', [], [], null, null, 1);
 
     Assert::equals(new Reflection(Value::class), $r->lookup('parent'));
   }
@@ -61,7 +61,7 @@ class ResultTest {
   #[Test]
   public function lookup_named() {
     $r= new Result(new StringWriter(new MemoryOutputStream()));
-    $r->type[0]= new ClassDeclaration([], '\\T', null, [], [], [], null, 1);
+    $r->type[0]= new ClassDeclaration([], '\\T', null, [], [], null, null, 1);
 
     Assert::equals(new Declaration($r->type[0], $r), $r->lookup('\\T'));
   }
@@ -77,5 +77,31 @@ class ResultTest {
   public function lookup_non_existant() {
     $r= new Result(new StringWriter(new MemoryOutputStream()));
     $r->lookup('\\NotFound');
+  }
+
+  #[Test]
+  public function line_number_initially_1() {
+    $r= new Result(new StringWriter(new MemoryOutputStream()));
+    Assert::equals(1, $r->line);
+  }
+
+  #[Test, Values([[1, '<?php test'], [2, "<?php \ntest"], [3, "<?php \n\ntest"]])]
+  public function write_at_line($line, $expected) {
+    $out= new MemoryOutputStream();
+    $r= new Result(new StringWriter($out));
+    $r->at($line)->out->write('test');
+
+    Assert::equals($expected, $out->bytes());
+    Assert::equals($line, $r->line);
+  }
+
+  #[Test]
+  public function at_cannot_go_backwards() {
+    $out= new MemoryOutputStream();
+    $r= new Result(new StringWriter($out));
+    $r->at(0)->out->write('test');
+
+    Assert::equals('<?php test', $out->bytes());
+    Assert::equals(1, $r->line);
   }
 }

--- a/src/test/php/lang/ast/unittest/ResultTest.class.php
+++ b/src/test/php/lang/ast/unittest/ResultTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\{StringWriter, MemoryOutputStream};
 use lang\ast\Result;
-use lang\ast\emit\{Declaration, Reflection};
+use lang\ast\emit\{Declaration, Escaping, Reflection};
 use lang\ast\nodes\ClassDeclaration;
 use lang\{Value, ClassNotFoundException};
 use unittest\{Assert, Expect, Test};
@@ -40,6 +40,20 @@ class ResultTest {
     $r= new Result(new StringWriter($out));
     $r->out->write('echo "Hello";');
     Assert::equals('<?php echo "Hello";', $out->bytes());
+  }
+
+  #[Test]
+  public function write_escaped() {
+    $out= new MemoryOutputStream();
+    $r= new Result(new StringWriter($out));
+
+    $r->out->write("'");
+    $r->out->redirect(new Escaping($out, ["'" => "\\'"]));
+    $r->out->write("echo 'Hello'");
+    $r->out->redirect($out);
+    $r->out->write("'");
+
+    Assert::equals("<?php 'echo \'Hello\''", $out->bytes());
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
@@ -1,0 +1,129 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\IllegalArgumentException;
+use unittest\{Assert, Expect, Test, Values};
+
+/**
+ * Annotations support. There are two tests extending this base class:
+ *
+ * - AnnotationsTest - emits XP Meta information
+ * - AttributesTest - emits PHP 8 attributes
+ */
+abstract class AnnotationSupport extends EmittingTest {
+
+  #[Test]
+  public function without_value() {
+    $t= $this->type('#[Test] class <T> { }');
+    Assert::equals(['test' => null], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function within_namespace() {
+    $t= $this->type('namespace tests; #[Test] class <T> { }');
+    Assert::equals(['test' => null], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function resolved_against_import() {
+    $t= $this->type('use unittest\Test; #[Test] class <T> { }');
+    Assert::equals(['test' => null], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function primitive_value() {
+    $t= $this->type('#[Author("Timm")] class <T> { }');
+    Assert::equals(['author' => 'Timm'], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function array_value() {
+    $t= $this->type('#[Authors(["Timm", "Alex"])] class <T> { }');
+    Assert::equals(['authors' => ['Timm', 'Alex']], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function map_value() {
+    $t= $this->type('#[Expect(["class" => \lang\IllegalArgumentException::class])] class <T> { }');
+    Assert::equals(['expect' => ['class' => IllegalArgumentException::class]], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function named_argument() {
+    $t= $this->type('#[Expect(class: \lang\IllegalArgumentException::class)] class <T> { }');
+    Assert::equals(['expect' => ['class' => IllegalArgumentException::class]], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function closure_value() {
+    $t= $this->type('#[Verify(function($arg) { return $arg; })] class <T> { }');
+    $f= $t->getAnnotation('verify');
+    Assert::equals('test', $f('test'));
+  }
+
+  #[Test]
+  public function arrow_function_value() {
+    $t= $this->type('#[Verify(fn($arg) => $arg)] class <T> { }');
+    $f= $t->getAnnotation('verify');
+    Assert::equals('test', $f('test'));
+  }
+
+  #[Test]
+  public function array_of_arrow_function_value() {
+    $t= $this->type('#[Verify([fn($arg) => $arg])] class <T> { }');
+    $f= $t->getAnnotation('verify');
+    Assert::equals('test', $f[0]('test'));
+  }
+
+  #[Test]
+  public function single_quoted_string_inside_non_constant_expression() {
+    $t= $this->type('#[Verify(fn($arg) => \'php\\\\\'.$arg)] class <T> { }');
+    $f= $t->getAnnotation('verify');
+    Assert::equals('php\\test', $f('test'));
+  }
+
+  #[Test]
+  public function has_access_to_class() {
+    $t= $this->type('#[Expect(self::SUCCESS)] class <T> { const SUCCESS = true; }');
+    Assert::equals(['expect' => true], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function method() {
+    $t= $this->type('class <T> { #[Test] public function fixture() { } }');
+    Assert::equals(['test' => null], $t->getMethod('fixture')->getAnnotations());
+  }
+
+  #[Test]
+  public function field() {
+    $t= $this->type('class <T> { #[Test] public $fixture; }');
+    Assert::equals(['test' => null], $t->getField('fixture')->getAnnotations());
+  }
+
+  #[Test]
+  public function param() {
+    $t= $this->type('class <T> { public function fixture(#[Test] $param) { } }');
+    Assert::equals(['test' => null], $t->getMethod('fixture')->getParameter(0)->getAnnotations());
+  }
+
+  #[Test]
+  public function params() {
+    $t= $this->type('class <T> { public function fixture(#[Inject(["name" => "a"])] $a, #[Inject] $b) { } }');
+    $m= $t->getMethod('fixture');
+    Assert::equals(
+      [['inject' => ['name' => 'a']], ['inject' => null]],
+      [$m->getParameter(0)->getAnnotations(), $m->getParameter(1)->getAnnotations()]
+    );
+  }
+
+  #[Test]
+  public function multiple_class_annotations() {
+    $t= $this->type('#[Resource("/"), Authenticated] class <T> { }');
+    Assert::equals(['resource' => '/', 'authenticated' => null], $t->getAnnotations());
+  }
+
+  #[Test]
+  public function multiple_member_annotations() {
+    $t= $this->type('class <T> { #[Test, Values([1, 2, 3])] public function fixture() { } }');
+    Assert::equals(['test' => null, 'values' => [1, 2, 3]], $t->getMethod('fixture')->getAnnotations());
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
@@ -126,4 +126,16 @@ abstract class AnnotationSupport extends EmittingTest {
     $t= $this->type('class <T> { #[Test, Values([1, 2, 3])] public function fixture() { } }');
     Assert::equals(['test' => null, 'values' => [1, 2, 3]], $t->getMethod('fixture')->getAnnotations());
   }
+
+  #[Test]
+  public function multiline_annotations() {
+    $t= $this->type('
+      #[Authors([
+        "Timm",
+        "Mr. Midori",
+      ])]
+      class <T> { }'
+    );
+    Assert::equals(['authors' => ['Timm', 'Mr. Midori']], $t->getAnnotations());
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
@@ -75,6 +75,13 @@ abstract class AnnotationSupport extends EmittingTest {
   }
 
   #[Test]
+  public function named_arrow_function_value() {
+    $t= $this->type('#[Verify(func: fn($arg) => $arg)] class <T> { }');
+    $f= $t->getAnnotation('verify');
+    Assert::equals('test', $f['func']('test'));
+  }
+
+  #[Test]
   public function single_quoted_string_inside_non_constant_expression() {
     $t= $this->type('#[Verify(fn($arg) => \'php\\\\\'.$arg)] class <T> { }');
     $f= $t->getAnnotation('verify');

--- a/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
@@ -1,116 +1,16 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use lang\ast\emit\php\XpMeta;
 
 /**
- * Annotations support
+ * Annotations via XP Meta information
  *
  * @see  https://github.com/xp-framework/rfc/issues/16
  * @see  https://github.com/xp-framework/rfc/issues/218
- * @see  https://wiki.php.net/rfc/shorter_attribute_syntax_change
  */
-class AnnotationsTest extends EmittingTest {
+class AnnotationsTest extends AnnotationSupport {
 
-  #[Test]
-  public function without_value() {
-    $t= $this->type('#[Test] class <T> { }');
-    Assert::equals(['test' => null], $t->getAnnotations());
-  }
+  /** @return string[] */
+  protected function emitters() { return [XpMeta::class]; }
 
-  #[Test]
-  public function within_namespace() {
-    $t= $this->type('namespace tests; #[Test] class <T> { }');
-    Assert::equals(['test' => null], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function resolved_against_import() {
-    $t= $this->type('use unittest\Test; #[Test] class <T> { }');
-    Assert::equals(['test' => null], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function primitive_value() {
-    $t= $this->type('#[Author("Timm")] class <T> { }');
-    Assert::equals(['author' => 'Timm'], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function array_value() {
-    $t= $this->type('#[Authors(["Timm", "Alex"])] class <T> { }');
-    Assert::equals(['authors' => ['Timm', 'Alex']], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function map_value() {
-    $t= $this->type('#[Expect(["class" => \lang\IllegalArgumentException::class])] class <T> { }');
-    Assert::equals(['expect' => ['class' => IllegalArgumentException::class]], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function named_argument() {
-    $t= $this->type('#[Expect(class: \lang\IllegalArgumentException::class)] class <T> { }');
-    Assert::equals(['expect' => ['class' => IllegalArgumentException::class]], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function closure_value() {
-    $t= $this->type('#[Verify(function($arg) { return $arg; })] class <T> { }');
-    $f= $t->getAnnotation('verify');
-    Assert::equals('test', $f('test'));
-  }
-
-  #[Test]
-  public function arrow_function_value() {
-    $t= $this->type('#[Verify(fn($arg) => $arg)] class <T> { }');
-    $f= $t->getAnnotation('verify');
-    Assert::equals('test', $f('test'));
-  }
-
-  #[Test]
-  public function has_access_to_class() {
-    $t= $this->type('#[Expect(self::SUCCESS)] class <T> { const SUCCESS = true; }');
-    Assert::equals(['expect' => true], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function method() {
-    $t= $this->type('class <T> { #[Test] public function fixture() { } }');
-    Assert::equals(['test' => null], $t->getMethod('fixture')->getAnnotations());
-  }
-
-  #[Test]
-  public function field() {
-    $t= $this->type('class <T> { #[Test] public $fixture; }');
-    Assert::equals(['test' => null], $t->getField('fixture')->getAnnotations());
-  }
-
-  #[Test]
-  public function param() {
-    $t= $this->type('class <T> { public function fixture(#[Test] $param) { } }');
-    Assert::equals(['test' => null], $t->getMethod('fixture')->getParameter(0)->getAnnotations());
-  }
-
-  #[Test]
-  public function params() {
-    $t= $this->type('class <T> { public function fixture(#[Inject(["name" => "a"])] $a, #[Inject] $b) { } }');
-    $m= $t->getMethod('fixture');
-    Assert::equals(
-      [['inject' => ['name' => 'a']], ['inject' => null]],
-      [$m->getParameter(0)->getAnnotations(), $m->getParameter(1)->getAnnotations()]
-    );
-  }
-
-  #[Test]
-  public function multiple_class_annotations() {
-    $t= $this->type('#[Resource("/"), Authenticated] class <T> { }');
-    Assert::equals(['resource' => '/', 'authenticated' => null], $t->getAnnotations());
-  }
-
-  #[Test]
-  public function multiple_member_annotations() {
-    $t= $this->type('class <T> { #[Test, Values([1, 2, 3])] public function fixture() { } }');
-    Assert::equals(['test' => null, 'values' => [1, 2, 3]], $t->getMethod('fixture')->getAnnotations());
-  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AttributesTest.class.php
@@ -1,0 +1,15 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\ast\emit\php\XpMeta;
+
+/**
+ * Annotations via PHP 8 attributes
+ *
+ * @see  https://wiki.php.net/rfc/shorter_attribute_syntax_change
+ */
+class AttributesTest extends AnnotationSupport {
+
+  /** @return string[] */
+  protected function emitters() { return []; }
+
+}

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -2,6 +2,7 @@
 
 use io\streams\{MemoryOutputStream, StringWriter};
 use lang\DynamicClassLoader;
+use lang\ast\emit\XPMeta;
 use lang\ast\{CompilingClassLoader, Emitter, Language, Result, Tokens};
 use unittest\{After, Assert, TestCase};
 use util\cmd\Console;
@@ -20,7 +21,7 @@ abstract class EmittingTest {
     $this->output= $output ? array_flip(explode(',', $output)) : [];
     $this->cl= DynamicClassLoader::instanceFor(self::class);
     $this->language= Language::named('PHP');
-    $this->emitter= Emitter::forRuntime($this->runtime())->newInstance();
+    $this->emitter= Emitter::forRuntime($this->runtime(), [XPMeta::class])->newInstance();
     foreach ($this->language->extensions() as $extension) {
       $extension->setup($this->language, $this->emitter);
     }

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\{MemoryOutputStream, StringWriter};
 use lang\DynamicClassLoader;
-use lang\ast\emit\XPMeta;
+use lang\ast\emit\php\XpMeta;
 use lang\ast\{CompilingClassLoader, Emitter, Language, Result, Tokens};
 use unittest\{After, Assert, TestCase};
 use util\cmd\Console;
@@ -21,7 +21,7 @@ abstract class EmittingTest {
     $this->output= $output ? array_flip(explode(',', $output)) : [];
     $this->cl= DynamicClassLoader::instanceFor(self::class);
     $this->language= Language::named('PHP');
-    $this->emitter= Emitter::forRuntime($this->runtime(), [XPMeta::class])->newInstance();
+    $this->emitter= Emitter::forRuntime($this->runtime(), [XpMeta::class])->newInstance();
     foreach ($this->language->extensions() as $extension) {
       $extension->setup($this->language, $this->emitter);
     }

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -21,11 +21,18 @@ abstract class EmittingTest {
     $this->output= $output ? array_flip(explode(',', $output)) : [];
     $this->cl= DynamicClassLoader::instanceFor(self::class);
     $this->language= Language::named('PHP');
-    $this->emitter= Emitter::forRuntime($this->runtime(), [XpMeta::class])->newInstance();
+    $this->emitter= Emitter::forRuntime($this->runtime(), $this->emitters())->newInstance();
     foreach ($this->language->extensions() as $extension) {
       $extension->setup($this->language, $this->emitter);
     }
   }
+
+  /**
+   * Returns emitters to use. Defaults to XpMeta
+   *
+   * @return string[]
+   */
+  protected function emitters() { return [XpMeta::class]; }
 
   /**
    * Returns runtime to use. Uses `PHP_VERSION` constant.

--- a/src/test/php/lang/ast/unittest/emit/EscapingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EscapingTest.class.php
@@ -1,0 +1,54 @@
+<?php namespace lang\ast\unittest\emit;
+
+use io\streams\MemoryOutputStream;
+use lang\ast\emit\Escaping;
+use unittest\{Assert, Test};
+
+class EscapingTest {
+
+  #[Test]
+  public function can_create() {
+    new Escaping(new MemoryOutputStream(), []);
+  }
+
+  #[Test]
+  public function escape_single_quote() {
+    $out= new MemoryOutputStream();
+    $fixture= new Escaping($out, ["'" => "\\'"]);
+    $fixture->write("'Hello', he said");
+
+    Assert::equals("\\'Hello\\', he said", $out->bytes());
+  }
+
+  #[Test]
+  public function calls_underlying_flush() {
+    $out= new class() extends MemoryOutputStream {
+      public $flushed= false;
+
+      public function flush() {
+        $this->flushed= true;
+        parent::flush();
+      }
+    };
+    $fixture= new Escaping($out, []);
+    $fixture->flush();
+
+    Assert::true($out->flushed);
+  }
+
+  #[Test]
+  public function calls_underlying_close() {
+    $out= new class() extends MemoryOutputStream {
+      public $closed= false;
+
+      public function close() {
+        $this->closed= true;
+        parent::close();
+      }
+    };
+    $fixture= new Escaping($out, []);
+    $fixture->close();
+
+    Assert::true($out->closed);
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/RewriteClassOnObjectsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/RewriteClassOnObjectsTest.class.php
@@ -24,7 +24,7 @@ class RewriteClassOnObjectsTest extends EmitterTraitTest {
   public function does_not_rewrite_type_literal() {
     Assert::equals('self::class', $this->emit(
       new ScopeExpression('self', new Literal('class')),
-      [new ClassDeclaration([], '\\T', null, [], [], [], null, 1)]
+      [new ClassDeclaration([], '\\T', null, [], [], null, null, 1)]
     ));
   }
 }

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -54,12 +54,12 @@ class CompilingClassLoaderTest {
 
   #[Test]
   public function string_representation() {
-    Assert::equals('CompilingCL<lang.ast.emit.PHP70⋈XPMeta>', CompilingClassLoader::instanceFor('php:7.0.0')->toString());
+    Assert::equals('CompilingCL<lang.ast.emit.PHP70⋈XpMeta>', CompilingClassLoader::instanceFor('php:7.0.0')->toString());
   }
 
   #[Test]
   public function hashcode() {
-    Assert::equals('CPHP70+XPMeta', CompilingClassLoader::instanceFor('php:7.0.0')->hashCode());
+    Assert::equals('CPHP70+XpMeta', CompilingClassLoader::instanceFor('php:7.0.0')->hashCode());
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -54,12 +54,12 @@ class CompilingClassLoaderTest {
 
   #[Test]
   public function string_representation() {
-    Assert::equals('CompilingCL<PHP70>', CompilingClassLoader::instanceFor('php:7.0.0')->toString());
+    Assert::equals('CompilingCL<lang.ast.emit.PHP70⋈XPMeta>', CompilingClassLoader::instanceFor('php:7.0.0')->toString());
   }
 
   #[Test]
   public function hashcode() {
-    Assert::equals('CPHP70', CompilingClassLoader::instanceFor('php:7.0.0')->hashCode());
+    Assert::equals('CPHP70+XPMeta', CompilingClassLoader::instanceFor('php:7.0.0')->hashCode());
   }
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -54,7 +54,7 @@ class CompilingClassLoaderTest {
 
   #[Test]
   public function string_representation() {
-    Assert::equals('CompilingCL<lang.ast.emit.PHP70⋈XpMeta>', CompilingClassLoader::instanceFor('php:7.0.0')->toString());
+    Assert::equals('CompilingCL<PHP70+XpMeta>', CompilingClassLoader::instanceFor('php:7.0.0')->toString());
   }
 
   #[Test]


### PR DESCRIPTION
This pull request implements #116 and changes the compiler no longer to emit XP meta information by default, and instead include api doc comments and attributes in the generated code. This is the first step towards generating code that runs without a dependency on XP core.

## Before

![image](https://user-images.githubusercontent.com/696742/147588430-24214b10-b9b3-4762-9bab-0c65d74eded3.png)

## After

![image](https://user-images.githubusercontent.com/696742/147588394-0a85478c-8bdd-404c-8775-b882f2f58ebb.png)

* * * 

*The old behavior can still be achieved by adding `-e php:xp-meta` to the command line*