### PR TITLE
Add support for omitting property types at compile time

### DIFF
--- a/src/main/php/lang/ast/emit/php/WithoutPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/php/WithoutPropertyTypes.class.php
@@ -1,0 +1,12 @@
+<?php namespace lang\ast\emit\php;
+
+trait WithoutPropertyTypes {
+
+  /**
+   * Returns type for use in properties, or NULL to use no type.
+   *
+   * @param  ?lang.ast.Type $type
+   * @return ?string
+   */
+  protected function propertyType($type) { return null; }
+}


### PR DESCRIPTION
This pull request makes it possible to omit property types at compile time. 

## Usage
Given the following source code:

```php
class Types {
  private string $name;
}
```

Typical compilation:
```bash
$ xp compile -q Types.php
<?php

 class Types{
private string $name;static function __init() {}} Types::__init();;
```

Compile without property types:
```bash
$ xp compile -q -a php:without-property-types Types.php
<?php

 class Types{
private  $name;static function __init() {}} Types::__init();;
```

Originally requested in https://github.com/xp-framework/compiler/issues/119 
