### PR TITLE
Do not error at compile time for unresolved classes

### DIFF
--- a/src/main/php/lang/ast/emit/GeneratedCode.class.php
+++ b/src/main/php/lang/ast/emit/GeneratedCode.class.php
@@ -80,6 +80,10 @@ class GeneratedCode extends Result {
       }
     }
 
-    return new Reflection($type);
+    if (class_exists($type) || interface_exists($type) || trait_exists($type) || enum_exists($type)) {
+      return new Reflection($type);
+    } else {
+      return new Incomplete($type);
+    }
   }
 }

--- a/src/main/php/lang/ast/emit/Incomplete.class.php
+++ b/src/main/php/lang/ast/emit/Incomplete.class.php
@@ -1,0 +1,21 @@
+<?php namespace lang\ast\emit;
+
+class Incomplete extends Type {
+  private $name;
+
+  /** @param string $name */
+  public function __construct($name) { $this->name= $name; }
+
+  /** @return string */
+  public function name() { return $this->name; }
+
+  /**
+   * Returns whether a given member is an enum case
+   *
+   * @param  string $member
+   * @return bool
+   */
+  public function rewriteEnumCase($member) {
+    return false;
+  }
+}

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -994,7 +994,11 @@ abstract class PHP extends Emitter {
       $result->out->write(')?'.$t.'::');
       $this->emitOne($result, $scope->member);
       $result->out->write(':null');
-    } else if ($scope->member instanceof Literal && $result->lookup($scope->type)->rewriteEnumCase($scope->member->expression)) {
+    } else if (
+      $scope->member instanceof Literal &&
+      'class' !== $scope->member->literal &&
+      $result->lookup($scope->type)->rewriteEnumCase($scope->member->expression)
+    ) {
       $result->out->write($scope->type.'::$'.$scope->member->expression);
     } else {
       $result->out->write($scope->type.'::');

--- a/src/test/php/lang/ast/unittest/emit/GeneratedCodeTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/GeneratedCodeTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use io\streams\MemoryOutputStream;
-use lang\ast\emit\{Declaration, Escaping, GeneratedCode, InType, Reflection};
+use lang\ast\emit\{Declaration, Escaping, GeneratedCode, InType, Reflection, Incomplete};
 use lang\ast\nodes\ClassDeclaration;
 use lang\ast\types\IsValue;
 use lang\{ClassNotFoundException, Value};
@@ -83,10 +83,10 @@ class GeneratedCodeTest {
     Assert::equals(new Reflection(Value::class), $r->lookup('\\lang\\Value'));
   }
 
-  #[Test, Expect(ClassNotFoundException::class)]
+  #[Test]
   public function lookup_non_existant() {
     $r= new GeneratedCode(new MemoryOutputStream());
-    $r->lookup('\\NotFound');
+    Assert::instance(Incomplete::class, $r->lookup('\\NotFound'));
   }
 
   #[Test]


### PR DESCRIPTION
This error prevents compiling the following code:

```php
use lang\Reflection;
use util\cmd\Console;

#[Author('Timm Friebe')]
class HelloWorld {

  /** Entry point */
  public static function main(array<string> $args): void {
    $author= Reflection::type(self::class)->annotation(Author::class)->argument(0);
    Console::writeLine('Author: ', $author);
  }
}
```

Instead of having an actual type for the `Author` annotation, we simply access its arguments. However, we still need to be able to resolve `::class`.