### PR TITLE
Inline nullable checks when casting

### DIFF
--- a/src/test/php/lang/ast/unittest/emit/CastingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CastingTest.class.php
@@ -89,6 +89,19 @@ class CastingTest extends EmittingTest {
     ));
   }
 
+  #[Test, Values([null, 'test'])]
+  public function nullable_string_cast_of_expression_returning($value) {
+    Assert::equals($value, $this->run(
+      'class <T> {
+        public function run($value) {
+          $values= [$value];
+          return (?string)array_pop($values);
+        }
+      }',
+      $value
+    ));
+  }
+
   #[Test]
   public function cast_braced() {
     Assert::equals(['test'], $this->run(


### PR DESCRIPTION
This pull request generates more efficient code when performing casting to nullable types:

```php
// Input
$value= (?string)$request->param('input');

// Generated code, before
$value= cast($request->param('input'), 'string', false);

// Generated code, now
$value= null === ($t0= $request->param('input')) ? null : (string)$t0;
```

In these cases, we can also do without the `cast()` function from XP Core.