### PR TITLE
Implement unchecked types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "^9.2",
+    "xp-framework/ast": "dev-feature/unchecked-types as 9.3.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -2,7 +2,18 @@
 
 use lang\ast\Node;
 use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal, Variable};
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 7.0 syntax
@@ -56,7 +67,8 @@ class PHP70 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -1,6 +1,17 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 7.1 syntax
@@ -52,7 +63,8 @@ class PHP71 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 }

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -1,6 +1,17 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 7.2 syntax
@@ -51,7 +62,8 @@ class PHP72 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 }

--- a/src/main/php/lang/ast/emit/PHP73.class.php
+++ b/src/main/php/lang/ast/emit/PHP73.class.php
@@ -1,6 +1,17 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 7.3 syntax. Same as PHP 7.2 but supports list reference assignments
@@ -51,7 +62,8 @@ class PHP73 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -1,6 +1,17 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 7.4 syntax
@@ -48,7 +59,8 @@ class PHP74 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 }

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -1,7 +1,18 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 8.0 syntax
@@ -48,7 +59,8 @@ class PHP80 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 }

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -1,7 +1,18 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 8.1 syntax
@@ -54,7 +65,8 @@ class PHP81 extends PHP {
         $l= $t->literal();
         return (1 === ($r= $rewrite[$l] ?? $l)) ? null : $r;
       },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 }

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -1,7 +1,18 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnchecked,
+  IsUnion,
+  IsValue
+};
 
 /**
  * PHP 8.2 syntax
@@ -40,7 +51,8 @@ class PHP82 extends PHP {
         return substr($u, 1);
       },
       IsLiteral::class      => function($t) { return $t->literal(); },
-      IsGeneric::class      => function($t) { return null; }
+      IsGeneric::class      => function($t) { return null; },
+      IsUnchecked::class    => function($t) { return null; },
     ];
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
@@ -139,4 +139,12 @@ class ParameterTest extends EmittingTest {
     ;
     Assert::equals(1, sizeof($p), 'number of parameters');
   }
+
+  #[Test]
+  public function soft_string_typed() {
+    $param= $this->param('@string $param');
+
+    Assert::null($param->getTypeRestriction());
+    Assert::equals(Primitive::$STRING, $param->getType());
+  }
 }


### PR DESCRIPTION
These types only end up in the type meta information.

```php
class Fixture {
  public function verified(string $param) { }
  public function unchecked(@string $param) { }
}

$f= new Fixture();
$t->verified(null);  // Exception
$t->unchecked(null); // Works
```

This is equivalent to using API docs only; however, the syntax is checked, whereas in the following, it isn't:

```php
class Fixture {
  public function verified(string $param) { }

  /** @param string $param */
  public function unchecked($param) { }
}
```

In reflection, a parameter type is available but not reported as a constraint.

```php
use lang\Reflection;

$r= Reflection::type(Fixture::class);

// Verified method
$c= $r->method('verified')->parameter(0)->constraint();
$c->type();    // Primitive::$STRING
$c->present(); // true

// Unchecked method
$c= $r->method('unchecked')->parameter(0)->constraint();
$c->type();    // Primitive::$STRING
$c->present(); // false
```

* Depends on https://github.com/xp-framework/ast/pull/42
* See https://github.com/xp-framework/compiler/issues/119#issuecomment-1427022356 