### PR TITLE
Add support for omitting expressions in destructuring assignments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "^9.1",
+    "xp-framework/ast": "^9.2",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -45,6 +45,17 @@ abstract class Emitter {
   }
 
   /**
+   * Raises an exception
+   *
+   * @param  string $error
+   * @param  ?Throwable $cause
+   * @return never
+   */
+  public function raise($error, $cause= null) {
+    throw new IllegalStateException($error, $cause);
+  }
+
+  /**
    * Transforms nodes of a certain kind using the given function, which
    * may return either single node, which will be then emitted, or an
    * iterable producing nodes, which will then be emitted as statements.

--- a/src/main/php/lang/ast/emit/ArrayUnpackUsingMerge.class.php
+++ b/src/main/php/lang/ast/emit/ArrayUnpackUsingMerge.class.php
@@ -19,7 +19,8 @@ trait ArrayUnpackUsingMerge {
 
     $unpack= false;
     foreach ($array->values as $pair) {
-      if ('unpack' === $pair[1]->kind) {
+      $element= $pair[1] ?? $this->raise('Cannot use empty array elements in arrays');
+      if ('unpack' === $element->kind) {
         $unpack= true;
         break;
       }
@@ -32,6 +33,7 @@ trait ArrayUnpackUsingMerge {
           $this->emitOne($result, $pair[0]);
           $result->out->write('=>');
         }
+
         if ('unpack' === $pair[1]->kind) {
           if ('array' === $pair[1]->expression->kind) {
             $result->out->write('],');

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -265,7 +265,7 @@ abstract class PHP extends Emitter {
         $this->emitOne($result, $pair[0]);
         $result->out->write('=>');
       }
-      $this->emitOne($result, $pair[1]);
+      $this->emitOne($result, $pair[1] ?? $this->raise('Cannot use empty array elements in arrays'));
       $result->out->write(',');
     }
     $result->out->write(']');
@@ -701,7 +701,9 @@ abstract class PHP extends Emitter {
           $this->emitOne($result, $pair[0]);
           $result->out->write('=>');
         }
-        $this->emitAssign($result, $pair[1]);
+        if ($pair[1]) {
+          $this->emitAssign($result, $pair[1]);
+        }
         $result->out->write(',');
       }
       $result->out->write(')');

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -121,7 +121,7 @@ class PHP70 extends PHP {
       // Rewrite destructuring unless assignment consists only of variables
       $r= false;
       foreach ($assignment->variable->values as $pair) {
-        if (!$pair[0] && $pair[1] instanceof Variable) continue;
+        if (null === $pair[0] && (null === $pair[1] || $pair[1] instanceof Variable)) continue;
         $r= true;
         break;
       }

--- a/src/main/php/lang/ast/emit/RewriteAssignments.class.php
+++ b/src/main/php/lang/ast/emit/RewriteAssignments.class.php
@@ -62,7 +62,7 @@ trait RewriteAssignments {
       // Rewrite destructuring unless assignment consists only of variables
       $r= false;
       foreach ($assignment->variable->values as $pair) {
-        if ($pair[1] instanceof Variable) continue;
+        if (null === $pair[1] || $pair[1] instanceof Variable) continue;
         $r= true;
         break;
       }

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
+use lang\IllegalStateException;
 use unittest\{Assert, Test, Values};
 
 class ArraysTest extends EmittingTest {
@@ -39,6 +40,15 @@ class ArraysTest extends EmittingTest {
     Assert::equals([1, 2, 3], $r);
   }
 
+  #[Test, Values(['[1, , 3]', '[1, , ]', '[, 1]']), Expect(class: IllegalStateException::class, withMessage: 'Cannot use empty array elements in arrays')]
+  public function arrays_cannot_have_empty_elements($input) {
+    $r= $this->run('class <T> {
+      public function run() {
+        return '.$input.';
+      }
+    }');
+  }
+
   #[Test]
   public function destructuring() {
     $r= $this->run('class <T> {
@@ -49,6 +59,30 @@ class ArraysTest extends EmittingTest {
     }');
 
     Assert::equals([1, 2], $r);
+  }
+
+  #[Test]
+  public function destructuring_with_empty_between() {
+    $r= $this->run('class <T> {
+      public function run() {
+        [$a, , $b]= [1, 2, 3];
+        return [$a, $b];
+      }
+    }');
+
+    Assert::equals([1, 3], $r);
+  }
+
+  #[Test]
+  public function destructuring_with_empty_start() {
+    $r= $this->run('class <T> {
+      public function run() {
+        [, $a, $b]= [1, 2, 3];
+        return [$a, $b];
+      }
+    }');
+
+    Assert::equals([2, 3], $r);
   }
 
   #[Test]


### PR DESCRIPTION
E.g. `list($a, , $b)= $expr` or `[, $a]= $expr`, see https://github.com/xp-framework/ast/releases/tag/v9.2.0