### PR TITLE
Add support for null, true and false types

### DIFF
--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -41,10 +41,19 @@ class PHP70 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
-        static $omit= ['object' => 1, 'void' => 1, 'iterable' => 1, 'mixed' => 1, 'never' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+        static $rewrite= [
+          'object'   => 1,
+          'void'     => 1,
+          'iterable' => 1,
+          'mixed'    => 1,
+          'null'     => 1,
+          'never'    => 1,
+          'true'     => 'bool',
+          'false'    => 'bool',
+        ];
 
         $l= $t->literal();
-        return isset($omit[$l]) ? null : $l;
+        return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -41,8 +41,10 @@ class PHP70 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
+        static $omit= ['object' => 1, 'void' => 1, 'iterable' => 1, 'mixed' => 1, 'never' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+
         $l= $t->literal();
-        return ('object' === $l || 'void' === $l || 'iterable' === $l || 'mixed' === $l || 'never' === $l) ? null : $l;
+        return isset($omit[$l]) ? null : $l;
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -39,8 +39,10 @@ class PHP71 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
+        static $omit= ['object' => 1, 'mixed' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+
         $l= $t->literal();
-        return ('object' === $l || 'mixed' === $l) ? null : ('never' === $l ? 'void' : $l);
+        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -39,10 +39,17 @@ class PHP71 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
-        static $omit= ['object' => 1, 'mixed' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+        static $rewrite= [
+          'object'   => 1,
+          'mixed'    => 1,
+          'null'     => 1,
+          'never'    => 'void',
+          'true'     => 'bool',
+          'false'    => 'bool',
+        ];
 
         $l= $t->literal();
-        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
+        return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -39,8 +39,10 @@ class PHP72 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
+        static $omit= ['mixed' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+
         $l= $t->literal();
-        return 'mixed' === $l ? null : ('never' === $l ? 'void' : $l);
+        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -39,10 +39,16 @@ class PHP72 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
-        static $omit= ['mixed' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+        static $rewrite= [
+          'mixed'    => 1,
+          'null'     => 1,
+          'never'    => 'void',
+          'true'     => 'bool',
+          'false'    => 'bool',
+        ];
 
         $l= $t->literal();
-        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
+        return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -37,10 +37,16 @@ class PHP74 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
-        static $omit= ['mixed' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+        static $rewrite= [
+          'mixed'    => 1,
+          'null'     => 1,
+          'never'    => 'void',
+          'true'     => 'bool',
+          'false'    => 'bool',
+        ];
 
         $l= $t->literal();
-        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
+        return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -37,8 +37,10 @@ class PHP74 extends PHP {
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {
+        static $omit= ['mixed' => 1, 'true' => 1, 'false' => 1, 'null' => 1];
+
         $l= $t->literal();
-        return 'mixed' === $l ? null : ('never' === $l ? 'void' : $l);
+        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
       },
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -30,10 +30,15 @@ class PHP80 extends PHP {
         return substr($u, 1);
       },
       IsLiteral::class      => function($t) {
-        static $omit= ['true' => 1, 'false' => 1, 'null' => 1];
+        static $rewrite= [
+          'null'     => 1,
+          'never'    => 'void',
+          'true'     => 'bool',
+          'false'    => 'bool',
+        ];
 
         $l= $t->literal();
-        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
+        return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       }
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -30,8 +30,10 @@ class PHP80 extends PHP {
         return substr($u, 1);
       },
       IsLiteral::class      => function($t) {
+        static $omit= ['true' => 1, 'false' => 1, 'null' => 1];
+
         $l= $t->literal();
-        return 'never' === $l ? 'void' : $l;
+        return isset($omit[$l]) ? null : ('never' === $l ? 'void' : $l);
       }
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -37,10 +37,14 @@ class PHP81 extends PHP {
         return substr($u, 1);
       },
       IsLiteral::class      => function($t) {
-        static $omit= ['true' => 1, 'false' => 1, 'null' => 1];
+        static $rewrite= [
+          'null'     => 1,
+          'true'     => 'bool',
+          'false'    => 'bool',
+        ];
 
         $l= $t->literal();
-        return isset($omit[$l]) ? null : $l;
+        return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       }
     ];
   }

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -36,7 +36,12 @@ class PHP81 extends PHP {
         }
         return substr($u, 1);
       },
-      IsLiteral::class      => function($t) { return $t->literal(); }
+      IsLiteral::class      => function($t) {
+        static $omit= ['true' => 1, 'false' => 1, 'null' => 1];
+
+        $l= $t->literal();
+        return isset($omit[$l]) ? null : $l;
+      }
     ];
   }
 }

--- a/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
@@ -28,8 +28,8 @@ class TypeLiteralsTest {
     yield [new IsLiteral('iterable'), null];
     yield [new IsLiteral('mixed'), null];
     yield [new IsLiteral('null'), null];
-    yield [new IsLiteral('false'), null];
-    yield [new IsLiteral('true'), null];
+    yield [new IsLiteral('false'), 'bool'];
+    yield [new IsLiteral('true'), 'bool'];
     yield [new IsNullable(new IsLiteral('string')), null];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), null];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
@@ -49,8 +49,8 @@ class TypeLiteralsTest {
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), null];
     yield [new IsLiteral('null'), null];
