### PR TITLE
Implement first class callable syntax for instance method references

### DIFF
--- a/src/main/php/lang/ast/emit/CallableInstanceMethodReferences.class.php
+++ b/src/main/php/lang/ast/emit/CallableInstanceMethodReferences.class.php
@@ -1,0 +1,26 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\nodes\{InstanceExpression, Literal};
+
+/**
+ * Rewrites `T->func(...)` to `fn(T $t) => $t->func()`.
+ *
+ * @see  https://externals.io/message/120011
+ */
+trait CallableInstanceMethodReferences {
+
+  protected function emitCallable($result, $callable) {
+    if (
+      $callable->expression instanceof InstanceExpression &&
+      $callable->expression->expression instanceof Literal
+    ) {
+      $type= $callable->expression->expression->expression;
+      $result->out->write('static function('.$type.' $_) { return $_->');
+      $this->emitOne($result, $callable->expression->member);
+      $result->out->write('(); }');
+    } else {
+      return parent::emitCallable($result, $callable);
+    }
+  }
+}
+

--- a/src/main/php/lang/ast/emit/CallableInstanceMethodReferences.class.php
+++ b/src/main/php/lang/ast/emit/CallableInstanceMethodReferences.class.php
@@ -15,9 +15,9 @@ trait CallableInstanceMethodReferences {
       $callable->expression->expression instanceof Literal
     ) {
       $type= $callable->expression->expression->expression;
-      $result->out->write('static function('.$type.' $_) { return $_->');
+      $result->out->write('static function('.$type.' $self, ... $args) { return $self->');
       $this->emitOne($result, $callable->expression->member);
-      $result->out->write('(); }');
+      $result->out->write('(...$args); }');
     } else {
       return parent::emitCallable($result, $callable);
     }

--- a/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
+++ b/src/main/php/lang/ast/emit/CallablesAsClosures.class.php
@@ -10,6 +10,7 @@ use lang\ast\nodes\{Expression, InstanceExpression, ScopeExpression, Literal};
  * @see  https://wiki.php.net/rfc/first_class_callable_syntax
  */
 trait CallablesAsClosures {
+  use CallableInstanceMethodReferences { emitCallable as callableInstanceMethodReferences; }
 
   private function emitQuoted($result, $node) {
     if ($node instanceof Literal) {
@@ -48,6 +49,14 @@ trait CallablesAsClosures {
   }
 
   protected function emitCallable($result, $callable) {
+    if (
+      $callable->expression instanceof InstanceExpression &&
+      $callable->expression->expression instanceof Literal
+    ) {
+      $this->callableInstanceMethodReferences($result, $callable);
+      return;
+    }
+
     $result->out->write('\Closure::fromCallable(');
     $this->emitQuoted($result, $callable->expression);
     $result->out->write(')');

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -974,19 +974,6 @@ abstract class PHP extends Emitter {
 
   protected function emitCallable($result, $callable) {
 
-    // T->func(...) is an instance method, create a trampoline
-    // See https://externals.io/message/120011
-    if (
-      $callable->expression instanceof InstanceExpression &&
-      $callable->expression->expression instanceof Literal
-    ) {
-      $type= $callable->expression->expression->expression;
-      $result->out->write('static function('.$type.' $_) { return $_->');
-      $this->emitOne($result, $callable->expression->member);
-      $result->out->write('(); }');
-      return;
-    }
-
     // Disambiguate the following:
     //
     // - `T::{$func}`, a dynamic class constant

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -10,6 +10,7 @@ use lang\ast\types\{IsUnion, IsIntersection, IsFunction, IsArray, IsMap, IsNulla
  * @see  https://wiki.php.net/rfc#php_70
  */
 class PHP70 extends PHP {
+  use CallableInstanceMethodReferences { emitCallable as callableInstanceMethodReferences; }
   use 
     ArbitrayNewExpressions,
     ArrayUnpackUsingMerge,
@@ -61,6 +62,14 @@ class PHP70 extends PHP {
   }
 
   protected function emitCallable($result, $callable) {
+    if (
+      $callable->expression instanceof InstanceExpression &&
+      $callable->expression->expression instanceof Literal
+    ) {
+      $this->callableInstanceMethodReferences($result, $callable);
+      return;
+    }
+
     $t= $result->temp();
     $result->out->write('(is_callable('.$t.'=');
     if ($callable->expression instanceof Literal) {

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -19,7 +19,7 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_81
  */
 class PHP81 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses, CallableInstanceMethodReferences;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -19,7 +19,7 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_82
  */
 class PHP82 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses, CallableInstanceMethodReferences;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP83.class.php
+++ b/src/main/php/lang/ast/emit/PHP83.class.php
@@ -18,7 +18,7 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_83
  */
 class PHP83 extends PHP {
-  use RewriteBlockLambdaExpressions, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, ReadonlyClasses, CallableInstanceMethodReferences;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -182,4 +182,15 @@ class CallableSyntaxTest extends EmittingTest {
     }');
     Assert::equals($this, $f($this)->value);
   }
+
+  #[Test]
+  public function instance_method_reference() {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+      public function run() {
+        $handles= [new Handle(0), new Handle(1), new Handle(2)];
+        return array_map(Handle->hashCode(...), $handles);
+      }
+    }');
+    Assert::equals(['#0', '#1', '#2'], $r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -184,7 +184,7 @@ class CallableSyntaxTest extends EmittingTest {
   }
 
   #[Test]
-  public function instance_method_reference() {
+  public function instance_method_reference_map() {
     $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
       public function run() {
         $handles= [new Handle(0), new Handle(1), new Handle(2)];
@@ -192,5 +192,17 @@ class CallableSyntaxTest extends EmittingTest {
       }
     }');
     Assert::equals(['#0', '#1', '#2'], $r);
+  }
+
+  #[Test]
+  public function instance_method_reference_sort() {
+    $r= $this->run('use util\Date; class <T> {
+      public function run() {
+        $dates= [new Date(43200), new Date(86400), new Date(0)];
+        usort($dates, Date->compareTo(...));
+        return array_map(Date->getTime(...), $dates);
+      }
+    }');
+    Assert::equals([86400, 43200, 0], $r);
   }
 }


### PR DESCRIPTION
Inspired by https://externals.io/message/120011

```php
class Person {
  public function __construct(private string $name) { }
  public function name(): string { return $this->name; }
}

$group= [new Person('Timm'), new Person('Alex')];

// Instead of the following:
$names= array_map(fn($person) => $person->name(), $group);

// ...we can now write this:
$names= array_map(Person->name(...), $group);

// ["Timm", "Alex"]