### PR TITLE
Implement readonly modifier for classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "^8.0",
+    "xp-framework/ast": "dev-feature/readonly_classes as 8.1.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "dev-feature/readonly_classes as 8.1.0",
+    "xp-framework/ast": "^8.1",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -19,6 +19,7 @@ class PHP70 extends PHP {
     OmitArgumentNames,
     OmitConstModifiers,
     OmitPropertyTypes,
+    ReadonlyClasses,
     ReadonlyProperties,
     RewriteClassOnObjects,
     RewriteEnums,

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -19,6 +19,7 @@ class PHP71 extends PHP {
     OmitArgumentNames,
     OmitPropertyTypes,
     ReadonlyProperties,
+    ReadonlyClasses,
     RewriteClassOnObjects,
     RewriteEnums,
     RewriteExplicitOctals,

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -19,6 +19,7 @@ class PHP72 extends PHP {
     OmitArgumentNames,
     OmitPropertyTypes,
     ReadonlyProperties,
+    ReadonlyClasses,
     RewriteClassOnObjects,
     RewriteEnums,
     RewriteExplicitOctals,

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -17,6 +17,7 @@ class PHP74 extends PHP {
     NonCapturingCatchVariables,
     NullsafeAsTernaries,
     OmitArgumentNames,
+    ReadonlyClasses,
     ReadonlyProperties,
     RewriteBlockLambdaExpressions,
     RewriteClassOnObjects,

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -9,7 +9,8 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, RewriteEnums, ReadonlyProperties, CallablesAsClosures, ArrayUnpackUsingMerge;
+  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, RewriteEnums;
+  use ReadonlyClasses, ReadonlyProperties, CallablesAsClosures, ArrayUnpackUsingMerge;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_81
  */
 class PHP81 extends PHP {
-  use RewriteBlockLambdaExpressions;
+  use RewriteBlockLambdaExpressions, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_82
  */
 class PHP82 extends PHP {
-  use RewriteBlockLambdaExpressions;
+  use RewriteBlockLambdaExpressions, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\Code;
+
 /**
  * Implements readonly properties by removing the `readonly` modifier from
  * the class and inheriting it to all properties (and promoted constructor
@@ -12,6 +14,8 @@ trait ReadonlyClasses {
   protected function emitClass($result, $class) {
     if (false !== ($p= array_search('readonly', $class->modifiers))) {
       unset($class->modifiers[$p]);
+
+      // Inherit
       foreach ($class->body as $member) {
         if ($member->is('property')) {
           $member->modifiers[]= 'readonly';
@@ -21,6 +25,10 @@ trait ReadonlyClasses {
           }
         }
       }
+
+      // Prevent dynamic members
+      $throw= new Code('throw new \\Error("Cannot create dynamic property ".__CLASS__."::".$name);');
+      $result->locals= [[], [], [null => [$throw, $throw]]];
     }
 
     return parent::emitClass($result, $class);

--- a/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
@@ -1,0 +1,21 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Implements readonly properties by removing the `readonly` modifier from
+ * the class and inheriting it to all properties.
+ *
+ * @see  https://wiki.php.net/rfc/readonly_classes
+ */
+trait ReadonlyClasses {
+
+  protected function emitClass($result, $class) {
+    if (false !== ($p= array_search('readonly', $class->modifiers))) {
+      unset($class->modifiers[$p]);
+      foreach ($class->body as $member) {
+        if ($member->is('property')) $member->modifiers[]= 'readonly';
+      }
+    }
+
+    return parent::emitClass($result, $class);
+  }
+}

--- a/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
@@ -2,7 +2,8 @@
 
 /**
  * Implements readonly properties by removing the `readonly` modifier from
- * the class and inheriting it to all properties.
+ * the class and inheriting it to all properties (and promoted constructor
+ * arguments).
  *
  * @see  https://wiki.php.net/rfc/readonly_classes
  */
@@ -12,7 +13,13 @@ trait ReadonlyClasses {
     if (false !== ($p= array_search('readonly', $class->modifiers))) {
       unset($class->modifiers[$p]);
       foreach ($class->body as $member) {
-        if ($member->is('property')) $member->modifiers[]= 'readonly';
+        if ($member->is('property')) {
+          $member->modifiers[]= 'readonly';
+        } else if ($member->is('method')) {
+          foreach ($member->signature->parameters as $param) {
+            $param->promote && $param->promote.= ' readonly';
+          }
+        }
       }
     }
 

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -45,11 +45,28 @@ class ReadonlyTest extends EmittingTest {
   }
 
   #[Test]
-  public function with_constructor_argument_promotion() {
+  public function class_with_constructor_argument_promotion() {
+    $t= $this->type('readonly class <T> {
+      public function __construct(public string $fixture) { }
+    }');
+
+    Assert::equals(
+      sprintf('public readonly string %s::$fixture', $t->getName()),
+      $t->getField('fixture')->toString()
+    );
+    Assert::equals('Test', $t->newInstance('Test')->fixture);
+  }
+
+  #[Test]
+  public function property_defined_with_constructor_argument_promotion() {
     $t= $this->type('class <T> {
       public function __construct(public readonly string $fixture) { }
     }');
 
+    Assert::equals(
+      sprintf('public readonly string %s::$fixture', $t->getName()),
+      $t->getField('fixture')->toString()
+    );
     Assert::equals('Test', $t->newInstance('Test')->fixture);
   }
 

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -173,4 +173,16 @@ class ReadonlyTest extends EmittingTest {
       public readonly string $fixture= "Test";
     }');
   }
+
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot create dynamic property .+fixture/')]
+  public function cannot_read_dynamic_members_from_readonly_classes() {
+    $t= $this->type('readonly class <T> { }');
+    $t->newInstance()->fixture;
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/Cannot create dynamic property .+fixture/')]
+  public function cannot_write_dynamic_members_from_readonly_classes() {
+    $t= $this->type('readonly class <T> { }');
+    $t->newInstance()->fixture= true;
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -4,11 +4,12 @@ use lang\Error;
 use unittest\{Assert, Expect, Test};
 
 /**
- * Readonly properties
+ * Readonly classes and properties
  *
  * @see  https://wiki.php.net/rfc/readonly_properties_v2
+ * @see  https://wiki.php.net/rfc/readonly_classes
  */
-class ReadonlyPropertiesTest extends EmittingTest {
+class ReadonlyTest extends EmittingTest {
 
   /** @return iterable */
   private function modifiers() {
@@ -20,7 +21,19 @@ class ReadonlyPropertiesTest extends EmittingTest {
   }
 
   #[Test]
-  public function declaration() {
+  public function class_declaration() {
+    $t= $this->type('readonly class <T> {
+      public int $fixture;
+    }');
+
+    Assert::equals(
+      sprintf('public readonly int %s::$fixture', $t->getName()),
+      $t->getField('fixture')->toString()
+    );
+  }
+
+  #[Test]
+  public function property_declaration() {
     $t= $this->type('class <T> {
       public readonly int $fixture;
     }');

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -185,4 +185,11 @@ class ReadonlyTest extends EmittingTest {
     $t= $this->type('readonly class <T> { }');
     $t->newInstance()->fixture= true;
   }
+
+  #[Test, Ignore('Until proper error handling facilities exist')]
+  public function readonly_classes_cannot_have_static_members() {
+    $this->type('readonly class <T> {
+      public static $test;
+    }');
+  }
 }


### PR DESCRIPTION
See https://wiki.php.net/rfc/readonly_classes and xp-framework/ast#37. The following comes quite close to [records](https://github.com/xp-lang/xp-records), although it doesn't declare getters but uses public readonly fields:

```php
readonly class Point {
  public function __construct(
    public int $x,
    public int $y,
  ) { }
}

$point= new Point(8, 42);
echo "Hello {$point->x}x{$point->y}!\n";

// Will not modify the member, raising an exception instead:
// $point->x= 9;
```

* [x] Inherit `readonly` modifiers on classes to all members and promoted constructor parameters
* [x] Prevent dynamic members
* [ ] Do not allow `readonly` on traits, interfaces and enums
* [ ] Prevent inheritance where `readonly` modifiers do not match
* [ ] Prevent static members in readonly classes
* [ ] Disallow `#[AllowDynamicProperties]` on readonly classes
* [ ] Remove emulation for PHP 8.2 once php/php-src#7305 is merged