-    yield [new IsLiteral('false'), null];
-    yield [new IsLiteral('true'), null];
+    yield [new IsLiteral('false'), 'bool'];
+    yield [new IsLiteral('true'), 'bool'];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), null];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), null];
@@ -71,8 +71,8 @@ class TypeLiteralsTest {
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), null];
     yield [new IsLiteral('null'), null];
-    yield [new IsLiteral('false'), null];
-    yield [new IsLiteral('true'), null];
+    yield [new IsLiteral('false'), 'bool'];
+    yield [new IsLiteral('true'), 'bool'];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), '?object'];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), null];
@@ -102,12 +102,12 @@ class TypeLiteralsTest {
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), 'mixed'];
     yield [new IsLiteral('null'), null];
-    yield [new IsLiteral('false'), null];
-    yield [new IsLiteral('true'), null];
+    yield [new IsLiteral('false'), 'bool'];
+    yield [new IsLiteral('true'), 'bool'];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), '?object'];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), 'string|int'];
-    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), 'string|bool'];
     yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), null];
   }
 
@@ -124,12 +124,12 @@ class TypeLiteralsTest {
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), 'mixed'];
     yield [new IsLiteral('null'), null];
-    yield [new IsLiteral('false'), null];
-    yield [new IsLiteral('true'), null];
+    yield [new IsLiteral('false'), 'bool'];
+    yield [new IsLiteral('true'), 'bool'];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), '?object'];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), 'string|int'];
-    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), 'string|bool'];
     yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), 'Test&Iterator'];
   }
 

--- a/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
@@ -27,8 +27,13 @@ class TypeLiteralsTest {
     yield [new IsLiteral('never'), null];
     yield [new IsLiteral('iterable'), null];
     yield [new IsLiteral('mixed'), null];
+    yield [new IsLiteral('null'), null];
+    yield [new IsLiteral('false'), null];
+    yield [new IsLiteral('true'), null];
     yield [new IsNullable(new IsLiteral('string')), null];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), null];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
+    yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), null];
   }
 
   /**
@@ -43,9 +48,14 @@ class TypeLiteralsTest {
     yield [new IsLiteral('never'), 'void'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), null];
+    yield [new IsLiteral('null'), null];
+    yield [new IsLiteral('false'), null];
+    yield [new IsLiteral('true'), null];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), null];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), null];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
+    yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), null];
   }
 
   /**
@@ -60,9 +70,14 @@ class TypeLiteralsTest {
     yield [new IsLiteral('never'), 'void'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), null];
+    yield [new IsLiteral('null'), null];
+    yield [new IsLiteral('false'), null];
+    yield [new IsLiteral('true'), null];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), '?object'];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), null];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
+    yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), null];
   }
 
   /**
@@ -86,9 +101,14 @@ class TypeLiteralsTest {
     yield [new IsLiteral('never'), 'void'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), 'mixed'];
+    yield [new IsLiteral('null'), null];
+    yield [new IsLiteral('false'), null];
+    yield [new IsLiteral('true'), null];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), '?object'];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), 'string|int'];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
+    yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), null];
   }
 
   /**
@@ -103,19 +123,36 @@ class TypeLiteralsTest {
     yield [new IsLiteral('never'), 'never'];
     yield [new IsLiteral('iterable'), 'iterable'];
     yield [new IsLiteral('mixed'), 'mixed'];
+    yield [new IsLiteral('null'), null];
+    yield [new IsLiteral('false'), null];
+    yield [new IsLiteral('true'), null];
     yield [new IsNullable(new IsLiteral('string')), '?string'];
     yield [new IsNullable(new IsLiteral('object')), '?object'];
     yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), 'string|int'];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), null];
     yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), 'Test&Iterator'];
   }
 
   /**
-   * PHP 8.2 is the same as PHP 8.1
+   * PHP 8.2 added `null`, `false` and `true`
    *
    * @return iterable
    */
   private function php82() {
-    yield from $this->php81();
+    yield from $this->base();
+    yield [new IsLiteral('object'), 'object'];
+    yield [new IsLiteral('void'), 'void'];
+    yield [new IsLiteral('never'), 'never'];
+    yield [new IsLiteral('iterable'), 'iterable'];
+    yield [new IsLiteral('mixed'), 'mixed'];
+    yield [new IsLiteral('null'), 'null'];
+    yield [new IsLiteral('false'), 'false'];
+    yield [new IsLiteral('true'), 'true'];
+    yield [new IsNullable(new IsLiteral('string')), '?string'];
+    yield [new IsNullable(new IsLiteral('object')), '?object'];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('int')]), 'string|int'];
+    yield [new IsUnion([new IsLiteral('string'), new IsLiteral('false')]), 'string|false'];
+    yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), 'Test&Iterator'];
   }
 
   #[Test, Values('php70')]


### PR DESCRIPTION
See https://wiki.php.net/rfc/null-false-standalone-types and https://wiki.php.net/rfc/true-type, all available in PHP 8.2. Will be omitted from the generated code for PHP < 8.2