### PR TITLE
Make enclosing type(s) accessible via code generator

### DIFF
--- a/src/main/php/lang/ast/CodeGen.class.php
+++ b/src/main/php/lang/ast/CodeGen.class.php
@@ -2,9 +2,19 @@
 
 class CodeGen {
   private $id= 0;
+  public $context= [];
 
   /** Creates a new, unique symbol */
   public function symbol() { return '_'.($this->id++); }
+
+  public function enter($context) {
+    array_unshift($this->context, $context);
+    return $context;
+  }
+
+  public function leave() {
+    return array_shift($this->context);
+  }
 
   /**
    * Search a given scope recursively for nodes with a given kind

--- a/src/main/php/lang/ast/emit/GeneratedCode.class.php
+++ b/src/main/php/lang/ast/emit/GeneratedCode.class.php
@@ -3,7 +3,6 @@
 class GeneratedCode extends Result {
   private $prolog, $epilog;
   public $line= 1;
-  public $type= [];
 
   /**
    * Starts a result stream, including an optional prolog and epilog
@@ -67,14 +66,18 @@ class GeneratedCode extends Result {
    * @return lang.ast.emit.Type
    */
   public function lookup($type) {
+    $enclosing= $this->codegen->context[0] ?? null;
+
     if ('self' === $type || 'static' === $type) {
-      return new Declaration($this->type[0], $this);
+      return new Declaration($enclosing->type, $this);
     } else if ('parent' === $type) {
-      return $this->type[0]->parent ? $this->lookup($this->type[0]->parent->literal()) : null;
+      return $enclosing->type->parent ? $this->lookup($enclosing->type->parent->literal()) : null;
     }
 
-    foreach ($this->type as $enclosing) {
-      if ($enclosing->name && $type === $enclosing->name->literal()) return new Declaration($enclosing, $this);
+    foreach ($this->codegen->context as $context) {
+      if ($context->type->name && $type === $context->type->name->literal()) {
+        return new Declaration($context->type, $this);
+      }
     }
 
     return new Reflection($type);

--- a/src/main/php/lang/ast/emit/InType.class.php
+++ b/src/main/php/lang/ast/emit/InType.class.php
@@ -1,12 +1,10 @@
 <?php namespace lang\ast\emit;
 
 class InType {
-  const STATICS= 0;
-  const INSTANCE= 1;
-
   public $type;
   public $meta= [];
-  public $init= [[], []];
+  public $init= [];
+  public $statics= [];
   public $virtual= [];
 
   public function __construct($type) {

--- a/src/main/php/lang/ast/emit/InType.class.php
+++ b/src/main/php/lang/ast/emit/InType.class.php
@@ -1,0 +1,15 @@
+<?php namespace lang\ast\emit;
+
+class InType {
+  const STATICS= 0;
+  const INSTANCE= 1;
+
+  public $type;
+  public $meta= [];
+  public $init= [[], []];
+  public $virtual= [];
+
+  public function __construct($type) {
+    $this->type= $type;
+  }
+}

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -287,7 +287,7 @@ abstract class PHP extends Emitter {
         $this->emitOne($result, $parameter->default);
       } else {
         $result->out->write('=null');
-        $result->codegen->context[0]->init[InType::INSTANCE]['null === $'.$parameter->name.' && $'.$parameter->name]= $parameter->default;
+        $result->codegen->context[0]->init['null === $'.$parameter->name.' && $'.$parameter->name]= $parameter->default;
       }
     }
     $result->locals[$parameter->name]= true;
@@ -377,7 +377,7 @@ abstract class PHP extends Emitter {
       $this->emitOne($result, $member);
     }
     $result->out->write('static function __init() {');
-    $this->emitInitializations($result, $context->init[InType::STATICS]);
+    $this->emitInitializations($result, $context->statics);
     $this->emitMeta($result, $enum->name, $enum->annotations, $enum->comment);
     $result->out->write('}} '.$enum->name->literal().'::__init();');
 
@@ -435,14 +435,14 @@ abstract class PHP extends Emitter {
 
     // Create constructor for property initializations to non-static scalars
     // which have not already been emitted inside constructor
-    if ($context->init[InType::INSTANCE]) {
+    if ($context->init) {
       $result->out->write('public function __construct() {');
-      $this->emitInitializations($result, $context->init[InType::INSTANCE]);
+      $this->emitInitializations($result, $context->init);
       $result->out->write('}');
     }
 
     $result->out->write('static function __init() {');
-    $this->emitInitializations($result, $context->init[InType::STATICS]);
+    $this->emitInitializations($result, $context->statics);
     $this->emitMeta($result, $class->name, $class->annotations, $class->comment);
     $result->out->write('}} '.$class->name->literal().'::__init();');
 
@@ -574,9 +574,9 @@ abstract class PHP extends Emitter {
         $result->out->write('=');
         $this->emitOne($result, $property->expression);
       } else if (in_array('static', $property->modifiers)) {
-        $result->codegen->context[0]->init[InType::STATICS]['self::$'.$property->name]= $property->expression;
+        $result->codegen->context[0]->statics['self::$'.$property->name]= $property->expression;
       } else {
-        $result->codegen->context[0]->init[InType::INSTANCE]['$this->'.$property->name]= $property->expression;
+        $result->codegen->context[0]->init['$this->'.$property->name]= $property->expression;
       }
     }
     $result->out->write(';');
@@ -615,8 +615,8 @@ abstract class PHP extends Emitter {
       $result->out->write(';');
     } else {
       $result->out->write(' {');
-      $this->emitInitializations($result, $result->codegen->context[0]->init[InType::INSTANCE]);
-      $result->codegen->context[0]->init[InType::INSTANCE]= [];
+      $this->emitInitializations($result, $result->codegen->context[0]->init);
+      $result->codegen->context[0]->init= [];
       foreach ($promoted as $param) {
         $result->out->write('$this->'.$param->name.($param->reference ? '=&$' : '=$').$param->name.';');
       }

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -287,7 +287,7 @@ abstract class PHP extends Emitter {
         $this->emitOne($result, $parameter->default);
       } else {
         $result->out->write('=null');
-        $result->locals[1]['null === $'.$parameter->name.' && $'.$parameter->name]= $parameter->default;
+        $result->codegen->context[0]->init[InType::INSTANCE]['null === $'.$parameter->name.' && $'.$parameter->name]= $parameter->default;
       }
     }
     $result->locals[$parameter->name]= true;
@@ -357,9 +357,7 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitEnum($result, $enum) {
-    array_unshift($result->type, $enum);
-    array_unshift($result->meta, []);
-    $result->locals= [[], []];
+    $context= $result->codegen->enter(new InType($enum));
 
     $enum->comment && $this->emitOne($result, $enum->comment);
     $enum->annotations && $this->emitOne($result, $enum->annotations);
@@ -375,23 +373,19 @@ abstract class PHP extends Emitter {
     }
 
     $result->out->write('{');
-
     foreach ($enum->body as $member) {
       $this->emitOne($result, $member);
     }
-
-    // Initializations
     $result->out->write('static function __init() {');
-    $this->emitInitializations($result, $result->locals[0]);
+    $this->emitInitializations($result, $context->init[InType::STATICS]);
     $this->emitMeta($result, $enum->name, $enum->annotations, $enum->comment);
     $result->out->write('}} '.$enum->name->literal().'::__init();');
-    array_shift($result->type);
+
+    $result->codegen->leave();
   }
 
   protected function emitClass($result, $class) {
-    array_unshift($result->type, $class);
-    array_unshift($result->meta, []);
-    $result->locals ?: $result->locals= [[], [], []];
+    $context= $result->codegen->context[0] ?? $result->codegen->enter(new InType($class));
 
     $class->comment && $this->emitOne($result, $class->comment);
     $class->annotations && $this->emitOne($result, $class->annotations);
@@ -412,26 +406,26 @@ abstract class PHP extends Emitter {
     }
 
     // Virtual properties support: __virtual member + __get() and __set()
-    if ($result->locals[2]) {
+    if ($context->virtual) {
       $result->out->write('private $__virtual= [');
-      foreach ($result->locals[2] as $name => $access) {
+      foreach ($context->virtual as $name => $access) {
         $name && $result->out->write("'{$name}' => null,");
       }
       $result->out->write('];');
 
       $result->out->write('public function __get($name) { switch ($name) {');
-      foreach ($result->locals[2] as $name => $access) {
+      foreach ($context->virtual as $name => $access) {
         $result->out->write($name ? 'case "'.$name.'":' : 'default:');
         $this->emitOne($result, $access[0]);
         $result->out->write('break;');
       }
-      isset($result->locals[2][null]) || $result->out->write(
+      isset($context->virtual[null]) || $result->out->write(
         'default: trigger_error("Undefined property ".__CLASS__."::".$name, E_USER_WARNING);'
       );
       $result->out->write('}}');
 
       $result->out->write('public function __set($name, $value) { switch ($name) {');
-      foreach ($result->locals[2] as $name => $access) {
+      foreach ($context->virtual as $name => $access) {
         $result->out->write($name ? 'case "'.$name.'":' : 'default:');
         $this->emitOne($result, $access[1]);
         $result->out->write('break;');
@@ -441,18 +435,18 @@ abstract class PHP extends Emitter {
 
     // Create constructor for property initializations to non-static scalars
     // which have not already been emitted inside constructor
-    if ($result->locals[1]) {
+    if ($context->init[InType::INSTANCE]) {
       $result->out->write('public function __construct() {');
-      $this->emitInitializations($result, $result->locals[1]);
+      $this->emitInitializations($result, $context->init[InType::INSTANCE]);
       $result->out->write('}');
     }
 
     $result->out->write('static function __init() {');
-    $this->emitInitializations($result, $result->locals[0]);
+    $this->emitInitializations($result, $context->init[InType::STATICS]);
     $this->emitMeta($result, $class->name, $class->annotations, $class->comment);
     $result->out->write('}} '.$class->name->literal().'::__init();');
-    array_shift($result->type);
-    $result->locals= [];
+
+    $result->codegen->leave();
   }
 
   protected function emitMeta($result, $name, $annotations, $comment) {
@@ -509,12 +503,13 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitInterface($result, $interface) {
-    array_unshift($result->meta, []);
+    $result->codegen->enter(new InType($interface));
 
     $interface->comment && $this->emitOne($result, $interface->comment);
     $interface->annotations && $this->emitOne($result, $interface->annotations);
     $result->at($interface->declared)->out->write('interface '.$interface->declaration());
     $interface->parents && $result->out->write(' extends '.implode(', ', $interface->parents));
+
     $result->out->write('{');
     foreach ($interface->body as $member) {
       $this->emitOne($result, $member);
@@ -522,10 +517,11 @@ abstract class PHP extends Emitter {
     $result->out->write('}');
 
     $this->emitMeta($result, $interface->name, $interface->annotations, $interface->comment);
+    $result->codegen->leave();
   }
 
   protected function emitTrait($result, $trait) {
-    array_unshift($result->meta, []);
+    $result->codegen->enter(new InType($trait));
 
     $trait->comment && $this->emitOne($result, $trait->comment);
     $trait->annotations && $this->emitOne($result, $trait->annotations);
@@ -537,6 +533,7 @@ abstract class PHP extends Emitter {
     $result->out->write('}');
 
     $this->emitMeta($result, $trait->name, $trait->annotations, $trait->comment);
+    $result->codegen->leave();
   }
 
   protected function emitUse($result, $use) {
@@ -561,7 +558,7 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitProperty($result, $property) {
-    $result->meta[0][self::PROPERTY][$property->name]= [
+    $result->codegen->context[0]->meta[self::PROPERTY][$property->name]= [
       DETAIL_RETURNS     => $property->type ? $property->type->name() : 'var',
       DETAIL_ANNOTATIONS => $property->annotations,
       DETAIL_COMMENT     => $property->comment,
@@ -577,27 +574,17 @@ abstract class PHP extends Emitter {
         $result->out->write('=');
         $this->emitOne($result, $property->expression);
       } else if (in_array('static', $property->modifiers)) {
-        $result->locals[0]['self::$'.$property->name]= $property->expression;
+        $result->codegen->context[0]->init[InType::STATICS]['self::$'.$property->name]= $property->expression;
       } else {
-        $result->locals[1]['$this->'.$property->name]= $property->expression;
+        $result->codegen->context[0]->init[InType::INSTANCE]['$this->'.$property->name]= $property->expression;
       }
     }
     $result->out->write(';');
   }
 
   protected function emitMethod($result, $method) {
-
-    // Include non-static initializations for members in constructor, removing
-    // them to signal emitClass() no constructor needs to be generated.
-    if ('__construct' === $method->name && isset($result->locals[1])) {
-      $locals= [[], $result->locals[1], [], 'this' => true];
-      $result->locals[1]= [];
-    } else {
-      $locals= [[], [], [], 'this' => true];
-    }
     $result->stack[]= $result->locals;
-    $result->locals= $locals;
-
+    $result->locals= ['this' => true];
     $meta= [
       DETAIL_RETURNS     => $method->signature->returns ? $method->signature->returns->name() : 'var',
       DETAIL_ANNOTATIONS => $method->annotations,
@@ -628,7 +615,8 @@ abstract class PHP extends Emitter {
       $result->out->write(';');
     } else {
       $result->out->write(' {');
-      $this->emitInitializations($result, $result->locals[1]);
+      $this->emitInitializations($result, $result->codegen->context[0]->init[InType::INSTANCE]);
+      $result->codegen->context[0]->init[InType::INSTANCE]= [];
       foreach ($promoted as $param) {
         $result->out->write('$this->'.$param->name.($param->reference ? '=&$' : '=$').$param->name.';');
       }
@@ -640,13 +628,8 @@ abstract class PHP extends Emitter {
       $this->emitProperty($result, new Property(explode(' ', $param->promote), $param->name, $param->type));
     }
 
-    // Copy any virtual properties inside locals[2] to class scope
-    $virtual= $result->locals[2];
     $result->locals= array_pop($result->stack);
-    foreach ($virtual as $name => $access) {
-      $result->locals[2][$name]= $access;
-    }
-    $result->meta[0][self::METHOD][$method->name]= $meta;
+    $result->codegen->context[0]->meta[self::METHOD][$method->name]= $meta;
   }
 
   protected function emitBraced($result, $braced) {
@@ -943,7 +926,7 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitNewClass($result, $new) {
-    array_unshift($result->meta, []);
+    $enclosing= $result->codegen->context[0] ?? null;
 
     $result->out->write('(new class(');
     $this->emitArguments($result, $new->arguments);
@@ -951,8 +934,8 @@ abstract class PHP extends Emitter {
 
     // Allow "extends self" to reference enclosing class (except if this
     // class is an anonymous class!)
-    if ($result->type && $result->type[0]->name && $new->definition->parent && 'self' === $new->definition->parent->name()) {
-      $result->out->write(' extends '.$result->type[0]->name->literal());
+    if ($enclosing && $enclosing->type->name && $new->definition->parent && 'self' === $new->definition->parent->name()) {
+      $result->out->write(' extends '.$enclosing->type->name->literal());
     } else if ($new->definition->parent) {
       $result->out->write(' extends '.$new->definition->parent->literal());
     }
@@ -965,7 +948,7 @@ abstract class PHP extends Emitter {
       $result->out->write(' implements '.substr($list, 2));
     }
 
-    array_unshift($result->type, $new->definition);
+    $result->codegen->enter(new InType($new->definition));
     $result->out->write('{');
     foreach ($new->definition->body as $member) {
       $this->emitOne($result, $member);
@@ -973,8 +956,7 @@ abstract class PHP extends Emitter {
     $result->out->write('function __new() {');
     $this->emitMeta($result, null, [], null);
     $result->out->write('return $this; }})->__new()');
-
-    array_shift($result->type);
+    $result->codegen->leave();
   }
 
   protected function emitCallable($result, $callable) {

--- a/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyClasses.class.php
@@ -28,7 +28,8 @@ trait ReadonlyClasses {
 
       // Prevent dynamic members
       $throw= new Code('throw new \\Error("Cannot create dynamic property ".__CLASS__."::".$name);');
-      $result->locals= [[], [], [null => [$throw, $throw]]];
+      $context= $result->codegen->enter(new InType($class));
+      $context->virtual[null]= [$throw, $throw];
     }
 
     return parent::emitClass($result, $class);

--- a/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
@@ -23,11 +23,12 @@ trait ReadonlyProperties {
 
     if (!in_array('readonly', $property->modifiers)) return parent::emitProperty($result, $property);
 
+    $context= $result->codegen->context[0];
     $modifiers= 0;
     foreach ($property->modifiers as $name) {
       $modifiers|= $lookup[$name];
     }
-    $result->meta[0][self::PROPERTY][$property->name]= [
+    $context->meta[self::PROPERTY][$property->name]= [
       DETAIL_RETURNS     => $property->type ? $property->type->name() : 'var',
       DETAIL_ANNOTATIONS => $property->annotations,
       DETAIL_COMMENT     => $property->comment,
@@ -53,7 +54,7 @@ trait ReadonlyProperties {
     }
 
     // Create virtual property implementing the readonly semantics
-    $result->locals[2][$property->name]= [
+    $context->virtual[$property->name]= [
       new Code(sprintf($check.'return $this->__virtual["%1$s"][0] ?? null;', $property->name)),
       new Code(sprintf(
         ($check ?: '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;').

--- a/src/main/php/lang/ast/emit/Result.class.php
+++ b/src/main/php/lang/ast/emit/Result.class.php
@@ -7,7 +7,6 @@ use lang\ast\CodeGen;
 class Result implements Closeable {
   public $out;
   public $codegen;
-  public $meta= [];
   public $locals= [];
   public $stack= [];
 

--- a/src/main/php/lang/ast/emit/RewriteEnums.class.php
+++ b/src/main/php/lang/ast/emit/RewriteEnums.class.php
@@ -79,7 +79,7 @@ trait RewriteEnums {
         $result->out->write('self::$'.$case->name.'= new self("'.$case->name.'");');
       }
     }
-    $this->emitInitializations($result, $context->init[InType::STATICS]);
+    $this->emitInitializations($result, $context->statics);
     $this->emitMeta($result, $enum->name, $enum->annotations, $enum->comment);
     $result->out->write('}} '.$enum->name.'::__init();');
     $result->codegen->leave();

--- a/src/main/php/lang/ast/emit/RewriteEnums.class.php
+++ b/src/main/php/lang/ast/emit/RewriteEnums.class.php
@@ -12,10 +12,7 @@ trait RewriteEnums {
   }
 
   protected function emitEnum($result, $enum) {
-    array_unshift($result->type, $enum);
-    array_unshift($result->meta, []);
-    $result->locals= [[], []];
-
+    $context= $result->codegen->enter(new InType($enum));
     $result->out->write('final class '.$enum->declaration().' implements \\'.($enum->base ? 'BackedEnum' : 'UnitEnum'));
 
     if ($enum->implements) {
@@ -82,9 +79,9 @@ trait RewriteEnums {
         $result->out->write('self::$'.$case->name.'= new self("'.$case->name.'");');
       }
     }
-    $this->emitInitializations($result, $result->locals[0]);
+    $this->emitInitializations($result, $context->init[InType::STATICS]);
     $this->emitMeta($result, $enum->name, $enum->annotations, $enum->comment);
     $result->out->write('}} '.$enum->name.'::__init();');
-    array_shift($result->type);
+    $result->codegen->leave();
   }
 }

--- a/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
@@ -1,6 +1,7 @@
 <?php namespace lang\ast\emit\php;
 
 use lang\ast\Code;
+use lang\ast\emit\InType;
 
 /**
  * Creates __get() and __set() overloads which will create type-checked
@@ -66,7 +67,8 @@ trait VirtualPropertyTypes {
       $check= '';
     }
 
-    $result->locals[2][$property->name]= [
+    $context= $result->codegen->context[0];
+    $context->virtual[$property->name]= [
       new Code(sprintf($check.'return $this->__virtual["%1$s"];', $property->name)),
       new Code(sprintf(
         $check.$assign.
@@ -78,7 +80,7 @@ trait VirtualPropertyTypes {
 
     // Initialize via constructor
     if (isset($property->expression)) {
-      $result->locals[1]['$this->'.$property->name]= $property->expression;
+      $context->init[InType::INSTANCE]['$this->'.$property->name]= $property->expression;
     }
 
     // Emit XP meta information for the reflection API
@@ -86,7 +88,7 @@ trait VirtualPropertyTypes {
     foreach ($property->modifiers as $name) {
       $modifiers|= $lookup[$name];
     }
-    $result->meta[0][self::PROPERTY][$property->name]= [
+    $context->meta[self::PROPERTY][$property->name]= [
       DETAIL_RETURNS     => $property->type ? $property->type->name() : 'var',
       DETAIL_ANNOTATIONS => $property->annotations,
       DETAIL_COMMENT     => $property->comment,

--- a/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
@@ -80,7 +80,7 @@ trait VirtualPropertyTypes {
 
     // Initialize via constructor
     if (isset($property->expression)) {
-      $context->init[InType::INSTANCE]['$this->'.$property->name]= $property->expression;
+      $context->init['$this->'.$property->name]= $property->expression;
     }
 
     // Emit XP meta information for the reflection API

--- a/src/main/php/lang/ast/emit/php/XpMeta.class.php
+++ b/src/main/php/lang/ast/emit/php/XpMeta.class.php
@@ -76,7 +76,7 @@ trait XpMeta {
     $this->attributes($result, $annotations, []);
     $result->out->write(', DETAIL_COMMENT => '.$this->comment($comment).'],');
 
-    foreach (array_shift($result->meta) as $type => $lookup) {
+    foreach ($result->codegen->context[0]->meta as $type => $lookup) {
       $result->out->write($type.' => [');
       foreach ($lookup as $key => $meta) {
         $result->out->write("'".$key."' => [");

--- a/src/test/php/lang/ast/unittest/emit/EmitterTraitTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmitterTraitTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\MemoryOutputStream;
 use lang\ast\Node;
-use lang\ast\emit\GeneratedCode;
+use lang\ast\emit\{InType, GeneratedCode};
 use unittest\Before;
 
 abstract class EmitterTraitTest {
@@ -11,7 +11,9 @@ abstract class EmitterTraitTest {
   /** Emits a node and returns the emitted code */
   protected function emit(Node $node, array $type= []): string {
     $result= new GeneratedCode(new MemoryOutputStream(), '');
-    $result->type= $type;
+    foreach ($type as $t) {
+      $result->codegen->enter(new InType($t));
+    }
 
     $this->emitter->emitOne($result, $node);
     return $result->out->bytes();

--- a/src/test/php/lang/ast/unittest/emit/GeneratedCodeTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/GeneratedCodeTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use io\streams\MemoryOutputStream;
-use lang\ast\emit\{GeneratedCode, Declaration, Escaping, Reflection};
+use lang\ast\emit\{InType, GeneratedCode, Declaration, Escaping, Reflection};
 use lang\ast\nodes\ClassDeclaration;
 use lang\ast\types\IsValue;
 use lang\{Value, ClassNotFoundException};
@@ -47,15 +47,15 @@ class GeneratedCodeTest {
   #[Test]
   public function lookup_self() {
     $r= new GeneratedCode(new MemoryOutputStream());
-    $r->type[0]= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1);
+    $context= $r->codegen->enter(new InType(new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1)));
 
-    Assert::equals(new Declaration($r->type[0], $r), $r->lookup('self'));
+    Assert::equals(new Declaration($context->type, $r), $r->lookup('self'));
   }
 
   #[Test]
   public function lookup_parent() {
     $r= new GeneratedCode(new MemoryOutputStream());
-    $r->type[0]= new ClassDeclaration([], new IsValue('\\T'), new IsValue('\\lang\\Value'), [], [], null, null, 1);
+    $r->codegen->enter(new InType(new ClassDeclaration([], new IsValue('\\T'), new IsValue('\\lang\\Value'), [], [], null, null, 1)));
 
     Assert::equals(new Reflection(Value::class), $r->lookup('parent'));
   }
@@ -63,7 +63,7 @@ class GeneratedCodeTest {
   #[Test]
   public function lookup_parent_without_parent() {
     $r= new GeneratedCode(new MemoryOutputStream());
-    $r->type[0]= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1);
+    $r->codegen->enter(new InType(new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1)));
 
     Assert::null($r->lookup('parent'));
   }
@@ -71,9 +71,9 @@ class GeneratedCodeTest {
   #[Test]
   public function lookup_named() {
     $r= new GeneratedCode(new MemoryOutputStream());
-    $r->type[0]= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1);
+    $context= $r->codegen->enter(new InType(new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1)));
 
-    Assert::equals(new Declaration($r->type[0], $r), $r->lookup('\\T'));
+    Assert::equals(new Declaration($context->type, $r), $r->lookup('\\T'));
   }
 
   #[Test]


### PR DESCRIPTION
This pull request makes the enclosing type, meta data, initializations and virtual properties accessible via `$codegen->context[0]->type` instead of misusing *locals[0..2]* for this.

*No measurable difference in memory usage or runtime performance by looking at the test suite*.