### PR TITLE
Emit meta data for class constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/reflection": "feature/typed_class_constants as 2.11.0",
+    "xp-framework/reflection": "dev-feature/typed_class_constants as 2.11.0",
     "xp-framework/test": "^1.0"
   },
   "bin": ["bin/xp.xp-framework.compiler.compile", "bin/xp.xp-framework.compiler.ast"],

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
+    "xp-framework/reflection": "feature/typed_class_constants as 2.11.0",
     "xp-framework/test": "^1.0"
   },
   "bin": ["bin/xp.xp-framework.compiler.compile", "bin/xp.xp-framework.compiler.ast"],

--- a/src/main/php/lang/ast/emit/OmitConstModifiers.class.php
+++ b/src/main/php/lang/ast/emit/OmitConstModifiers.class.php
@@ -9,6 +9,14 @@
 trait OmitConstModifiers {
 
   protected function emitConst($result, $const) {
+    $result->codegen->scope[0]->meta[self::CONSTANT][$const->name]= [
+      DETAIL_RETURNS     => $const->type ? $const->type->name() : 'var',
+      DETAIL_ANNOTATIONS => $const->annotations,
+      DETAIL_COMMENT     => $const->comment,
+      DETAIL_TARGET_ANNO => [],
+      DETAIL_ARGUMENTS   => []
+    ];
+
     $result->out->write('const '.$const->name.'=');
     $this->emitOne($result, $const->expression);
     $result->out->write(';');

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -21,6 +21,7 @@ use lang\ast\{Emitter, Node, Type, Result};
 abstract class PHP extends Emitter {
   const PROPERTY = 0;
   const METHOD   = 1;
+  const CONSTANT = 2;
 
   protected $literals= [];
 
@@ -562,6 +563,14 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitConst($result, $const) {
+    $result->codegen->scope[0]->meta[self::CONSTANT][$const->name]= [
+      DETAIL_RETURNS     => $const->type ? $const->type->name() : 'var',
+      DETAIL_ANNOTATIONS => $const->annotations,
+      DETAIL_COMMENT     => $const->comment,
+      DETAIL_TARGET_ANNO => [],
+      DETAIL_ARGUMENTS   => []
+    ];
+
     $const->comment && $this->emitOne($result, $const->comment);
     $const->annotations && $this->emitOne($result, $const->annotations);
     $result->at($const->declared)->out->write(implode(' ', $const->modifiers).' const '.$const->name.'=');

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\ArrayType;
+use lang\{ArrayType, Primitive, Reflection};
 use test\{Assert, Ignore, Test, Values};
 
 class MembersTest extends EmittingTest {
@@ -59,15 +59,13 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function typed_class_constant() {
-    $r= $this->run('class <T> {
+    $t= Reflection::type($this->type('class <T> {
       private const string MEMBER = "Test";
+    }'));
+    $const= $t->constant('MEMBER');
 
-      public function run() {
-        return self::MEMBER;
-      }
-    }');
-
-    Assert::equals('Test', $r);
+    Assert::equals('Test', $const->value());
+    Assert::equals(Primitive::$STRING, $const->constraint()->type());
   }
 
   #[Test, Values(['$this->$member', '$this->{$member}', '$this->{strtoupper($member)}'])]

--- a/src/test/php/lang/ast/unittest/emit/OmitConstModifiersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/OmitConstModifiersTest.class.php
@@ -1,11 +1,12 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\ast\emit\{OmitConstModifiers, PHP};
-use lang\ast\nodes\{Constant, Literal};
-use lang\ast\types\IsLiteral;
-use test\{Assert, Test};
+use lang\ast\nodes\{Constant, ClassDeclaration, Literal};
+use lang\ast\types\{IsLiteral, IsValue};
+use test\{Assert, Before, Test};
 
 class OmitConstModifiersTest extends EmitterTraitTest {
+  private $type;
 
   /** @return lang.ast.Emitter */
   protected function fixture() {
@@ -14,19 +15,20 @@ class OmitConstModifiersTest extends EmitterTraitTest {
     };
   }
 
+  #[Before]
+  public function type() {
+    $this->type= new ClassDeclaration([], new IsValue('\\T'), null, [], [], null, null, 1);
+  }
+
   #[Test]
   public function omits_type() {
-    Assert::equals(
-      'const TEST="test";',
-      $this->emit(new Constant([], 'TEST', new IsLiteral('string'), new Literal('"test"')))
-    );
+    $const= new Constant([], 'TEST', new IsLiteral('string'), new Literal('"test"'));
+    Assert::equals('const TEST="test";', $this->emit($const, [$this->type]));
   }
 
   #[Test]
   public function omits_modifier() {
-    Assert::equals(
-      'const TEST="test";',
-      $this->emit(new Constant(['private'], 'TEST', new IsLiteral('string'), new Literal('"test"')))
-    );
+    $const= new Constant(['private'], 'TEST', new IsLiteral('string'), new Literal('"test"'));
+    Assert::equals('const TEST="test";', $this->emit($const, [$this->type]));
   }
 }


### PR DESCRIPTION
See #157 - this is so reflection works for PHP < 8.3