### PR TITLE
Support `::namespace` to resolve namespace names

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -959,6 +959,7 @@ abstract class PHP extends Emitter {
       $this->emitOne($result, $scope->type);
       $result->out->write('::');
       $this->emitOne($result, $scope->member);
+      return;
     } else if ($scope->type instanceof Node) {
       $t= $result->temp();
       $result->out->write('('.$t.'=');
@@ -966,12 +967,19 @@ abstract class PHP extends Emitter {
       $result->out->write(')?'.$t.'::');
       $this->emitOne($result, $scope->member);
       $result->out->write(':null');
-    } else if ($scope->member instanceof Literal && $result->lookup($scope->type)->rewriteEnumCase($scope->member->expression)) {
-      $result->out->write($scope->type.'::$'.$scope->member->expression);
-    } else {
-      $result->out->write($scope->type.'::');
-      $this->emitOne($result, $scope->member);
+      return;
+    } else if ($scope->member instanceof Literal) {
+      if ('namespace' === $scope->member->expression) {
+        $result->out->write("'".ltrim($scope->type, '\\')."'");
+        return;
+      } else if ($result->lookup($scope->type)->rewriteEnumCase($scope->member->expression)) {
+        $result->out->write($scope->type.'::$'.$scope->member->expression);
+        return;
+      }
     }
+
+    $result->out->write($scope->type.'::');
+    $this->emitOne($result, $scope->member);
   }
 
   protected function emitInstance($result, $instance) {

--- a/src/test/php/lang/ast/unittest/emit/NamespacesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NamespacesTest.class.php
@@ -84,4 +84,34 @@ class NamespacesTest extends EmittingTest {
     }');
     Assert::equals(new Date('1977-12-14'), $r);
   }
+
+  #[Test]
+  public function unqualified_namespace_constant() {
+    $r= $this->run('namespace test\api; class <T> {
+      public function run() {
+        return v1::namespace;
+      }
+    }');
+    Assert::equals('test\\api\\v1', $r);
+  }
+
+  #[Test]
+  public function relative_namespace_constant() {
+    $r= $this->run('namespace test; class <T> {
+      public function run() {
+        return api\v1::namespace;
+      }
+    }');
+    Assert::equals('test\\api\\v1', $r);
+  }
+
+  #[Test]
+  public function absolute_namespace_constant() {
+    $r= $this->run('class <T> {
+      public function run() {
+        return \test\api\v1::namespace;
+      }
+    }');
+    Assert::equals('test\\api\\v1', $r);
+  }
 }


### PR DESCRIPTION
Before:
```php
namespace de\thekid\shorturl;

new RestApi(new ResourcesIn('de.thekid.shorturl.api'));

// or (with a somewhat ugly string concatenation):
new RestApi(new ResourcesIn(__NAMESPACE__.'\\api'));

// or (with the overhead of XP reflection):
new RestApi(new ResourcesIn(typeof($this)->getPackage()->getPackage('api'));

// Alternatively, the `::class` construct will work here, too. However, the 
// code does not convey the meaning very well!
// new RestApi(new ResourcesIn(api::class));
```

After:
```php
namespace de\thekid\shorturl;

new RestApi(new ResourcesIn(api::namespace));
```