### PR TITLE
Omit constant types for all PHP versions < 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/reflection": "dev-feature/typed_class_constants as 2.11.0",
+    "xp-framework/reflection": "^2.11",
     "xp-framework/test": "^1.0"
   },
   "bin": ["bin/xp.xp-framework.compiler.compile", "bin/xp.xp-framework.compiler.ast"],

--- a/src/main/php/lang/ast/emit/OmitConstantTypes.class.php
+++ b/src/main/php/lang/ast/emit/OmitConstantTypes.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\emit;
+
+/**
+ * Removes type hints for PHP versions that do not support typed
+ * constants - everything below PHP 8.3
+ *
+ * @see  https://wiki.php.net/rfc/typed_class_constants
+ */
+trait OmitConstantTypes {
+
+  /**
+   * Returns constant type
+   *
+   * @param  ?lang.ast.Type $type
+   * @return string
+   */
+  protected function constantType($type) { return ''; }
+}

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -95,6 +95,22 @@ abstract class PHP extends Emitter {
   }
 
   /**
+   * As of PHP 8.3: Constant type declarations support all type declarations
+   * supported by PHP with the exception of void and callable.
+   *
+   * @see    https://wiki.php.net/rfc/typed_class_constants#supported_types
+   * @param  ?lang.ast.Type $type
+   * @return ?string
+   */
+  protected function constantType($type) {
+    if (null === $type || $type instanceof IsFunction || 'callable' === $type->literal()) {
+      return null;
+    } else {
+      return $this->literal($type);
+    }
+  }
+
+  /**
    * Enclose a node inside a closure
    *
    * @param  lang.ast.Result $result
@@ -573,7 +589,7 @@ abstract class PHP extends Emitter {
 
     $const->comment && $this->emitOne($result, $const->comment);
     $const->annotations && $this->emitOne($result, $const->annotations);
-    $result->at($const->declared)->out->write(implode(' ', $const->modifiers).' const '.$const->name.'=');
+    $result->at($const->declared)->out->write(implode(' ', $const->modifiers).' const '.$this->constantType($const->type).' '.$const->name.'=');
     $this->emitOne($result, $const->expression);
     $result->out->write(';');
   }

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -19,6 +19,7 @@ class PHP70 extends PHP {
     NullsafeAsTernaries,
     OmitArgumentNames,
     OmitConstModifiers,
+    OmitConstantTypes,
     OmitPropertyTypes,
     ReadonlyClasses,
     ReadonlyProperties,

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -18,6 +18,7 @@ class PHP71 extends PHP {
     NonCapturingCatchVariables,
     NullsafeAsTernaries,
     OmitArgumentNames,
+    OmitConstantTypes,
     OmitPropertyTypes,
     ReadonlyProperties,
     ReadonlyClasses,

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -18,6 +18,7 @@ class PHP72 extends PHP {
     NonCapturingCatchVariables,
     NullsafeAsTernaries,
     OmitArgumentNames,
+    OmitConstantTypes,
     OmitPropertyTypes,
     ReadonlyProperties,
     ReadonlyClasses,

--- a/src/main/php/lang/ast/emit/PHP73.class.php
+++ b/src/main/php/lang/ast/emit/PHP73.class.php
@@ -19,6 +19,7 @@ class PHP73 extends PHP {
     NonCapturingCatchVariables,
     NullsafeAsTernaries,
     OmitArgumentNames,
+    OmitConstantTypes,
     OmitPropertyTypes,
     ReadonlyProperties,
     ReadonlyClasses,

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -17,6 +17,7 @@ class PHP74 extends PHP {
     NonCapturingCatchVariables,
     NullsafeAsTernaries,
     OmitArgumentNames,
+    OmitConstantTypes,
     ReadonlyClasses,
     ReadonlyProperties,
     RewriteBlockLambdaExpressions,

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -18,8 +18,17 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_80
  */
 class PHP80 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, RewriteExplicitOctals, RewriteEnums;
-  use ReadonlyClasses, ReadonlyProperties, CallablesAsClosures, ArrayUnpackUsingMerge;
+  use
+    ArrayUnpackUsingMerge,
+    CallablesAsClosures,
+    OmitConstantTypes,
+    ReadonlyClasses,
+    ReadonlyProperties,
+    RewriteBlockLambdaExpressions,
+    RewriteDynamicClassConstants,
+    RewriteEnums,
+    RewriteExplicitOctals
+  ;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -19,7 +19,7 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_81
  */
 class PHP81 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses, OmitConstantTypes;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -19,7 +19,7 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_82
  */
 class PHP82 extends PHP {
-  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses;
+  use RewriteBlockLambdaExpressions, RewriteDynamicClassConstants, ReadonlyClasses, OmitConstantTypes;
 
   /** Sets up type => literal mappings */
   public function __construct() {


### PR DESCRIPTION
```bash
$ echo '<?php class T { const string NAME= "Test"; }' | xp compile -t php:8.2 -q -
<?php  class T{ const  NAME="Test";static function __init() {}} T::__init();;
# ^^^^^^^^^^^^^^^^^^^^
# Type is omitted

$ echo '<?php class T { const string NAME= "Test"; }' | xp compile -t php:8.3 -q -
<?php  class T{ const string NAME="Test";static function __init() {}} T::__init();;
# ^^^^^^^^^^^^^^^^^^^^
# Typed with string
```

See #157