### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: git config --system core.autocrlf false; git config --system core.eol lf
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up PHP ${{ matrix.php-versions }}
       uses: shivammathur/setup-php@v2
@@ -43,7 +43,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2.1.3
+      uses: actions/cache@v3
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -56,4 +56,4 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.0 | ^10.0"
+    "xp-framework/test": "dev-main"
   },
   "bin": ["bin/xp.xp-framework.compiler.compile", "bin/xp.xp-framework.compiler.ast"],
   "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/test": "dev-main"
+    "xp-framework/test": "^1.0"
   },
   "bin": ["bin/xp.xp-framework.compiler.compile", "bin/xp.xp-framework.compiler.ast"],
   "autoload" : {

--- a/src/test/php/lang/ast/unittest/EmitterTest.class.php
+++ b/src/test/php/lang/ast/unittest/EmitterTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace lang\ast\unittest;
 
 use io\streams\MemoryOutputStream;
-use lang\ast\nodes\{Variable, Comment};
-use lang\ast\{Emitter, Node, Code, Result};
-use lang\{IllegalStateException, IllegalArgumentException};
-use unittest\{Assert, Expect, Test, TestCase};
+use lang\ast\nodes\{Comment, Variable};
+use lang\ast\{Code, Emitter, Node, Result};
+use lang\{IllegalArgumentException, IllegalStateException};
+use test\{Assert, Expect, Test, TestCase};
 
 class EmitterTest {
 

--- a/src/test/php/lang/ast/unittest/ResultTest.class.php
+++ b/src/test/php/lang/ast/unittest/ResultTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace lang\ast\unittest;
 
 use io\streams\MemoryOutputStream;
-use lang\ast\emit\{Result, Declaration, Escaping, Reflection};
+use lang\ast\emit\{Declaration, Escaping, Reflection, Result};
 use lang\ast\nodes\ClassDeclaration;
-use lang\{Value, ClassNotFoundException};
-use unittest\{Assert, Expect, Test};
+use lang\{ClassNotFoundException, Value};
+use test\{Assert, Expect, Test};
 
 class ResultTest {
 

--- a/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
+++ b/src/test/php/lang/ast/unittest/TypeLiteralsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest;
 
 use lang\ast\emit\{PHP70, PHP71, PHP72, PHP74, PHP80, PHP81, PHP82};
-use lang\ast\types\{IsLiteral, IsArray, IsFunction, IsMap, IsValue, IsNullable, IsUnion, IsIntersection, IsGeneric};
-use unittest\{Assert, Test, Values};
+use lang\ast\types\{IsArray, IsFunction, IsGeneric, IsIntersection, IsLiteral, IsMap, IsNullable, IsUnion, IsValue};
+use test\{Assert, Test, Values};
 
 class TypeLiteralsTest {
 
@@ -156,37 +156,37 @@ class TypeLiteralsTest {
     yield [new IsIntersection([new IsValue('Test'), new IsValue('Iterator')]), 'Test&Iterator'];
   }
 
-  #[Test, Values('php70')]
+  #[Test, Values(from: 'php70')]
   public function php70_literals($type, $literal) {
     Assert::equals($literal, (new PHP70())->literal($type));
   }
 
-  #[Test, Values('php71')]
+  #[Test, Values(from: 'php71')]
   public function php71_literals($type, $literal) {
     Assert::equals($literal, (new PHP71())->literal($type));
   }
 
-  #[Test, Values('php72')]
+  #[Test, Values(from: 'php72')]
   public function php72_literals($type, $literal) {
     Assert::equals($literal, (new PHP72())->literal($type));
   }
 
-  #[Test, Values('php74')]
+  #[Test, Values(from: 'php74')]
   public function php74_literals($type, $literal) {
     Assert::equals($literal, (new PHP74())->literal($type));
   }
 
-  #[Test, Values('php80')]
+  #[Test, Values(from: 'php80')]
   public function php80_literals($type, $literal) {
     Assert::equals($literal, (new PHP80())->literal($type));
   }
 
-  #[Test, Values('php81')]
+  #[Test, Values(from: 'php81')]
   public function php81_literals($type, $literal) {
     Assert::equals($literal, (new PHP81())->literal($type));
   }
 
-  #[Test, Values('php82')]
+  #[Test, Values(from: 'php82')]
   public function php82_literals($type, $literal) {
     Assert::equals($literal, (new PHP82())->literal($type));
   }

--- a/src/test/php/lang/ast/unittest/cli/CompileOnlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/CompileOnlyTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\cli;
 
-use unittest\Test;
+use test\Test;
 use xp\compiler\CompileOnly;
 
 class CompileOnlyTest {

--- a/src/test/php/lang/ast/unittest/cli/FromFileTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/FromFileTest.class.php
@@ -3,7 +3,7 @@
 use io\streams\FileInputStream;
 use io\{File, Folder};
 use lang\Environment;
-use unittest\{Assert, After, Before, Test};
+use test\{After, Assert, Before, Test};
 use xp\compiler\FromFile;
 
 class FromFileTest {

--- a/src/test/php/lang/ast/unittest/cli/FromFilesInTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/FromFilesInTest.class.php
@@ -3,7 +3,7 @@
 use io\streams\FileInputStream;
 use io\{File, Folder};
 use lang\Environment;
-use unittest\{Assert, After, Before, Test, Values};
+use test\{After, Assert, Before, Test, Values};
 use xp\compiler\FromFilesIn;
 
 class FromFilesInTest {
@@ -50,7 +50,7 @@ class FromFilesInTest {
     new FromFilesIn($this->folder->getURI());
   }
 
-  #[Test, Values('files')]
+  #[Test, Values(from: 'files')]
   public function iteration($expected) {
     $results= [];
     foreach (new FromFilesIn($this->folder) as $path => $stream) {

--- a/src/test/php/lang/ast/unittest/cli/FromInputsTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/FromInputsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\cli;
 
-use io\streams\{FileInputStream, ConsoleInputStream};
-use unittest\{Assert, Test, Values};
+use io\streams\{ConsoleInputStream, FileInputStream};
+use test\{Assert, Test, Values};
 use xp\compiler\FromInputs;
 
 class FromInputsTest {
@@ -18,7 +18,7 @@ class FromInputsTest {
     new FromInputs([]);
   }
 
-  #[Test, Values('inputs')]
+  #[Test, Values(from: 'inputs')]
   public function iteration($inputs, $expected) {
     $results= [];
     foreach (new FromInputs($inputs) as $path => $stream) {

--- a/src/test/php/lang/ast/unittest/cli/InputTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/InputTest.class.php
@@ -2,9 +2,9 @@
 
 use io\{File, Folder};
 use lang\{Environment, IllegalArgumentException};
-use unittest\{Assert, After, Before, Expect, Test, Values};
+use test\{After, Assert, Before, Expect, Test, Values};
 use util\cmd\Console;
-use xp\compiler\{Input, FromStream, FromFile, FromFilesIn, FromInputs};
+use xp\compiler\{FromFile, FromFilesIn, FromInputs, FromStream, Input};
 
 class InputTest {
   private $folder, $file;

--- a/src/test/php/lang/ast/unittest/cli/OutputTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/OutputTest.class.php
@@ -2,9 +2,9 @@
 
 use io\{File, Folder};
 use lang\Environment;
-use unittest\{Assert, After, Before, Test, Values};
+use test\{After, Assert, Before, Test, Values};
 use util\cmd\Console;
-use xp\compiler\{Output, CompileOnly, ToStream, ToFile, ToArchive, ToFolder};
+use xp\compiler\{CompileOnly, Output, ToArchive, ToFile, ToFolder, ToStream};
 
 class OutputTest {
   private $folder, $file, $archive;

--- a/src/test/php/lang/ast/unittest/cli/ToArchiveTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/ToArchiveTest.class.php
@@ -3,7 +3,7 @@
 use io\{File, Folder};
 use lang\Environment;
 use lang\archive\ArchiveClassLoader;
-use unittest\{After, Assert, Before, Test};
+use test\{After, Assert, Before, Test};
 use xp\compiler\ToArchive;
 
 class ToArchiveTest {

--- a/src/test/php/lang/ast/unittest/cli/ToFileTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/ToFileTest.class.php
@@ -3,7 +3,7 @@
 use io\{File, Folder};
 use lang\Environment;
 use lang\FileSystemClassLoader;
-use unittest\{After, Assert, Before, Test};
+use test\{After, Assert, Before, Test};
 use xp\compiler\ToFile;
 
 class ToFileTest {

--- a/src/test/php/lang/ast/unittest/cli/ToFolderTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/ToFolderTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\ast\unittest\cli;
 
-use io\{Folder, File};
+use io\{File, Folder};
 use lang\Environment;
 use lang\FileSystemClassLoader;
-use unittest\{After, Assert, Before, Test};
+use test\{After, Assert, Before, Test};
 use xp\compiler\ToFolder;
 
 class ToFolderTest {

--- a/src/test/php/lang/ast/unittest/cli/ToStreamTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/ToStreamTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\cli;
 
 use io\streams\MemoryOutputStream;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use xp\compiler\ToStream;
 
 class ToStreamTest {

--- a/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 /**
  * Annotations support. There are two tests extending this base class:

--- a/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Runnable;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\AbstractDeferredInvokationHandler;
 
 /**

--- a/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
@@ -83,7 +83,7 @@ class ArgumentPromotionTest extends EmittingTest {
     );
   }
 
-  #[Test, Expect(class: Errors::class, message: 'Variadic parameters cannot be promoted')]
+  #[Test, Expect(class: Errors::class, message: '/Variadic parameters cannot be promoted/')]
   public function variadic_parameters_cannot_be_promoted() {
     $this->type('class <T> {
       public function __construct(private string... $in) { }

--- a/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\Primitive;
 use lang\ast\Errors;
-use unittest\{Assert, Expect, Test};
+use test\{Assert, Expect, Test};
 
 /**
  * Argument promotion
@@ -83,7 +83,7 @@ class ArgumentPromotionTest extends EmittingTest {
     );
   }
 
-  #[Test, Expect(class: Errors::class, withMessage: 'Variadic parameters cannot be promoted')]
+  #[Test, Expect(class: Errors::class, message: 'Variadic parameters cannot be promoted')]
   public function variadic_parameters_cannot_be_promoted() {
     $this->type('class <T> {
       public function __construct(private string... $in) { }

--- a/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Argument unpacking

--- a/src/test/php/lang/ast/unittest/emit/ArrayTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArrayTypesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Array types

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\IllegalStateException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class ArraysTest extends EmittingTest {
 
@@ -40,7 +40,7 @@ class ArraysTest extends EmittingTest {
     Assert::equals([1, 2, 3], $r);
   }
 
-  #[Test, Values(['[1, , 3]', '[1, , ]', '[, 1]']), Expect(class: IllegalStateException::class, withMessage: 'Cannot use empty array elements in arrays')]
+  #[Test, Values(['[1, , 3]', '[1, , ]', '[, 1]']), Expect(class: IllegalStateException::class, message: 'Cannot use empty array elements in arrays')]
   public function arrays_cannot_have_empty_elements($input) {
     $r= $this->run('class <T> {
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/BlockTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/BlockTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class BlockTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/BracesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/BracesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class BracesTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Error;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 /**
  * Tests for first-class callable syntax

--- a/src/test/php/lang/ast/unittest/emit/CastingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CastingTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ClassCastException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class CastingTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/ClassLiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ClassLiteralTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Primitive;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Tests `::class`

--- a/src/test/php/lang/ast/unittest/emit/CommentsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CommentsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class CommentsTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Throwable;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class ControlStructuresTest extends EmittingTest {
 
@@ -154,7 +154,7 @@ class ControlStructuresTest extends EmittingTest {
     Assert::equals('10+ items', $r);
   }
 
-  #[Test, Expect(class: Throwable::class, withMessage: '/Unhandled match (value of type .+|case .+)/')]
+  #[Test, Expect(class: Throwable::class, message: '/Unhandled match (value of type .+|case .+)/')]
   public function unhandled_match() {
     $this->run('class <T> {
       public function run($arg) {
@@ -167,7 +167,7 @@ class ControlStructuresTest extends EmittingTest {
     }', SEEK_END);
   }
 
-  #[Test, Expect(class: Throwable::class, withMessage: '/Unknown seek mode .+/')]
+  #[Test, Expect(class: Throwable::class, message: '/Unknown seek mode .+/')]
   public function match_with_throw_expression() {
     $this->run('class <T> {
       public function run($arg) {

--- a/src/test/php/lang/ast/unittest/emit/DeclarationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/DeclarationTest.class.php
@@ -3,7 +3,7 @@
 use lang\ast\emit\Declaration;
 use lang\ast\nodes\{ClassDeclaration, Property};
 use lang\ast\types\IsValue;
-use unittest\{Assert, Before, Test, Expect};
+use test\{Assert, Before, Expect, Test};
 
 class DeclarationTest {
   private $type;

--- a/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Error;
-use unittest\{Assert, Expect, AssertionFailedError, Test};
+use test\{Assert, AssertionFailedError, Expect, Test};
 
 class DeclareTest extends EmittingTest {
 
@@ -21,7 +21,7 @@ class DeclareTest extends EmittingTest {
     }'));
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/must be of (the )?type int(eger)?, string given/')]
+  #[Test, Expect(class: Error::class, message: '/must be of (the )?type int(eger)?, string given/')]
   public function strict_types_on() {
     $this->run('declare(strict_types = 1); class <T> {
       public static function number(int $n) { return $n; }

--- a/src/test/php/lang/ast/unittest/emit/EchoTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EchoTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class EchoTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/EmitterTraitTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmitterTraitTest.class.php
@@ -2,8 +2,8 @@
 
 use io\streams\MemoryOutputStream;
 use lang\ast\Node;
-use lang\ast\emit\{InType, GeneratedCode};
-use unittest\Before;
+use lang\ast\emit\{GeneratedCode, InType};
+use test\Before;
 
 abstract class EmitterTraitTest {
   private $emitter;

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -5,7 +5,7 @@ use lang\DynamicClassLoader;
 use lang\ast\emit\GeneratedCode;
 use lang\ast\emit\php\XpMeta;
 use lang\ast\{CompilingClassLoader, Emitter, Language, Result, Tokens};
-use unittest\{After, Assert, TestCase};
+use test\{After, Assert, TestCase};
 use util\cmd\Console;
 
 abstract class EmittingTest {

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -5,9 +5,10 @@ use lang\DynamicClassLoader;
 use lang\ast\emit\GeneratedCode;
 use lang\ast\emit\php\XpMeta;
 use lang\ast\{CompilingClassLoader, Emitter, Language, Result, Tokens};
-use test\{After, Assert, TestCase};
+use test\{Args, After, Assert, TestCase};
 use util\cmd\Console;
 
+#[Args(['output' => null])]
 abstract class EmittingTest {
   private static $id= 0;
   private $cl, $language, $emitter, $output;

--- a/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
@@ -5,7 +5,7 @@ use lang\{Enum, Error};
 use test\verify\Condition;
 use test\{Action, Assert, Expect, Ignore, Test, Values};
 
-#[Condition(assert: 'fn() => function_exists("enum_exists")')]
+#[Condition(assert: 'function_exists("enum_exists")')]
 class EnumTest extends EmittingTest {
 
   #[Test]

--- a/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
@@ -2,10 +2,10 @@
 
 use lang\reflect\TargetInvocationException;
 use lang\{Enum, Error};
-use unittest\actions\VerifyThat;
-use unittest\{Assert, Action, Ignore, Expect, Values, Test};
+use test\verify\Condition;
+use test\{Action, Assert, Expect, Ignore, Test, Values};
 
-#[Action(eval: 'new VerifyThat(fn() => function_exists("enum_exists"))')]
+#[Condition(assert: 'fn() => function_exists("enum_exists")')]
 class EnumTest extends EmittingTest {
 
   #[Test]
@@ -138,7 +138,7 @@ class EnumTest extends EmittingTest {
     Assert::equals($expected, $t->getMethod('from')->invoke(null, [$arg])->name);
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/"illegal" is not a valid backing value for enum .+/')]
+  #[Test, Expect(class: Error::class, message: '/"illegal" is not a valid backing value for enum .+/')]
   public function backed_enum_from_nonexistant() {
     $t= $this->type('enum <T>: string {
       case ASC  = "asc";

--- a/src/test/php/lang/ast/unittest/emit/EscapingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EscapingTest.class.php
@@ -2,7 +2,7 @@
 
 use io\streams\MemoryOutputStream;
 use lang\ast\emit\Escaping;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class EscapingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test};
+use test\{Assert, Expect, Test};
 
 class ExceptionsTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/FunctionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/FunctionTypesTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\{FunctionType, Primitive};
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Function types

--- a/src/test/php/lang/ast/unittest/emit/GeneratedCodeTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/GeneratedCodeTest.class.php
@@ -1,11 +1,11 @@
 <?php namespace lang\ast\unittest\emit;
 
 use io\streams\MemoryOutputStream;
-use lang\ast\emit\{InType, GeneratedCode, Declaration, Escaping, Reflection};
+use lang\ast\emit\{Declaration, Escaping, GeneratedCode, InType, Reflection};
 use lang\ast\nodes\ClassDeclaration;
 use lang\ast\types\IsValue;
-use lang\{Value, ClassNotFoundException};
-use unittest\{Assert, Expect, Values, Test};
+use lang\{ClassNotFoundException, Value};
+use test\{Assert, Expect, Test, Values};
 
 class GeneratedCodeTest {
 

--- a/src/test/php/lang/ast/unittest/emit/GotoTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/GotoTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class GotoTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/ImportTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ImportTest.class.php
@@ -2,7 +2,7 @@
 
 use Traversable, Iterator;
 use lang\XPClass;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\Date;
 
 class ImportTest extends EmittingTest {

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 /**
  * Initialize parameters and properties with arbitrary expressions
@@ -27,7 +27,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
     yield ['[new Handle(0)]', [new Handle(0)]];
   }
 
-  #[Test, Values('expressions')]
+  #[Test, Values(from: 'expressions')]
   public function property($declaration, $expected) {
     Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\{FileInput, Handle}; class <T> {
       const INITIAL= "initial";
@@ -39,7 +39,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
     }', $declaration)));
   }
 
-  #[Test, Values('expressions')]
+  #[Test, Values(from: 'expressions')]
   public function reflective_access_to_property($declaration, $expected) {
     Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\{FileInput, Handle}; class <T> {
       const INITIAL= "initial";

--- a/src/test/php/lang/ast/unittest/emit/InstanceOfTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstanceOfTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class InstanceOfTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\Date;
 
 class InstantiationTest extends EmittingTest {

--- a/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\{Primitive, XPClass, TypeIntersection};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Test, Action};
+use lang\{Primitive, TypeIntersection, XPClass};
+use test\verify\Runtime;
+use test\{Action, Assert, Test};
 
 /**
  * Intersection types
@@ -47,7 +47,7 @@ class IntersectionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  #[Test, Runtime(php: '>=8.1.0-dev')]
   public function field_type_restriction_with_php81() {
     $t= $this->type('class <T> {
       private Traversable&Countable $test;
@@ -59,7 +59,7 @@ class IntersectionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  #[Test, Runtime(php: '>=8.1.0-dev')]
   public function parameter_type_restriction_with_php81() {
     $t= $this->type('class <T> {
       public function test(Traversable&Countable $arg) { }
@@ -71,7 +71,7 @@ class IntersectionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1.0-dev")')]
+  #[Test, Runtime(php: '>=8.1.0-dev')]
   public function return_type_restriction_with_php81() {
     $t= $this->type('class <T> {
       public function test(): Traversable&Countable { }

--- a/src/test/php/lang/ast/unittest/emit/InvocationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InvocationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Test, Values};
+use test\verify\Runtime;
+use test\{Action, Assert, Test, Values};
 
 class InvocationTest extends EmittingTest {
 
@@ -139,7 +139,7 @@ class InvocationTest extends EmittingTest {
     ));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function named_arguments_in_reverse_order() {
     Assert::equals('html(&lt;) = &amp;lt;', $this->run(
       'class <T> {
@@ -155,7 +155,7 @@ class InvocationTest extends EmittingTest {
     ));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0")')]
+  #[Test, Runtime(php: '>=8.0')]
   public function named_arguments_omitting_one() {
     Assert::equals('html(&lt;) = &lt;', $this->run(
       'class <T> {

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -48,7 +48,7 @@ class LambdasTest extends EmittingTest {
     Assert::equals(3, $r(1));
   }
 
-  #[Test, Condition(assert: 'fn() => property_exists(LambdaExpression::class, "static")')]
+  #[Test, Condition(assert: 'property_exists(LambdaExpression::class, "static")')]
   public function static_fn_does_not_capture_this() {
     $r= $this->run('class <T> {
       public function run() {
@@ -59,7 +59,7 @@ class LambdasTest extends EmittingTest {
     Assert::false($r());
   }
 
-  #[Test, Condition(assert: 'fn() => property_exists(ClosureExpression::class, "static")')]
+  #[Test, Condition(assert: 'property_exists(ClosureExpression::class, "static")')]
   public function static_function_does_not_capture_this() {
     $r= $this->run('class <T> {
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -2,8 +2,8 @@
 
 use lang\ast\Errors;
 use lang\ast\nodes\{ClosureExpression, LambdaExpression};
-use unittest\actions\VerifyThat;
-use unittest\{Action, Assert, Expect, Test};
+use test\verify\Condition;
+use test\{Action, Assert, Expect, Test};
 
 /**
  * Lambdas (a.k.a. arrow functions) support
@@ -48,7 +48,7 @@ class LambdasTest extends EmittingTest {
     Assert::equals(3, $r(1));
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => property_exists(LambdaExpression::class, "static"))')]
+  #[Test, Condition(assert: 'fn() => property_exists(LambdaExpression::class, "static")')]
   public function static_fn_does_not_capture_this() {
     $r= $this->run('class <T> {
       public function run() {
@@ -59,7 +59,7 @@ class LambdasTest extends EmittingTest {
     Assert::false($r());
   }
 
-  #[Test, Action(eval: 'new VerifyThat(fn() => property_exists(ClosureExpression::class, "static"))')]
+  #[Test, Condition(assert: 'fn() => property_exists(ClosureExpression::class, "static")')]
   public function static_function_does_not_capture_this() {
     $r= $this->run('class <T> {
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/LoopsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LoopsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class LoopsTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ArrayType;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class MembersTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/MultipleCatchTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MultipleCatchTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\{IllegalArgumentException, IllegalStateException};
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 /**
  * Multiple catch

--- a/src/test/php/lang/ast/unittest/emit/NamespacesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NamespacesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\Date;
 
 class NamespacesTest extends EmittingTest {

--- a/src/test/php/lang/ast/unittest/emit/NullCoalesceAssignmentTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NullCoalesceAssignmentTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class NullCoalesceAssignmentTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/NullCoalesceTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NullCoalesceTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Action, Assert, Test};
+use test\{Action, Assert, Test};
 
 class NullCoalesceTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/NullSafeTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NullSafeTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Nullsafe operator support

--- a/src/test/php/lang/ast/unittest/emit/OmitConstModifiersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/OmitConstModifiersTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\ast\emit\{PHP, OmitConstModifiers};
+use lang\ast\emit\{OmitConstModifiers, PHP};
 use lang\ast\nodes\{Constant, Literal};
 use lang\ast\types\IsLiteral;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class OmitConstModifiersTest extends EmitterTraitTest {
 

--- a/src/test/php/lang/ast/unittest/emit/OmitTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/OmitTypesTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\ast\emit\{OmitPropertyTypes, OmitReturnTypes};
 use lang\ast\types\IsLiteral;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class OmitTypesTest {
   use OmitPropertyTypes, OmitReturnTypes;

--- a/src/test/php/lang/ast/unittest/emit/PHP81Test.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PHP81Test.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\Type;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class PHP81Test extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/PHP82Test.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PHP82Test.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\Type;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class PHP82Test extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\{ArrayType, MapType, Primitive, Type, Value, XPClass};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Test, Values, Action};
+use test\verify\Runtime;
+use test\{Action, Assert, Test, Values};
 
 class ParameterTest extends EmittingTest {
   use NullableSupport;
@@ -38,7 +38,7 @@ class ParameterTest extends EmittingTest {
     Assert::equals(Type::$VAR, $this->param('$param')->getType());
   }
 
-  #[Test, Values('special')]
+  #[Test, Values(from: 'special')]
   public function with_special_type($declaration, $type) {
     Assert::equals($type, $this->param($declaration)->getType());
   }
@@ -73,7 +73,7 @@ class ParameterTest extends EmittingTest {
     Assert::equals($this->nullable(Primitive::$STRING), $this->param('?string $param')->getType());
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1")')]
+  #[Test, Runtime(php: '>=7.1')]
   public function nullable_string_type_restriction() {
     Assert::equals($this->nullable(Primitive::$STRING), $this->param('?string $param')->getTypeRestriction());
   }

--- a/src/test/php/lang/ast/unittest/emit/PrecedenceTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PrecedenceTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class PrecedenceTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/PropertyTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PropertyTypesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Property types

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Error;
-use unittest\{Assert, Expect, Ignore, Values, Test};
+use test\{Assert, Expect, Ignore, Test, Values};
 
 /**
  * Readonly classes and properties
@@ -70,7 +70,7 @@ class ReadonlyTest extends EmittingTest {
     Assert::equals('Test', $t->newInstance('Test')->fixture);
   }
 
-  #[Test, Values('modifiers')]
+  #[Test, Values(from: 'modifiers')]
   public function reading_from_class($modifiers) {
     $t= $this->type('class <T> {
       public function __construct('.$modifiers.' readonly string $fixture) { }
@@ -99,7 +99,7 @@ class ReadonlyTest extends EmittingTest {
     Assert::equals('Test', $i->run());
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access protected property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access protected property .+fixture/')]
   public function cannot_read_protected() {
     $t= $this->type('class <T> {
       public function __construct(protected readonly string $fixture) { }
@@ -107,7 +107,7 @@ class ReadonlyTest extends EmittingTest {
     $t->newInstance('Test')->fixture;
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access protected property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access protected property .+fixture/')]
   public function cannot_write_protected() {
     $t= $this->type('class <T> {
       public function __construct(protected readonly string $fixture) { }
@@ -115,7 +115,7 @@ class ReadonlyTest extends EmittingTest {
     $t->newInstance('Test')->fixture= 'Modified';
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access private property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access private property .+fixture/')]
   public function cannot_read_private() {
     $t= $this->type('class <T> {
       public function __construct(private readonly string $fixture) { }
@@ -123,7 +123,7 @@ class ReadonlyTest extends EmittingTest {
     $t->newInstance('Test')->fixture;
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access private property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access private property .+fixture/')]
   public function cannot_write_private() {
     $t= $this->type('class <T> {
       public function __construct(private readonly string $fixture) { }
@@ -151,7 +151,7 @@ class ReadonlyTest extends EmittingTest {
     Assert::equals('Test', $i->fixture);
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot initialize readonly property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot initialize readonly property .+fixture/')]
   public function cannot_initialize_from_outside() {
     $t= $this->type('class <T> {
       public readonly string $fixture;
@@ -159,7 +159,7 @@ class ReadonlyTest extends EmittingTest {
     $t->newInstance()->fixture= 'Test';
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot modify readonly property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot modify readonly property .+fixture/')]
   public function cannot_be_set_after_initialization() {
     $t= $this->type('class <T> {
       public function __construct(public readonly string $fixture) { }
@@ -174,13 +174,13 @@ class ReadonlyTest extends EmittingTest {
     }');
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot create dynamic property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot create dynamic property .+fixture/')]
   public function cannot_read_dynamic_members_from_readonly_classes() {
     $t= $this->type('readonly class <T> { }');
     $t->newInstance()->fixture;
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot create dynamic property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot create dynamic property .+fixture/')]
   public function cannot_write_dynamic_members_from_readonly_classes() {
     $t= $this->type('readonly class <T> { }');
     $t->newInstance()->fixture= true;

--- a/src/test/php/lang/ast/unittest/emit/ReflectionTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReflectionTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\Reflection;
-use lang\{Value, Enum, ClassNotFoundException, ClassLoader};
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Test, Expect};
+use lang\{ClassLoader, ClassNotFoundException, Enum, Value};
+use test\verify\Runtime;
+use test\{Action, Assert, Expect, Test};
 
 class ReflectionTest {
 
@@ -40,7 +40,7 @@ class ReflectionTest {
     Assert::false($reflect->rewriteEnumCase('EMPTY'));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion("<8.1")')]
+  #[Test, Runtime(php: '<8.1')]
   public function rewrites_simulated_unit_enums() {
     $spec= ['kind' => 'class', 'extends' => null, 'implements' => [\UnitEnum::class], 'use' => []];
     $t= ClassLoader::defineType('ReflectionTestSimulatedEnum', $spec, '{
@@ -58,7 +58,7 @@ class ReflectionTest {
     Assert::false($reflect->rewriteEnumCase('EMPTY'));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.1")')]
+  #[Test, Runtime(php: '>=8.1')]
   public function does_not_rewrite_native_enums() {
     $spec= ['kind' => 'enum', 'extends' => null, 'implements' => [], 'use' => []];
     $t= ClassLoader::defineType('ReflectionTestNativeEnum', $spec, '{

--- a/src/test/php/lang/ast/unittest/emit/ReturnTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReturnTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class ReturnTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/RewriteClassOnObjectsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/RewriteClassOnObjectsTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\{PHP, RewriteClassOnObjects};
-use lang\ast\nodes\{ScopeExpression, Variable, Literal, ClassDeclaration};
+use lang\ast\nodes\{ClassDeclaration, Literal, ScopeExpression, Variable};
 use lang\ast\types\IsValue;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class RewriteClassOnObjectsTest extends EmitterTraitTest {
 

--- a/src/test/php/lang/ast/unittest/emit/RewriteLambdaExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/RewriteLambdaExpressionsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\{PHP, RewriteLambdaExpressions};
-use lang\ast\nodes\{LambdaExpression, ReturnStatement, Signature, Literal, Block};
-use unittest\{Assert, Test};
+use lang\ast\nodes\{Block, LambdaExpression, Literal, ReturnStatement, Signature};
+use test\{Assert, Test};
 
 class RewriteLambdaExpressionsTest extends EmitterTraitTest {
 

--- a/src/test/php/lang/ast/unittest/emit/RewriteMultiCatchTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/RewriteMultiCatchTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\{PHP, RewriteMultiCatch};
-use lang\ast\nodes\{TryStatement, CatchStatement};
-use unittest\{Assert, Test};
+use lang\ast\nodes\{CatchStatement, TryStatement};
+use test\{Assert, Test};
 
 class RewriteMultiCatchTest extends EmitterTraitTest {
 

--- a/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class ScalarsTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/SyntaxErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/SyntaxErrorsTest.class.php
@@ -2,21 +2,21 @@
 
 use lang\IllegalStateException;
 use lang\ast\Errors;
-use unittest\{Assert, Expect, Test};
+use test\{Assert, Expect, Test};
 
 class SyntaxErrorsTest extends EmittingTest {
 
-  #[Test, Expect(class: Errors::class, withMessage: 'Missing semicolon after assignment statement')]
+  #[Test, Expect(class: Errors::class, message: 'Missing semicolon after assignment statement')]
   public function missing_semicolon() {
     $this->emit('$greeting= hello() world()');
   }
 
-  #[Test, Expect(class: Errors::class, withMessage: 'Unexpected :')]
+  #[Test, Expect(class: Errors::class, message: 'Unexpected :')]
   public function unexpected_colon() {
     $this->emit('$greeting= hello();:');
   }
 
-  #[Test, Expect(class: IllegalStateException::class, withMessage: 'Unexpected operator = at line 1')]
+  #[Test, Expect(class: IllegalStateException::class, message: 'Unexpected operator = at line 1')]
   public function operator() {
     $this->emit('=;');
   }

--- a/src/test/php/lang/ast/unittest/emit/SyntaxErrorsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/SyntaxErrorsTest.class.php
@@ -6,17 +6,17 @@ use test\{Assert, Expect, Test};
 
 class SyntaxErrorsTest extends EmittingTest {
 
-  #[Test, Expect(class: Errors::class, message: 'Missing semicolon after assignment statement')]
+  #[Test, Expect(class: Errors::class, message: '/Missing semicolon after assignment statement/')]
   public function missing_semicolon() {
     $this->emit('$greeting= hello() world()');
   }
 
-  #[Test, Expect(class: Errors::class, message: 'Unexpected :')]
+  #[Test, Expect(class: Errors::class, message: '/Unexpected :/')]
   public function unexpected_colon() {
     $this->emit('$greeting= hello();:');
   }
 
-  #[Test, Expect(class: IllegalStateException::class, message: 'Unexpected operator = at line 1')]
+  #[Test, Expect(class: IllegalStateException::class, message: '/Unexpected operator =/')]
   public function operator() {
     $this->emit('=;');
   }

--- a/src/test/php/lang/ast/unittest/emit/TernaryTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TernaryTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use io\Path;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class TernaryTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/TrailingCommasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TrailingCommasTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class TrailingCommasTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/TraitsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TraitsTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\XPClass;
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Test};
+use test\verify\Runtime;
+use test\{Action, Assert, Test};
 
 /**
  * Traits
@@ -63,7 +63,7 @@ class TraitsTest extends EmittingTest {
     Assert::equals('Not spinning', $t->getMethod('noLongerSpinning')->invoke($instance));
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.2.0-dev")')]
+  #[Test, Runtime(php: '>=8.2.0-dev')]
   public function can_have_constants() {
     $t= $this->type('trait <T> { const FIXTURE = 1; }');
     Assert::equals(1, $t->getConstant('FIXTURE'));

--- a/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
@@ -3,7 +3,7 @@
 use lang\ast\Code;
 use lang\ast\nodes\{Method, Signature};
 use lang\ast\types\IsLiteral;
-use unittest\{Assert, Before, Test, Values};
+use test\{Assert, Before, Test, Values};
 
 class TransformationsTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/TypeDeclarationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TypeDeclarationTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\XPClass;
 use lang\reflect\Modifiers;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 
 class TypeDeclarationTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/UnicodeEscapesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UnicodeEscapesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class UnicodeEscapesTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/UnionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UnionTypesTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\{Primitive, Nullable, Type, TypeUnion};
-use unittest\actions\RuntimeVersion;
-use unittest\{Assert, Test, Action};
+use lang\{Nullable, Primitive, Type, TypeUnion};
+use test\verify\Runtime;
+use test\{Action, Assert, Test};
 
 /**
  * Union types
@@ -71,7 +71,7 @@ class UnionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0.0-dev")')]
+  #[Test, Runtime(php: '>=8.0.0-dev')]
   public function nullable_union_type_restriction() {
     $t= $this->type('class <T> {
       public function test(): int|string|null { }
@@ -83,7 +83,7 @@ class UnionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0.0-dev")')]
+  #[Test, Runtime(php: '>=8.0.0-dev')]
   public function parameter_type_restriction_with_php8() {
     $t= $this->type('class <T> {
       public function test(int|string|array<string> $arg) { }
@@ -95,7 +95,7 @@ class UnionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0.0-dev")')]
+  #[Test, Runtime(php: '>=8.0.0-dev')]
   public function parameter_function_type_restriction_with_php8() {
     $t= $this->type('class <T> {
       public function test(): string|(function(): string) { }
@@ -107,7 +107,7 @@ class UnionTypesTest extends EmittingTest {
     );
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=8.0.0-dev")')]
+  #[Test, Runtime(php: '>=8.0.0-dev')]
   public function return_type_restriction_with_php8() {
     $t= $this->type('class <T> {
       public function test(): int|string|array<string> { }

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /**
  * Using statement and disposables

--- a/src/test/php/lang/ast/unittest/emit/VarargsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/VarargsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class VarargsTest extends EmittingTest {
 

--- a/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\ast\emit\php\{XpMeta, VirtualPropertyTypes};
+use lang\ast\emit\php\{VirtualPropertyTypes, XpMeta};
 use lang\{Error, Primitive};
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 
 class VirtualPropertyTypesTest extends EmittingTest {
 
@@ -27,7 +27,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
     Assert::equals(MODIFIER_PRIVATE, $t->getField('value')->getModifiers());
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access private property .+::\\$value/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access private property .+::\\$value/')]
   public function cannot_read_private_field() {
     $t= $this->type('class <T> {
       private int $value;
@@ -36,7 +36,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
     $t->newInstance()->value;
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access private property .+::\\$value/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access private property .+::\\$value/')]
   public function cannot_write_private_field() {
     $t= $this->type('class <T> {
       private int $value;
@@ -45,7 +45,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
     $t->newInstance()->value= 6100;
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access protected property .+::\\$value/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access protected property .+::\\$value/')]
   public function cannot_read_protected_field() {
     $t= $this->type('class <T> {
       protected int $value;
@@ -54,7 +54,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
     $t->newInstance()->value;
   }
 
-  #[Test, Expect(class: Error::class, withMessage: '/Cannot access protected property .+::\\$value/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot access protected property .+::\\$value/')]
   public function cannot_write_protected_field() {
     $t= $this->type('class <T> {
       protected int $value;
@@ -87,7 +87,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
     Assert::equals(6100, $t->getField('value')->setAccessible(true)->get($t->newInstance()));
   }
 
-  #[Test, Values([[null], ['Test'], [[]]]), Expect(class: Error::class, withMessage: '/property .+::\$value of type int/')]
+  #[Test, Values([[null], ['Test'], [[]]]), Expect(class: Error::class, message: '/property .+::\$value of type int/')]
   public function type_checked_at_runtime($in) {
     $this->run('class <T> {
       private int $value;

--- a/src/test/php/lang/ast/unittest/emit/YieldTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/YieldTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 /** @see http://php.net/manual/en/language.generators.syntax.php */
 class YieldTest extends EmittingTest {

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -2,9 +2,9 @@
 
 use io\{File, Files, Folder};
 use lang\ast\CompilingClassLoader;
-use lang\{ClassFormatException, ClassNotFoundException, ElementNotFoundException, ClassLoader, Environment};
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Expect, Test, Values};
+use lang\{ClassFormatException, ClassLoader, ClassNotFoundException, ElementNotFoundException, Environment};
+use test\verify\Runtime;
+use test\{Action, Assert, Expect, Test, Values};
 
 class CompilingClassLoaderTest {
   private static $runtime;
@@ -131,14 +131,14 @@ class CompilingClassLoaderTest {
     Assert::equals('Tests', $class->getSimpleName());
   }
 
-  #[Test, Expect(class: ClassFormatException::class, withMessage: 'Compiler error: Expected "type name", have "(end)"')]
+  #[Test, Expect(class: ClassFormatException::class, message: 'Compiler error: Expected "type name", have "(end)"')]
   public function load_class_with_syntax_errors() {
     $this->compile(['Errors' => "<?php\nclass"], function($loader, $types) {
       return $loader->loadClass($types['Errors']);
     });
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.3")'), Expect(class: ClassFormatException::class, withMessage: '/Compiler error: Class .+ not found/')]
+  #[Test, Runtime(php: '>=7.3'), Expect(class: ClassFormatException::class, message: '/Compiler error: Class .+ not found/')]
   public function load_class_with_non_existant_parent() {
     $code= "<?php namespace %s;\nclass Orphan extends NotFound { }";
     $this->compile(['Orphan' => $code], function($loader, $types) {

--- a/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
+++ b/src/test/php/lang/ast/unittest/loader/CompilingClassLoaderTest.class.php
@@ -131,7 +131,7 @@ class CompilingClassLoaderTest {
     Assert::equals('Tests', $class->getSimpleName());
   }
 
-  #[Test, Expect(class: ClassFormatException::class, message: 'Compiler error: Expected "type name", have "(end)"')]
+  #[Test, Expect(class: ClassFormatException::class, message: '/Compiler error: Expected "type name", have .+/')]
   public function load_class_with_syntax_errors() {
     $this->compile(['Errors' => "<?php\nclass"], function($loader, $types) {
       return $loader->loadClass($types['Errors']);


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Mostly migrated automatically, needed a small fix for imports from global namespace (`use Traversable;`), using patterns inside `#[Expect]` which previously supported substring matches and adjustments to not use `fn()`-syntax inside `#[Condition]`.

## Metrics
Before
```
Tests:       902 passed, 4 skipped
Memory used: 12261.99 kB (12314.85 kB peak)
Time taken:  0.231 seconds
```

After
```
Test cases:  902 succeeded, 4 skipped
Memory used: 11046.30 kB (11100.43 kB peak)
Time taken:  0.248 seconds (1.403 seconds overall)
```