### PR TITLE
Refactor how annotations with non-constant arguments are emitted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "description" : "XP Compiler",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^11.6",
+    "xp-framework/core": "^11.6 | ^10.16",
     "xp-framework/ast": "^10.1",
     "php" : ">=7.0.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
   "description" : "XP Compiler",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^11.0 | ^10.0",
+    "xp-framework/core": "^11.6",
     "xp-framework/ast": "^10.1",
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/reflection": "^2.11",
+    "xp-framework/reflection": "^2.13",
     "xp-framework/test": "^1.5"
   },
   "bin": ["bin/xp.xp-framework.compiler.compile", "bin/xp.xp-framework.compiler.ast"],


### PR DESCRIPTION
This pull request changes the way annotations with non-constant arguments are emitted.

### Single argument

```php
// Declaration in user code
#[Verify(fn() => extension_loaded('pcntl')]

// Previous behavior
#[Verify(eval: 'fn() => extension_loaded(\'pcntl\')')]

// Code that is emitted now
#[Verify(eval: ['fn() => extension_loaded(\'pcntl\')'])]
```

### Multiple (and named) arguments

```php
// Declaration in user code
#[Verify(fn() => extension_loaded('pcntl'), optional: true)]

// Previous behavior created an ambiguity with supplying a single value with the respective array
#[Verify(eval: '[\'0\' => fn() => extension_loaded(\'pcntl\'), \'optional\' => true]')]

// Code that is emitted now
#[Verify(eval: ['fn() => extension_loaded(\'pcntl\'))', 'optional' => 'true'])]
```

The array notation is supported by the following changes:

* https://github.com/xp-framework/reflection/pull/35, released in [2.12.0](https://github.com/xp-framework/reflection/releases/tag/v2.12.0)
* https://github.com/xp-framework/core/pull/324, released in [11.6.0](https://github.com/xp-framework/core/releases/tag/v11.6.0)