### PR TITLE
Implement command line option to set file extension for compiled files

### DIFF
--- a/src/main/php/xp/compiler/CompileRunner.class.php
+++ b/src/main/php/xp/compiler/CompileRunner.class.php
@@ -69,6 +69,7 @@ class CompileRunner {
     $in= $out= '-';
     $quiet= false;
     $augment= [];
+    $ext= \xp::CLASS_FILE_EXT;
     for ($i= 0; $i < sizeof($args); $i++) {
       if ('-t' === $args[$i]) {
         $target= $args[++$i];
@@ -78,6 +79,8 @@ class CompileRunner {
         $out= $args[++$i];
         $in= array_slice($args, $i + 1);
         break;
+      } else if ('-e' === $args[$i]) {
+        $ext= $args[++$i];
       } else if ('-n' === $args[$i]) {
         $out= null;
         $in= array_slice($args, $i + 1);
@@ -98,7 +101,7 @@ class CompileRunner {
     }
 
     $input= Input::newInstance($in);
-    $output= Output::newInstance($out);
+    $output= Output::newInstance($out)->using($ext);
 
     $t= new Timer();
     $total= $errors= 0;

--- a/src/main/php/xp/compiler/Output.class.php
+++ b/src/main/php/xp/compiler/Output.class.php
@@ -3,6 +3,7 @@
 use util\cmd\Console;
 
 abstract class Output {
+  protected $extension= \xp::CLASS_FILE_EXT;
 
   /**
    * Returns output from the command line argument
@@ -22,6 +23,17 @@ abstract class Output {
     } else {
       return new ToFolder($arg);
     }
+  }
+
+  /**
+   * Change file extension, which defaults to `xp::CLASS_FILE_EXT`.
+   *
+   * @param  string $extension
+   * @return self
+   */
+  public function using($extension) {
+    $this->extension= '.' === $extension[0] ? $extension : '.'.$extension;
+    return $this;
   }
 
   /**

--- a/src/main/php/xp/compiler/ToArchive.class.php
+++ b/src/main/php/xp/compiler/ToArchive.class.php
@@ -21,15 +21,21 @@ class ToArchive extends Output {
    * @return io.streams.OutputStream
    */
   public function target($name) {
-    return new class($this->archive, $name) implements OutputStream {
-      private static $replace= [DIRECTORY_SEPARATOR => '/', '.php' => \xp::CLASS_FILE_EXT];
+    return new class($this->archive, $name, $this->extension) implements OutputStream {
+      private $archive, $name, $replace;
       private $bytes= '';
-      private $archive, $name;
 
-      public function __construct($archive, $name) { $this->archive= $archive; $this->name= $name; }
+      public function __construct($archive, $name, $extension) {
+        $this->archive= $archive;
+        $this->name= $name;
+        $this->replace= [DIRECTORY_SEPARATOR => '/', '.php' => $extension];
+      }
+
       public function write($bytes) { $this->bytes.= $bytes; }
+
       public function flush() {  }
-      public function close() { $this->archive->addBytes(strtr($this->name, self::$replace), $this->bytes); }
+
+      public function close() { $this->archive->addBytes(strtr($this->name, $this->replace), $this->bytes); }
     };
   }
 

--- a/src/main/php/xp/compiler/ToFolder.class.php
+++ b/src/main/php/xp/compiler/ToFolder.class.php
@@ -18,9 +18,9 @@ class ToFolder extends ToFileSystem {
    */
   public function target($name) {
     if ('-' === $name) {
-      $f= new File($this->folder, 'out'.\xp::CLASS_FILE_EXT);
+      $f= new File($this->folder, 'out'.$this->extension);
     } else {
-      $f= new File($this->folder, str_replace('.php', \xp::CLASS_FILE_EXT, $name));
+      $f= new File($this->folder, str_replace('.php', $this->extension, $name));
     }
     $this->ensure($f->path);
     return $f->out();

--- a/src/test/php/lang/ast/unittest/cli/ToFolderTest.class.php
+++ b/src/test/php/lang/ast/unittest/cli/ToFolderTest.class.php
@@ -28,10 +28,10 @@ class ToFolderTest {
 
   #[Test]
   public function dash_special_case() {
-    with ((new ToFolder($this->folder))->target('-'), function($out) {
+    with ((new ToFolder($this->folder))->using('.php')->target('-'), function($out) {
       $out->write('<?php ...');
     });
-    Assert::true((new File($this->folder, 'out'.\xp::CLASS_FILE_EXT))->exists());
+    Assert::true((new File($this->folder, 'out.php'))->exists());
   }
 
   #[Test]


### PR DESCRIPTION
Default:

```bash
$ xp compile HelloWorld.php dist/
# ...

$ ls -al dist/HelloWorld*
-rwxr-xr-x 1 timmf timmf 519 Feb 19 13:12 dist/HelloWorld.class.php
```

Using `.php` file extension:

```bash
$ xp compile -e .php HelloWorld.php dist/
# ...

$ ls -al dist/HelloWorld*
-rwxr-xr-x 1 timmf timmf 519 Feb 19 13:13 dist/HelloWorld.php
```

See https://github.com/xp-framework/compiler/pull/158#issuecomment-1435988175