### PR TITLE
Support dynamic class constant fetch

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@ XP Compiler ChangeLog
 
 ## ?.?.? / ????-??-??
 
+## 8.10.0 / 2023-04-08
+
+* Merged PR #161: Support dynamic class constant fetch, the first PHP
+  8.3 feature: https://wiki.php.net/rfc/dynamic_class_constant_fetch
+  (@thekid)
+
 ## 8.9.0 / 2023-02-19
 
 * Merged PR #159: Implement command line option to set file extension

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "dev-feature/expressions as 10.0.0",
+    "xp-framework/ast": "dev-feature/expressions as 9.99.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "^9.2",
+    "xp-framework/ast": "dev-feature/expressions as 10.0.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^11.0 | ^10.0",
-    "xp-framework/ast": "dev-feature/expressions as 9.99.0",
+    "xp-framework/ast": "^10.0",
     "php" : ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/ArbitrayNewExpressions.class.php
+++ b/src/main/php/lang/ast/emit/ArbitrayNewExpressions.class.php
@@ -14,8 +14,8 @@ trait ArbitrayNewExpressions {
     if (!($new->type instanceof IsExpression)) return parent::emitNew($result, $new);
 
     // Emit supported `new $var`, rewrite unsupported `new ($expr)`
-    if ($new->type->expression instanceof Variable) {
-      $result->out->write('new $'.$new->type->expression->name.'(');
+    if ($new->type->expression instanceof Variable && $new->type->expression->const) {
+      $result->out->write('new $'.$new->type->expression->pointer.'(');
       $this->emitArguments($result, $new->arguments);
       $result->out->write(')');
     } else {

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal};
+use lang\ast\nodes\{Expression, InstanceExpression, ScopeExpression, Literal};
 
 /**
  * Rewrites callable expressions to `Callable::fromClosure()`
@@ -36,6 +36,10 @@ trait CallablesAsClosures {
       $result->out->write(',');
       $this->emitQuoted($result, $node->member);
       $result->out->write(']');
+    } else if ($node instanceof Expression) {
+
+      // Rewrite T::{<f>} => [T::class, <f>]
+      $this->emitOne($result, $node->inline);
     } else {
 
       // Emit other expressions as-is

--- a/src/main/php/lang/ast/emit/NullsafeAsTernaries.class.php
+++ b/src/main/php/lang/ast/emit/NullsafeAsTernaries.class.php
@@ -12,13 +12,6 @@ trait NullsafeAsTernaries {
     $result->out->write('null===('.$t.'=');
     $this->emitOne($result, $instance->expression);
     $result->out->write(')?null:'.$t.'->');
-
-    if ('literal' === $instance->member->kind) {
-      $result->out->write($instance->member->expression);
-    } else {
-      $result->out->write('{');
-      $this->emitOne($result, $instance->member);
-      $result->out->write('}');
-    }
+    $this->emitOne($result, $instance->member);
   }
 }

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\emit;
 
 use lang\ast\Node;
-use lang\ast\nodes\{InstanceExpression, ScopeExpression, Literal, Variable};
+use lang\ast\nodes\{Expression, InstanceExpression, ScopeExpression, Literal, Variable};
 use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
 
 /**
@@ -74,6 +74,9 @@ class PHP70 extends PHP {
       $this->emitOne($result, $callable->expression->expression);
       if ($callable->expression->member instanceof Literal) {
         $result->out->write(',"'.trim($callable->expression->member, '"\'').'"');
+      } else if ($callable->expression->member instanceof Expression) {
+        $result->out->write(',');
+        $this->emitOne($result, $callable->expression->member->inline);
       } else {
         $result->out->write(',');
         $this->emitOne($result, $callable->expression->member);
@@ -90,6 +93,9 @@ class PHP70 extends PHP {
       }
       if ($callable->expression->member instanceof Literal) {
         $result->out->write(',"'.trim($callable->expression->member, '"\'').'"');
+      } else if ($callable->expression->member instanceof Expression) {
+        $result->out->write(',');
+        $this->emitOne($result, $callable->expression->member->inline);
       } else {
         $result->out->write(',');
         $this->emitOne($result, $callable->expression->member);

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -9,7 +9,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteExplicitOctals, RewriteEnums;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, RewriteExplicitOctals, RewriteEnums;
   use ReadonlyClasses, ReadonlyProperties, CallablesAsClosures, ArrayUnpackUsingMerge;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_81
  */
 class PHP81 extends PHP {
-  use RewriteBlockLambdaExpressions, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -10,7 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_82
  */
 class PHP82 extends PHP {
-  use RewriteBlockLambdaExpressions, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP83.class.php
+++ b/src/main/php/lang/ast/emit/PHP83.class.php
@@ -1,0 +1,45 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\Node;
+use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNullable, IsValue, IsLiteral, IsGeneric};
+
+/**
+ * PHP 8.3 syntax
+ *
+ * @see  https://wiki.php.net/rfc#php_83
+ */
+class PHP83 extends PHP {
+  use RewriteBlockLambdaExpressions, ReadonlyClasses;
+
+  /** Sets up type => literal mappings */
+  public function __construct() {
+    $this->literals= [
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsValue::class        => function($t) { return $t->literal(); },
+      IsNullable::class     => function($t) {
+        if (null === ($l= $this->literal($t->element))) return null;
+        return $t->element instanceof IsUnion ? $l.'|null' : '?'.$l;
+      },
+      IsIntersection::class => function($t) {
+        $i= '';
+        foreach ($t->components as $component) {
+          if (null === ($l= $this->literal($component))) return null;
+          $i.= '&'.$l;
+        }
+        return substr($i, 1);
+      },
+      IsUnion::class        => function($t) {
+        $u= '';
+        foreach ($t->components as $component) {
+          if (null === ($l= $this->literal($component))) return null;
+          $u.= '|'.$l;
+        }
+        return substr($u, 1);
+      },
+      IsLiteral::class      => function($t) { return $t->literal(); },
+      IsGeneric::class      => function($t) { return null; }
+    ];
+  }
+}

--- a/src/main/php/lang/ast/emit/RewriteClassOnObjects.class.php
+++ b/src/main/php/lang/ast/emit/RewriteClassOnObjects.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\nodes\Literal;
+use lang\ast\nodes\{Expression, Literal};
 
 /**
  * Rewrites `[expr]::class` to `get_class($object)` except if expression
@@ -9,6 +9,7 @@ use lang\ast\nodes\Literal;
  * @see  https://wiki.php.net/rfc/class_name_literal_on_object
  */
 trait RewriteClassOnObjects {
+  use RewriteDynamicClassConstants { emitScope as rewriteDynamicClassConstants; }
 
   protected function emitScope($result, $scope) {
     if ($scope->member instanceof Literal && 'class' === $scope->member->expression && !is_string($scope->type)) {
@@ -16,7 +17,7 @@ trait RewriteClassOnObjects {
       $this->emitOne($result, $scope->type);
       $result->out->write(')');
     } else {
-      parent::emitScope($result, $scope);
+      $this->rewriteDynamicClassConstants($result, $scope);
     }
   }
 }

--- a/src/main/php/lang/ast/emit/RewriteDynamicClassConstants.class.php
+++ b/src/main/php/lang/ast/emit/RewriteDynamicClassConstants.class.php
@@ -1,0 +1,21 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\nodes\Expression;
+
+/**
+ * Rewrite dynamic class constants, e.g. `T::{<expr>}`.
+ *
+ * @see  https://wiki.php.net/rfc/dynamic_class_constant_fetch
+ */
+trait RewriteDynamicClassConstants {
+
+  protected function emitScope($result, $scope) {
+    if ($scope->member instanceof Expression && -1 !== $scope->line) {
+      $result->out->write('constant('.$scope->type.'::class."::".');
+      $this->emitOne($result, $scope->member->inline);
+      $result->out->write(')');
+    } else {
+      parent::emitScope($result, $scope);
+    }
+  }
+}

--- a/src/test/php/lang/ast/unittest/EmitterTest.class.php
+++ b/src/test/php/lang/ast/unittest/EmitterTest.class.php
@@ -74,7 +74,10 @@ class EmitterTest {
   #[Test]
   public function transform_modifying_node() {
     $fixture= $this->newEmitter();
-    $fixture->transform('variable', function($codegen, $var) { $var->name= '_'.$var->name; return $var; });
+    $fixture->transform('variable', function($codegen, $var) {
+      $var->pointer= '_'.$var->pointer;
+      return $var;
+    });
     $out= $fixture->write([new Variable('a')], new MemoryOutputStream());
 
     Assert::equals('<?php $_a;', $out->bytes());
@@ -83,7 +86,9 @@ class EmitterTest {
   #[Test]
   public function transform_to_node() {
     $fixture= $this->newEmitter();
-    $fixture->transform('variable', function($codegen, $var) { return new Code('$variables["'.$var->name.'"]'); });
+    $fixture->transform('variable', function($codegen, $var) {
+      return new Code('$variables["'.$var->pointer.'"]');
+    });
     $out= $fixture->write([new Variable('a')], new MemoryOutputStream());
 
     Assert::equals('<?php $variables["a"];', $out->bytes());
@@ -92,7 +97,9 @@ class EmitterTest {
   #[Test]
   public function transform_to_array() {
     $fixture= $this->newEmitter();
-    $fixture->transform('variable', function($codegen, $var) { return [new Code('$variables["'.$var->name.'"]')]; });
+    $fixture->transform('variable', function($codegen, $var) {
+      return [new Code('$variables["'.$var->pointer.'"]')];
+    });
     $out= $fixture->write([new Variable('a')], new MemoryOutputStream());
 
     Assert::equals('<?php $variables["a"];;', $out->bytes());

--- a/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
@@ -27,6 +27,30 @@ class InstantiationTest extends EmittingTest {
   }
 
   #[Test]
+  public function new_dynamic_var() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $class= \\util\\Date::class;
+        $var= "class";
+        return new $$var();
+      }
+    }');
+    Assert::instance(Date::class, $r);
+  }
+
+  #[Test]
+  public function new_var_expr() {
+    $r= $this->run('class <T> {
+      public function run() {
+        $class= \\util\\Date::class;
+        $var= "class";
+        return new ${$var}();
+      }
+    }');
+    Assert::instance(Date::class, $r);
+  }
+
+  #[Test]
   public function new_expr() {
     $r= $this->run('class <T> {
       private function factory() { return \\util\\Date::class; }

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ArrayType;
-use test\{Assert, Test, Values};
+use test\{Assert, Ignore, Test, Values};
 
 class MembersTest extends EmittingTest {
 
@@ -70,8 +70,78 @@ class MembersTest extends EmittingTest {
     Assert::equals('Test', $r);
   }
 
-  #[Test]
+  #[Test, Values(['$this->$member', '$this->{$member}'])]
+  public function dynamic_instance_property($syntax) {
+    $r= $this->run('class <T> {
+      private $MEMBER= "Test";
+
+      public function run() {
+        $member= "MEMBER";
+        return '.$syntax.';
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[Test, Ignore('Unsupported!')]
   public function dynamic_class_property() {
+    $r= $this->run('class <T> {
+      private static $MEMBER= "Test";
+
+      public function run() {
+        $member= "MEMBER";
+        return self::${$member};
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[Test, Values(['$this->$method()', '$this->{$method}()'])]
+  public function dynamic_instance_method($syntax) {
+    $r= $this->run('class <T> {
+      private function test() { return "Test"; }
+
+      public function run() {
+        $method= "test";
+        return '.$syntax.';
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[Test, Values(['self::$method()', 'self::{$method}()'])]
+  public function dynamic_class_method($syntax) {
+    $r= $this->run('class <T> {
+      private static function test() { return "Test"; }
+
+      public function run() {
+        $method= "test";
+        return '.$syntax.';
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[Test, Ignore('Unsupported!')]
+  public function dynamic_class_constant() {
+    $r= $this->run('class <T> {
+      const MEMBER= "Test";
+
+      public function run() {
+        $member= "MEMBER";
+        return self::{$member};
+      }
+    }');
+
+    Assert::equals('Test', $r);
+  }
+
+  #[Test]
+  public function property_of_dynamic_class() {
     $r= $this->run('class <T> {
       private static $MEMBER= "Test";
 
@@ -85,7 +155,7 @@ class MembersTest extends EmittingTest {
   }
 
   #[Test]
-  public function dynamic_class_method() {
+  public function method_of_dynamic_class() {
     $r= $this->run('class <T> {
       private static function member() { return "Test"; }
 
@@ -99,7 +169,7 @@ class MembersTest extends EmittingTest {
   }
 
   #[Test]
-  public function dynamic_class_constant() {
+  public function constant_of_dynamic_class() {
     $r= $this->run('class <T> {
       private const MEMBER = "Test";
 

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -70,7 +70,7 @@ class MembersTest extends EmittingTest {
     Assert::equals('Test', $r);
   }
 
-  #[Test, Values(['$this->$member', '$this->{$member}'])]
+  #[Test, Values(['$this->$member', '$this->{$member}', '$this->{strtoupper($member)}'])]
   public function dynamic_instance_property($syntax) {
     $r= $this->run('class <T> {
       private $MEMBER= "Test";
@@ -84,21 +84,21 @@ class MembersTest extends EmittingTest {
     Assert::equals('Test', $r);
   }
 
-  #[Test, Ignore('Unsupported!')]
-  public function dynamic_class_property() {
+  #[Test, Values(['self::$$member', 'self::${$member}', 'self::${strtoupper($member)}'])]
+  public function dynamic_class_property($syntax) {
     $r= $this->run('class <T> {
       private static $MEMBER= "Test";
 
       public function run() {
         $member= "MEMBER";
-        return self::${$member};
+        return '.$syntax.';
       }
     }');
 
     Assert::equals('Test', $r);
   }
 
-  #[Test, Values(['$this->$method()', '$this->{$method}()'])]
+  #[Test, Values(['$this->$method()', '$this->{$method}()', '$this->{strtolower($method)}()'])]
   public function dynamic_instance_method($syntax) {
     $r= $this->run('class <T> {
       private function test() { return "Test"; }
@@ -112,7 +112,7 @@ class MembersTest extends EmittingTest {
     Assert::equals('Test', $r);
   }
 
-  #[Test, Values(['self::$method()', 'self::{$method}()'])]
+  #[Test, Values(['self::$method()', 'self::{$method}()', 'self::{strtolower($method)}()'])]
   public function dynamic_class_method($syntax) {
     $r= $this->run('class <T> {
       private static function test() { return "Test"; }
@@ -126,14 +126,14 @@ class MembersTest extends EmittingTest {
     Assert::equals('Test', $r);
   }
 
-  #[Test, Ignore('Unsupported!')]
-  public function dynamic_class_constant() {
+  #[Test, Values(['self::{$member}', 'self::{strtoupper($member)}'])]
+  public function dynamic_class_constant($syntax) {
     $r= $this->run('class <T> {
       const MEMBER= "Test";
 
       public function run() {
         $member= "MEMBER";
-        return self::{$member};
+        return '.$syntax.';
       }
     }');
 


### PR DESCRIPTION
See https://wiki.php.net/rfc/dynamic_class_constant_fetch and https://github.com/php/php-src/pull/9793

* [x] Instance properties: `$this->$member`, `$this->{$member}`
* [x] Static properties: `self::${$member}`
* [x] Instance methods: `$this->$method()`, `$this->{$method}()`
* [x] Static methods: `self::$method()`, `self::{$method}()`
* [x] Constants: `self::{$member}`

This pull request also fixes support for dynamic static properties.