### PR TITLE
Add emitter to create property type checks for PHP < 7.4

### DIFF
--- a/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
@@ -1,0 +1,76 @@
+<?php namespace lang\ast\emit\php;
+
+use lang\ast\Code;
+
+/**
+ * Creates __get() and __set() overloads which will create type-checked
+ * instance properties for PHP < 7.4
+ *
+ * @see  https://wiki.php.net/rfc/typed_properties_v2
+ */
+trait VirtualPropertyTypes {
+
+  protected function emitProperty($result, $property) {
+    static $lookup= [
+      'public'    => MODIFIER_PUBLIC,
+      'protected' => MODIFIER_PROTECTED,
+      'private'   => MODIFIER_PRIVATE,
+      'static'    => MODIFIER_STATIC,
+      'final'     => MODIFIER_FINAL,
+      'abstract'  => MODIFIER_ABSTRACT,
+      'readonly'  => 0x0080, // XP 10.13: MODIFIER_READONLY
+    ];
+
+    // Because PHP doesn't have __getStatic() and __setStatic(), we cannot simulate
+    // property type checks for static members.
+    if (null === $property->type || in_array('static', $property->modifiers)) {
+      return parent::emitProperty($result, $property);
+    }
+
+    // Create virtual instance property implementing type coercion and checks
+    switch ($property->type->name()) {
+      case 'string':
+        $assign= 'if (is_scalar($value)) $this->__virtual["%1$s"]= (string)$value;';
+        break;
+      case 'bool':
+        $assign= 'if (is_scalar($value)) $this->__virtual["%1$s"]= (bool)$value;';
+        break;
+      case 'int':
+        $assign= 'if (is_numeric($value) || is_bool($value)) $this->__virtual["%1$s"]= (int)$value;';
+        break;
+      case 'float':
+        $assign= 'if (is_numeric($value) || is_bool($value)) $this->__virtual["%1$s"]= (float)$value;';
+        break;
+      default:
+        $assign= 'if (is("%2$s", $value)) $this->__virtual["%1$s"]= $value;';
+        break;
+    }
+
+    $result->locals[2][$property->name]= [
+      new Code('return $this->__virtual["'.$property->name.'"];'),
+      new Code(sprintf(
+        $assign.'else throw new \\TypeError("Cannot assign ".typeof($value)." to property ".self::class."::\\$%1$s of type %2$s");',
+        $property->name,
+        $property->type->name()
+      ))
+    ];
+
+    // Initialize via constructor
+    if (isset($property->expression)) {
+      $result->locals[1]['$this->'.$property->name]= $property->expression;
+    }
+
+    // Emit XP meta information for the reflection API
+    $modifiers= 0;
+    foreach ($property->modifiers as $name) {
+      $modifiers|= $lookup[$name];
+    }
+    $result->meta[0][self::PROPERTY][$property->name]= [
+      DETAIL_RETURNS     => $property->type ? $property->type->name() : 'var',
+      DETAIL_ANNOTATIONS => $property->annotations,
+      DETAIL_COMMENT     => $property->comment,
+      DETAIL_TARGET_ANNO => [],
+      DETAIL_ARGUMENTS   => [$modifiers]
+    ];
+  }
+}

--- a/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
@@ -25,8 +25,8 @@ trait VirtualPropertyTypes {
       'readonly'  => 0x0080, // XP 10.13: MODIFIER_READONLY
     ];
 
