### PR TITLE
Add support for specifying keys in list()

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -697,6 +697,10 @@ abstract class PHP extends Emitter {
     } else if ('array' === $target->kind) {
       $result->out->write('list(');
       foreach ($target->values as $pair) {
+        if ($pair[0]) {
+          $this->emitOne($result, $pair[0]);
+          $result->out->write('=>');
+        }
         $this->emitAssign($result, $pair[1]);
         $result->out->write(',');
       }

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -63,6 +63,20 @@ class ArraysTest extends EmittingTest {
     Assert::equals([2, 1], $r);
   }
 
+  #[Test]
+  public function destructuring_map_with_expression() {
+    $r= $this->run('class <T> {
+      private $one= "one";
+      public function run() {
+        $two= "two";
+        [$two => $a, $this->one => $b]= ["one" => 1, "two" => 2];
+        return [$a, $b];
+      }
+    }');
+
+    Assert::equals([2, 1], $r);
+  }
+
   #[Test, Values(['$list', '$this->instance', 'self::$static'])]
   public function reference_destructuring($reference) {
     $r= $this->run('class <T> {

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -51,6 +51,18 @@ class ArraysTest extends EmittingTest {
     Assert::equals([1, 2], $r);
   }
 
+  #[Test]
+  public function destructuring_map() {
+    $r= $this->run('class <T> {
+      public function run() {
+        ["two" => $a, "one" => $b]= ["one" => 1, "two" => 2];
+        return [$a, $b];
+      }
+    }');
+
+    Assert::equals([2, 1], $r);
+  }
+
   #[Test, Values(['$list', '$this->instance', 'self::$static'])]
   public function reference_destructuring($reference) {
     $r= $this->run('class <T> {


### PR DESCRIPTION
Example:

```php
['one' => $a, 'two' => $b]= ['two' => 2, 'one' => 1];

echo $a; // 1
echo $b; // 2
```

See https://wiki.php.net/rfc/list_keys, supported since PHP 7.1