### PR TITLE
Implement "Destructuring Coalesce" RFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@ XP Compiler ChangeLog
 
 ## ?.?.? / ????-??-??
 
+* Merged PR #146: Add support for omitting expressions in destructuring
+  assignments, e.g. `list($a, , $b)= $expr` or `[, $a]= $expr`.
+  (@thekid)
 * Merged PR #145: Add support for specifying keys in list(), which has
   been in PHP since 7.1.0, see https://wiki.php.net/rfc/list_keys
   (@thekid)

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal, Variable};
+use lang\ast\nodes\{InstanceExpression, ScopeExpression, UnaryExpression, BinaryExpression, Literal};
 use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
 
 /**
@@ -119,13 +119,13 @@ class PHP70 extends PHP {
     } else if ('array' === $assignment->variable->kind) {
 
       // Rewrite destructuring unless assignment consists only of variables
-      $r= false;
       foreach ($assignment->variable->values as $pair) {
-        if (null === $pair[0] && (null === $pair[1] || $pair[1] instanceof Variable)) continue;
-        $r= true;
-        break;
+        if (
+          $pair[0] ||
+          $pair[1] instanceof UnaryExpression ||
+          $pair[1] instanceof BinaryExpression
+        ) return $this->rewriteDestructuring($result, $assignment);
       }
-      if ($r) return $this->rewriteDestructuring($result, $assignment);
     }
 
     return parent::emitAssignment($result, $assignment);

--- a/src/main/php/lang/ast/emit/PHP73.class.php
+++ b/src/main/php/lang/ast/emit/PHP73.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\nodes\BinaryExpression;
 use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
 
 /**
@@ -22,6 +23,7 @@ class PHP73 extends PHP {
     OmitPropertyTypes,
     ReadonlyProperties,
     ReadonlyClasses,
+    RewriteAssignments,
     RewriteClassOnObjects,
     RewriteEnums,
     RewriteExplicitOctals,
@@ -62,8 +64,13 @@ class PHP73 extends PHP {
       $this->emitOne($result, $assignment->variable);
       $result->out->write('=');
       $this->emitOne($result, $assignment->expression);
-    } else {
-      parent::emitAssignment($result, $assignment);
+      return;
+    } else if ('array' === $assignment->variable->kind) {
+      foreach ($assignment->variable->values as $pair) {
+        if ($pair[1] instanceof BinaryExpression) return $this->rewriteDestructuring($result, $assignment);
+      }
     }
+
+    parent::emitAssignment($result, $assignment);
   }
 }

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -21,6 +21,7 @@ class PHP74 extends PHP {
     ReadonlyProperties,
     RewriteBlockLambdaExpressions,
     RewriteClassOnObjects,
+    RewriteDestructuring,
     RewriteEnums,
     RewriteExplicitOctals,
     RewriteThrowableExpressions

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, RewriteEnums;
+  use RewriteBlockLambdaExpressions, RewriteDestructuring, RewriteExplicitOctals, RewriteEnums;
   use ReadonlyClasses, ReadonlyProperties, CallablesAsClosures, ArrayUnpackUsingMerge;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_81
  */
 class PHP81 extends PHP {
-  use RewriteBlockLambdaExpressions, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDestructuring, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_82
  */
 class PHP82 extends PHP {
-  use RewriteBlockLambdaExpressions, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDestructuring, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/RewriteAssignments.class.php
+++ b/src/main/php/lang/ast/emit/RewriteAssignments.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\nodes\{UnaryExpression, Variable, Literal, InstanceExpression, ScopeExpression};
+use lang\ast\nodes\{UnaryExpression, BinaryExpression, Variable, Literal, InstanceExpression, ScopeExpression};
 
 /**
  * Rewrites list reference assignments and null-coalesce for PHP <= 7.3
@@ -9,57 +9,7 @@ use lang\ast\nodes\{UnaryExpression, Variable, Literal, InstanceExpression, Scop
  * @see  https://wiki.php.net/rfc/list_reference_assignment
  */
 trait RewriteAssignments {
-
-  protected function rewriteDestructuring($result, $assignment) {
-    $t= $result->temp();
-    $result->out->write('is_array('.$t.'=');
-
-    // Create reference to right-hand if possible
-    $r= $assignment->expression;
-    if (
-      ($r instanceof Variable) ||
-      ($r instanceof InstanceExpression && $r->member instanceof Literal) ||
-      ($r instanceof ScopeExpression && $r->member instanceof Variable)
-    ) {
-      $result->out->write('&');
-    }
-
-    $this->emitOne($result, $assignment->expression);
-    $result->out->write(')?[');
-    foreach ($assignment->variable->values as $i => $pair) {
-      if (null === $pair[1]) {
-        $result->out->write('null,');
-        continue;
-      }
-
-      // Assign by reference
-      if ($pair[1] instanceof UnaryExpression) {
-        $this->emitAssign($result, $pair[1]->expression);
-        $result->out->write('='.$pair[1]->operator.$t.'[');
-      } else {
-        $this->emitAssign($result, $pair[1]);
-        $result->out->write('='.$t.'[');
-      }
-
-      if ($pair[0]) {
-        $this->emitOne($result, $pair[0]);
-        $result->out->write('],');
-      } else {
-        $result->out->write($i.'],');
-      }
-    }
-    $result->out->write(']:([');
-    foreach ($assignment->variable->values as $pair) {
-      if ($pair[1] instanceof UnaryExpression) {
-        $this->emitAssign($result, $pair[1]->expression);
-        $result->out->write('=null,');
-      } else if ($pair[1]) {
-        $this->emitAssign($result, $pair[1]);
-        $result->out->write('=null,');
-      }
-    }
-    $result->out->write(']?'.$t.':null)');
-  }
+  use RewriteDestructuring { emitAssignment as private; }
 
   protected function emitAssignment($result, $assignment) {
     if ('??=' === $assignment->operator) {
@@ -72,15 +22,12 @@ trait RewriteAssignments {
       $this->emitOne($result, $assignment->expression);
       return;
     } else if ('array' === $assignment->variable->kind) {
-
-      // Rewrite destructuring unless assignment consists only of variables
-      $r= false;
       foreach ($assignment->variable->values as $pair) {
-        if (null === $pair[1] || $pair[1] instanceof Variable) continue;
-        $r= true;
-        break;
+        if (
+          $pair[1] instanceof UnaryExpression ||
+          $pair[1] instanceof BinaryExpression
+        ) return $this->rewriteDestructuring($result, $assignment);
       }
-      if ($r) return $this->rewriteDestructuring($result, $assignment);
     }
 
     return parent::emitAssignment($result, $assignment);

--- a/src/main/php/lang/ast/emit/RewriteDestructuring.class.php
+++ b/src/main/php/lang/ast/emit/RewriteDestructuring.class.php
@@ -36,19 +36,16 @@ trait RewriteDestructuring {
         continue;
       }
 
-      // Assign by reference
+      // Assign by reference, null-coalesce handling
       $value= new OffsetExpression($temp, $pair[0] ?? new Literal((string)$i));
       if ($pair[1] instanceof UnaryExpression) {
         $this->emitAssignment($result, new Assignment($pair[1]->expression, '=&', $value));
-        $default= null;
       } else if ($pair[1] instanceof BinaryExpression) {
         $target= $pair[1]->left;
         $pair[1]->left= $value;
         $this->emitAssignment($result, new Assignment($target, '=', $pair[1]));
-        $default= $pair[1];
       } else {
         $this->emitAssignment($result, new Assignment($pair[1], '=', $value));
-        $default= null;
       }
       $result->out->write(',');
     }

--- a/src/main/php/lang/ast/emit/RewriteDestructuring.class.php
+++ b/src/main/php/lang/ast/emit/RewriteDestructuring.class.php
@@ -1,0 +1,83 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\nodes\{UnaryExpression, BinaryExpression, Variable, Literal, InstanceExpression, ScopeExpression};
+
+trait RewriteDestructuring {
+
+  protected function rewriteDestructuring($result, $assignment) {
+    $t= $result->temp();
+    $result->out->write('is_array('.$t.'=');
+
+    // Create reference to right-hand if possible
+    $r= $assignment->expression;
+    if (
+      ($r instanceof Variable) ||
+      ($r instanceof InstanceExpression && $r->member instanceof Literal) ||
+      ($r instanceof ScopeExpression && $r->member instanceof Variable)
+    ) {
+      $result->out->write('&');
+    }
+
+    $this->emitOne($result, $assignment->expression);
+    $result->out->write(')?[');
+    foreach ($assignment->variable->values as $i => $pair) {
+      if (null === $pair[1]) {
+        $result->out->write('null,');
+        continue;
+      }
+
+      // Assign by reference
+      if ($pair[1] instanceof UnaryExpression) {
+        $this->emitAssign($result, $pair[1]->expression);
+        $result->out->write('='.$pair[1]->operator.$t.'[');
+        $default= null;
+      } else if ($pair[1] instanceof BinaryExpression) {
+        $this->emitAssign($result, $pair[1]->left);
+        $result->out->write('='.$t.'[');
+        $default= $pair[1];
+      } else {
+        $this->emitAssign($result, $pair[1]);
+        $result->out->write('='.$t.'[');
+        $default= null;
+      }
+
+      if ($pair[0]) {
+        $this->emitOne($result, $pair[0]);
+        $result->out->write(']');
+      } else {
+        $result->out->write($i.']');
+      }
+
+      // Null-coalesce
+      if ($default) {
+        $result->out->write($default->operator);
+        $this->emitOne($result, $default->right);
+      }
+      $result->out->write(',');
+    }
+    $result->out->write(']:([');
+    foreach ($assignment->variable->values as $pair) {
+      if (null === $pair[1]) {
+        continue;
+      } else if ($pair[1] instanceof UnaryExpression) {
+        $this->emitAssign($result, $pair[1]->expression);
+      } else if ($pair[1] instanceof BinaryExpression) {
+        $this->emitAssign($result, $pair[1]->left);
+      } else if ($pair[1]) {
+        $this->emitAssign($result, $pair[1]);
+      }
+      $result->out->write('=null,');
+    }
+    $result->out->write(']?'.$t.':null)');
+  }
+
+  protected function emitAssignment($result, $assignment) {
+    if ('array' === $assignment->variable->kind) {
+      foreach ($assignment->variable->values as $pair) {
+        if ($pair[1] instanceof BinaryExpression) return $this->rewriteDestructuring($result, $assignment);
+      }
+    }
+
+    parent::emitAssignment($result, $assignment);
+  }
+}

--- a/src/main/php/lang/ast/emit/RewriteDestructuring.class.php
+++ b/src/main/php/lang/ast/emit/RewriteDestructuring.class.php
@@ -42,17 +42,13 @@ trait RewriteDestructuring {
         $this->emitAssignment($result, new Assignment($pair[1]->expression, '=&', $value));
         $default= null;
       } else if ($pair[1] instanceof BinaryExpression) {
-        $this->emitAssignment($result, new Assignment($pair[1]->left, '=&', $value));
+        $target= $pair[1]->left;
+        $pair[1]->left= $value;
+        $this->emitAssignment($result, new Assignment($target, '=', $pair[1]));
         $default= $pair[1];
       } else {
         $this->emitAssignment($result, new Assignment($pair[1], '=', $value));
         $default= null;
-      }
-
-      // Null-coalesce
-      if ($default) {
-        $result->out->write($default->operator);
-        $this->emitOne($result, $default->right);
       }
       $result->out->write(',');
     }

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -178,6 +178,18 @@ class ArraysTest extends EmittingTest {
     Assert::equals([null, null, $value], $r);
   }
 
+  #[Test, Values([['key=value', ['key', 'value']], ['key', ['key', null]]])]
+  public function destructuring_coalesce($input, $expected) {
+    $r= $this->run('class <T> {
+      public function run($input) {
+        [$a, $b ?? null]= explode("=", $input, 2);
+        return [$a, $b];
+      }
+    }', $input);
+
+    Assert::equals($expected, $r);
+  }
+
   #[Test]
   public function init_with_variable() {
     $r= $this->run('class <T> {

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -190,6 +190,18 @@ class ArraysTest extends EmittingTest {
     Assert::equals($expected, $r);
   }
 
+  #[Test, Values([[['a' => 1, 'b' => 2], [1, 2]], [['a' => 1], [1, null]]])]
+  public function destructuring_coalesce_with_keys($input, $expected) {
+    $r= $this->run('class <T> {
+      public function run($input) {
+        ["a" => $a, "b" => $b ?? null]= $input;
+        return [$a, $b];
+      }
+    }', $input);
+
+    Assert::equals($expected, $r);
+  }
+
   #[Test]
   public function init_with_variable() {
     $r= $this->run('class <T> {


### PR DESCRIPTION
Adds support for destructuring coalesce to all PHP versions supported by XP Compiler (7.0 - 8.2). Quoting the RFC:

> Allowing for [$a ?? $b] = $array;, where $a is assigned $b if the key in the array is null or missing.

## Example
Taken from the RFC:

```php
[$key, $value ?? null]= explode('=', 'key=value', 2);
$key;   // "key"
$value; // "value"

[$key, $value ?? null]= explode('=', 'key', 2);
$key;   // "key"
$value; // null
```

## Implementation

The functionality is implemented by rewriting destructuring assignments inside `lang.ast.emit.RewriteDestructuring`:

```php
// Input - also works using list(...) syntax
[$key, $value ?? 'default']= $expr;

// Emitted as
$__t= $expr;
is_array($__t)
  ? [$key= $__t[0], $value= $__t[1] ?? 'default']
  : ([$key= null, $value= null] ? $__t : null)
;
```

*Note: The "otherwise" branch of the ternary statement above is needed to be compatible with how `list()` works. It sets all variables to NULL and returns the given right-hand-side expression if this expression is not an array. For example, `$r= list($a, $b)= "Test"; return [$a, $b, $r]` returns `[null, null, "Test"]`!*

## Shortcomings

This doesn't work when used inside `foreach`, see also https://github.com/xp-framework/compiler/issues/31#issuecomment-395961865

## See also

* https://wiki.php.net/rfc/destructuring_coalesce - RFC
* https://externals.io/message/118829 - Discussion
* https://github.com/php/php-src/pull/9747 - Pull request