-    // Exclude properties w/o type and static properties
-    if (null === $property->type || in_array('static', $property->modifiers)) {
+    // Exclude properties w/o type, static and readonly properties
+    if (null === $property->type || in_array('static', $property->modifiers) || in_array('readonly', $property->modifiers)) {
       return parent::emitProperty($result, $property);
     }
 

--- a/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
@@ -1,0 +1,120 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\ast\emit\php\{XpMeta, VirtualPropertyTypes};
+use lang\{Error, Primitive};
+use unittest\{Assert, Expect, Test, Values};
+
+class VirtualPropertyTypesTest extends EmittingTest {
+
+  /** @return string[] */
+  protected function emitters() { return [XpMeta::class, VirtualPropertyTypes::class]; }
+
+  #[Test]
+  public function type_available_via_reflection() {
+    $t= $this->type('class <T> {
+      private int $value;
+    }');
+
+    Assert::equals(Primitive::$INT, $t->getField('value')->getType());
+  }
+
+  #[Test]
+  public function modifiers_available_via_reflection() {
+    $t= $this->type('class <T> {
+      private int $value;
+    }');
+
+    Assert::equals(MODIFIER_PRIVATE, $t->getField('value')->getModifiers());
+  }
+
+  #[Test]
+  public function initial_value_available_via_reflection() {
+    $t= $this->type('class <T> {
+      private int $value = 6100;
+    }');
+
+    Assert::equals(6100, $t->getField('value')->setAccessible(true)->get($t->newInstance()));
+  }
+
+  #[Test, Values([[null], ['Test'], [[]]]), Expect(class: Error::class, withMessage: '/property .+::\$value of type int/')]
+  public function type_checked_at_runtime($in) {
+    $this->run('class <T> {
+      private int $value;
+
+      public function run($arg) {
+        $this->value= $arg;
+      }
+    }', $in);
+  }
+
+  #[Test]
+  public function value_type_test() {
+    $handle= new Handle(0);
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      private Handle $value;
+
+      public function run($arg) {
+        $this->value= $arg;
+        return $this->value;
+      }
+    }', $handle);
+
+    Assert::equals($handle, $r);
+  }
+
+  #[Test, Values(['', 'Test', 1, 1.5, true, false])]
+  public function string_type_coercion($in) {
+    $r= $this->run('class <T> {
+      private string $value;
+
+      public function run($arg) {
+        $this->value= $arg;
+        return $this->value;
+      }
+    }', $in);
+
+    Assert::equals((string)$in, $r);
+  }
+
+  #[Test, Values(['', 'Test', 1, 1.5, true, false])]
+  public function bool_type_coercion($in) {
+    $r= $this->run('class <T> {
+      private bool $value;
+
+      public function run($arg) {
+        $this->value= $arg;
+        return $this->value;
+      }
+    }', $in);
+
+    Assert::equals((bool)$in, $r);
+  }
+
+  #[Test, Values(['1', '1.5', 1, 1.5, true, false])]
+  public function int_type_coercion($in) {
+    $r= $this->run('class <T> {
+      private int $value;
+
+      public function run($arg) {
+        $this->value= $arg;
+        return $this->value;
+      }
+    }', $in);
+
+    Assert::equals((int)$in, $r);
+  }
+
+  #[Test, Values(['1', '1.5', 1, 1.5, true, false])]
+  public function float_type_coercion($in) {
+    $r= $this->run('class <T> {
+      private float $value;
+
+      public function run($arg) {
+        $this->value= $arg;
+        return $this->value;
+      }
+    }', $in);
+
+    Assert::equals((float)$in, $r);
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
@@ -27,6 +27,57 @@ class VirtualPropertyTypesTest extends EmittingTest {
     Assert::equals(MODIFIER_PRIVATE, $t->getField('value')->getModifiers());
   }
 
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot access private property .+::\\$value/')]
+  public function cannot_read_private_field() {
+    $t= $this->type('class <T> {
+      private int $value;
+    }');
+
+    $t->newInstance()->value;
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot access private property .+::\\$value/')]
+  public function cannot_write_private_field() {
+    $t= $this->type('class <T> {
+      private int $value;
+    }');
+
+    $t->newInstance()->value= 6100;
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot access protected property .+::\\$value/')]
+  public function cannot_read_protected_field() {
+    $t= $this->type('class <T> {
+      protected int $value;
+    }');
+
+    $t->newInstance()->value;
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot access protected property .+::\\$value/')]
+  public function cannot_write_protected_field() {
+    $t= $this->type('class <T> {
+      protected int $value;
+    }');
+
+    $t->newInstance()->value= 6100;
+  }
+
+  #[Test]
+  public function can_access_protected_field_from_subclass() {
+    $t= $this->type('class <T> {
+      protected int $value;
+    }');
+    $i= newinstance($t->getName(), [], [
+      'run' => function() {
+        $this->value= 6100;
+        return $this->value;
+      }
+    ]);
+
+    Assert::equals(6100, $i->run());
+  }
+
   #[Test]
   public function initial_value_available_via_reflection() {
     $t= $this->type('class <T> {


### PR DESCRIPTION
This pull request makes it possible to emit code for PHP versions < 7.4 which will simulate typed properties as described in https://wiki.php.net/rfc/typed_properties_v2. 

## Usage

By means of the *-e* switch on the command line:

```sh
$ xp compile -t php:7.0 -e php:virtual-property-types <in> <out>
#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Important

The emitter is not enabled by default as a) it does not work with static properties due to a limitation in PHP and b) the generated code is *much* slower than its native implementation. So instead of a "prune" option (as asked for by @Danon in #119), users will have to explicitely add this command line switch to generate code which behaves the same in all PHP versions.