### PR TITLE
Refactor test code to use new reflection library

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -376,6 +376,15 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitEnumCase($result, $case) {
+    $result->codegen->scope[0]->meta[self::CONSTANT][$case->name]= [
+      DETAIL_RETURNS     => 'self',
+      DETAIL_ANNOTATIONS => $case->annotations,
+      DETAIL_COMMENT     => $case->comment,
+      DETAIL_TARGET_ANNO => [],
+      DETAIL_ARGUMENTS   => []
+    ];
+
+    $case->annotations && $this->emitOne($result, $case->annotations);
     $result->out->write('case '.$case->name);
     if ($case->expression) {
       $result->out->write('=');

--- a/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\{Reflection, IllegalArgumentException};
+use lang\IllegalArgumentException;
 use test\{Assert, Expect, Test, Values};
 
 /**
@@ -10,18 +10,6 @@ use test\{Assert, Expect, Test, Values};
  * - AttributesTest - emits PHP 8 attributes
  */
 abstract class AnnotationSupport extends EmittingTest {
-
-  /**
-   * Declares annotations, optionally including a type
-   *
-   * @param  string $declaration
-   * @return lang.reflection.Type
-   */
-  private function declare($declaration) {
-    return Reflection::type($this->type(
-      $declaration.(strstr($declaration, '<T>') ? '' : ' class <T> { }')
-    ));
-  }
 
   /**
    * Returns annotations present in the given type
@@ -127,13 +115,13 @@ abstract class AnnotationSupport extends EmittingTest {
   public function has_access_to_class() {
     Assert::equals(
       ['Expect' => [true]],
-      $this->annotations($this->declare('#[Expect(self::SUCCESS)] class <T> { const SUCCESS = true; }'))
+      $this->annotations($this->declare('#[Expect(self::SUCCESS)] class %T { const SUCCESS = true; }'))
     );
   }
 
   #[Test]
   public function method() {
-    $t= $this->declare('class <T> { #[Test] public function fixture() { } }');
+    $t= $this->declare('class %T { #[Test] public function fixture() { } }');
     Assert::equals(
       ['Test' => []],
       $this->annotations($t->method('fixture'))
@@ -142,7 +130,7 @@ abstract class AnnotationSupport extends EmittingTest {
 
   #[Test]
   public function field() {
-    $t= $this->declare('class <T> { #[Test] public $fixture; }');
+    $t= $this->declare('class %T { #[Test] public $fixture; }');
     Assert::equals(
       ['Test' => []],
       $this->annotations($t->property('fixture'))
@@ -151,7 +139,7 @@ abstract class AnnotationSupport extends EmittingTest {
 
   #[Test]
   public function param() {
-    $t= $this->declare('class <T> { public function fixture(#[Test] $param) { } }');
+    $t= $this->declare('class %T { public function fixture(#[Test] $param) { } }');
     Assert::equals(
       ['Test' => []],
       $this->annotations($t->method('fixture')->parameter(0))
@@ -160,7 +148,7 @@ abstract class AnnotationSupport extends EmittingTest {
 
   #[Test]
   public function params() {
-    $t= $this->declare('class <T> { public function fixture(#[Inject(["name" => "a"])] $a, #[Inject] $b) { } }');
+    $t= $this->declare('class %T { public function fixture(#[Inject(["name" => "a"])] $a, #[Inject] $b) { } }');
     Assert::equals(
       ['Inject' => [['name' => 'a']]],
       $this->annotations($t->method('fixture')->parameter(0))
@@ -181,7 +169,7 @@ abstract class AnnotationSupport extends EmittingTest {
 
   #[Test]
   public function multiple_member_annotations() {
-    $t= $this->declare('class <T> { #[Test, Values([1, 2, 3])] public function fixture() { } }');
+    $t= $this->declare('class %T { #[Test, Values([1, 2, 3])] public function fixture() { } }');
     Assert::equals(
       ['Test' => [], 'Values' => [[1, 2, 3]]],
       $this->annotations($t->method('fixture'))
@@ -195,7 +183,7 @@ abstract class AnnotationSupport extends EmittingTest {
         "Timm",
         "Mr. Midori",
       ])]
-      class <T> { }'
+      class %T { }'
     ));
     Assert::equals(['Authors' => [['Timm', 'Mr. Midori']]], $annotations);
   }

--- a/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationSupport.class.php
@@ -10,20 +10,7 @@ use test\{Assert, Expect, Test, Values};
  * - AttributesTest - emits PHP 8 attributes
  */
 abstract class AnnotationSupport extends EmittingTest {
-
-  /**
-   * Returns annotations present in the given type
-   *
-   * @param  lang.reflection.Annotated $annotated
-   * @return [:var[]]
-   */
-  private function annotations($annotated) {
-    $r= [];
-    foreach ($annotated->annotations() as $name => $annotation) {
-      $r[$name]= $annotation->arguments();
-    }
-    return $r;
-  }
+  use AnnotationsOf;
 
   #[Test]
   public function without_value() {

--- a/src/test/php/lang/ast/unittest/emit/AnnotationsOf.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationsOf.class.php
@@ -1,0 +1,18 @@
+<?php namespace lang\ast\unittest\emit;
+
+trait AnnotationsOf {
+
+  /**
+   * Returns annotations present in the given type
+   *
+   * @param  lang.reflection.Annotated $annotated
+   * @return [:var[]]
+   */
+  private function annotations($annotated) {
+    $r= [];
+    foreach ($annotated->annotations() as $name => $annotation) {
+      $r[$name]= $annotation->arguments();
+    }
+    return $r;
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnonymousClassTest.class.php
@@ -14,7 +14,7 @@ class AnonymousClassTest extends EmittingTest {
 
   #[Test]
   public function parentless() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new class() {
           public function id() { return "test"; }
@@ -26,7 +26,7 @@ class AnonymousClassTest extends EmittingTest {
 
   #[Test]
   public function extending_base_class() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new class() extends \\util\\AbstractDeferredInvokationHandler {
           public function initialize() {
@@ -40,7 +40,7 @@ class AnonymousClassTest extends EmittingTest {
 
   #[Test]
   public function implementing_interface() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new class() implements \\lang\\Runnable {
           public function run() {
@@ -54,7 +54,7 @@ class AnonymousClassTest extends EmittingTest {
 
   #[Test]
   public function method_annotations() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new class() {
 
@@ -69,22 +69,22 @@ class AnonymousClassTest extends EmittingTest {
 
   #[Test]
   public function extending_enclosing_class() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public static function run() {
         return new class() extends self { };
       }
     }');
-    Assert::instance($t, Reflection::type($t)->method('run')->invoke(null));
+    Assert::instance($t->class(), $t->method('run')->invoke(null));
   }
 
   #[Test]
   public function referencing_enclosing_class() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       const ID= 6100;
 
       public static function run() {
         return new class() extends self {
-          public static $id= <T>::ID;
+          public static $id= %T::ID;
         };
       }
     }');

--- a/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentUnpackingTest.class.php
@@ -12,7 +12,7 @@ class ArgumentUnpackingTest extends EmittingTest {
 
   #[Test]
   public function invoking_method() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function fixture(... $args) { return $args; }
 
       public function run() {
@@ -25,7 +25,7 @@ class ArgumentUnpackingTest extends EmittingTest {
 
   #[Test]
   public function in_array_initialization_with_variable() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $args= [3, 4];
         return [1, 2, ...$args];
@@ -36,7 +36,7 @@ class ArgumentUnpackingTest extends EmittingTest {
 
   #[Test]
   public function in_array_initialization_with_literal() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return [1, 2, ...[3, 4]];
       }
@@ -46,7 +46,7 @@ class ArgumentUnpackingTest extends EmittingTest {
 
   #[Test]
   public function in_map_initialization() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $args= ["type" => "car"];
         return ["color" => "red", ...$args, "year" => 2002];
@@ -57,7 +57,7 @@ class ArgumentUnpackingTest extends EmittingTest {
 
   #[Test]
   public function from_generator() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function items() {
         yield 1;
         yield 2;
@@ -72,7 +72,7 @@ class ArgumentUnpackingTest extends EmittingTest {
 
   #[Test]
   public function from_iterator() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function items() {
         return new \ArrayIterator([1, 2]);
       }

--- a/src/test/php/lang/ast/unittest/emit/ArrayTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArrayTypesTest.class.php
@@ -11,37 +11,37 @@ class ArrayTypesTest extends EmittingTest {
 
   #[Test]
   public function int_array_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private array<int> $test;
     }');
 
-    Assert::equals('int[]', $t->getField('test')->getType()->getName());
+    Assert::equals('int[]', $t->property('test')->constraint()->type()->getName());
   }
 
   #[Test]
   public function int_map_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private array<string, int> $test;
     }');
 
-    Assert::equals('[:int]', $t->getField('test')->getType()->getName());
+    Assert::equals('[:int]', $t->property('test')->constraint()->type()->getName());
   }
 
   #[Test]
   public function nested_map_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private array<string, array<int>> $test;
     }');
 
-    Assert::equals('[:int[]]', $t->getField('test')->getType()->getName());
+    Assert::equals('[:int[]]', $t->property('test')->constraint()->type()->getName());
   }
 
   #[Test]
   public function var_map_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private array<string, mixed> $test;
     }');
 
-    Assert::equals('[:var]', $t->getField('test')->getType()->getName());
+    Assert::equals('[:var]', $t->property('test')->constraint()->type()->getName());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArraysTest.class.php
@@ -7,7 +7,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function array_literal() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return [1, 2, 3];
       }
@@ -18,7 +18,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function map_literal() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return ["a" => 1, "b" => 2];
       }
@@ -29,7 +29,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function append() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $r= [1, 2];
         $r[]= 3;
@@ -42,7 +42,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test, Values(['[1, , 3]', '[1, , ]', '[, 1]']), Expect(class: IllegalStateException::class, message: 'Cannot use empty array elements in arrays')]
   public function arrays_cannot_have_empty_elements($input) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return '.$input.';
       }
@@ -51,7 +51,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function destructuring() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         [$a, $b]= [1, 2];
         return [$a, $b];
@@ -63,7 +63,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function nested_destructuring() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         [[$a, $b], $c]= [[1, 2], 3];
         return [$a, $b, $c];
@@ -75,7 +75,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function destructuring_with_empty_between() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         [$a, , $b]= [1, 2, 3];
         return [$a, $b];
@@ -87,7 +87,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function destructuring_with_empty_start() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         [, $a, $b]= [1, 2, 3];
         return [$a, $b];
@@ -99,7 +99,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function destructuring_map() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         ["two" => $a, "one" => $b]= ["one" => 1, "two" => 2];
         return [$a, $b];
@@ -111,7 +111,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function destructuring_map_with_expression() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $one= "one";
       public function run() {
         $two= "two";
@@ -125,7 +125,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function nested_destructuring_with_map() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         ["nested" => ["one" => $a], "three" => $b]= ["nested" => ["one" => 1], "three" => 3];
         return [$a, $b];
@@ -137,7 +137,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test, Values(['$list', '$this->instance', 'self::$static'])]
   public function reference_destructuring($reference) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $instance= [1, 2];
       private static $static= [1, 2];
 
@@ -155,7 +155,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function list_destructuring() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         list($a, $b)= [1, 2];
         return [$a, $b];
@@ -167,7 +167,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function swap_using_destructuring() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $a= 1;
         $b= 2;
@@ -181,7 +181,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function result_of_destructuring() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return [$a, $b]= [1, 2];
       }
@@ -192,7 +192,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test, Values([null, true, false, 0, 0.5, '', 'Test'])]
   public function destructuring_with_non_array($value) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         $r= [$a, $b]= $arg;
         return [$a, $b, $r];
@@ -204,7 +204,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function init_with_variable() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $KEY= "key";
         return [$KEY => "value"];
@@ -216,7 +216,7 @@ class ArraysTest extends EmittingTest {
 
   #[Test]
   public function init_with_member_variable() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static $KEY= "key";
       public function run() {
         return [self::$KEY => "value"];

--- a/src/test/php/lang/ast/unittest/emit/BlockTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/BlockTest.class.php
@@ -6,7 +6,7 @@ class BlockTest extends EmittingTest {
 
   #[Test]
   public function empty_block() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         {
         }
@@ -19,7 +19,7 @@ class BlockTest extends EmittingTest {
 
   #[Test]
   public function block_with_assignment() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         {
           $result= true;

--- a/src/test/php/lang/ast/unittest/emit/BracesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/BracesTest.class.php
@@ -6,7 +6,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function inc() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $id= 0;
 
       public function run() {
@@ -19,7 +19,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function braces_around_new() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return (new \\util\\Date(250905600))->getTime();
       }
@@ -30,7 +30,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function no_braces_necessary_around_new() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new \\util\\Date(250905600)->getTime();
       }
@@ -41,7 +41,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function property_vs_method_ambiguity() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $f;
 
       public function __construct() {
@@ -58,7 +58,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function nested_braces() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function test() { return "test"; }
 
       public function run() {
@@ -71,7 +71,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function braced_expression_not_confused_with_cast() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       const WIDTH = 640;
 
       public function run() {
@@ -84,7 +84,7 @@ class BracesTest extends EmittingTest {
 
   #[Test, Values([['(__LINE__)."test"', '3test'], ['(__LINE__) + 1', 4], ['(__LINE__) - 1', 2]])]
   public function global_constant_in_braces_not_confused_with_cast($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return '.$input.';
       }
@@ -95,7 +95,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function function_call_in_braces() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $e= STDOUT;
         return false !== (fstat(STDOUT));
@@ -107,7 +107,7 @@ class BracesTest extends EmittingTest {
 
   #[Test]
   public function invoke_on_braced_null_coalesce() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function __invoke() { return "OK"; }
       public function fail() { return function() { return "FAIL"; }; }
 

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -23,14 +23,14 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function native_function() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public function run() { return strlen(...); }
     }');
   }
 
   #[Test]
   public function instance_method() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public function length($arg) { return strlen($arg); }
       public function run() { return $this->length(...); }
     }');
@@ -38,7 +38,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function class_method() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public static function length($arg) { return strlen($arg); }
       public function run() { return self::length(...); }
     }');
@@ -46,7 +46,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function private_method() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       private function length($arg) { return strlen($arg); }
       public function run() { return $this->length(...); }
     }');
@@ -54,7 +54,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function string_reference() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public function run() {
         $func= "strlen";
         return $func(...);
@@ -64,7 +64,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function fn_reference() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public function run() {
         $func= fn($arg) => strlen($arg);
         return $func(...);
@@ -74,7 +74,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function instance_property_reference() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       private $func= "strlen";
       public function run() {
         return ($this->func)(...);
@@ -84,7 +84,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test, Values(['$this->$func(...)', '$this->{$func}(...)'])]
   public function variable_instance_method($expr) {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       private function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
@@ -95,7 +95,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test, Values(['self::$func(...)', 'self::{$func}(...)'])]
   public function variable_class_method($expr) {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       private static function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
@@ -106,7 +106,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function variable_class_method_with_variable_class() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       private static function length($arg) { return strlen($arg); }
       public function run() {
         $func= "length";
@@ -118,14 +118,14 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function string_function_reference() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public function run() { return "strlen"(...); }
     }');
   }
 
   #[Test]
   public function array_instance_method_reference() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public function length($arg) { return strlen($arg); }
       public function run() { return [$this, "length"](...); }
     }');
@@ -133,7 +133,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function array_class_method_reference() {
-    $this->verify('class <T> {
+    $this->verify('class %T {
       public static function length($arg) { return strlen($arg); }
       public function run() { return [self::class, "length"](...); }
     }');
@@ -141,7 +141,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test, Expect(Error::class), Values(['nonexistant', '$this->nonexistant', 'self::nonexistant', '$nonexistant', '$null'])]
   public function non_existant($expr) {
-    $this->run('class <T> {
+    $this->run('class %T {
       public function run() {
         $null= null;
         $nonexistant= "nonexistant";
@@ -152,7 +152,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function instantiation() {
-    $f= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $f= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         return new Handle(...);
       }
@@ -162,7 +162,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function instantiation_in_map() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         return array_map(new Handle(...), [0, 1, 2]);
       }
@@ -172,7 +172,7 @@ class CallableSyntaxTest extends EmittingTest {
 
   #[Test]
   public function anonymous_instantiation() {
-    $f= $this->run('class <T> {
+    $f= $this->run('class %T {
       public function run() {
         return new class(...) {
           public $value;

--- a/src/test/php/lang/ast/unittest/emit/CastingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CastingTest.class.php
@@ -11,7 +11,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values([0, 1, -1, 0.5, -1.5, '', 'test', true, false])]
   public function string_cast($value) {
     Assert::equals((string)$value, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (string)$value;
         }
@@ -23,7 +23,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values(['0', '1', '-1', '6100', '', 0.5, -1.5, 0, 1, -1, true, false])]
   public function int_cast($value) {
     Assert::equals((int)$value, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (int)$value;
         }
@@ -35,7 +35,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values([[[]], [[0, 1, 2]], [['key' => 'value']], null, false, true, 1, 1.5, '', 'test'])]
   public function array_cast($value) {
     Assert::equals((array)$value, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (array)$value;
         }
@@ -47,7 +47,7 @@ class CastingTest extends EmittingTest {
   #[Test]
   public function value_cast() {
     Assert::equals($this, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (\lang\ast\unittest\emit\CastingTest)$value;
         }
@@ -59,7 +59,7 @@ class CastingTest extends EmittingTest {
   #[Test]
   public function int_array_cast() {
     Assert::equals([1, 2, 3], $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (array<int>)$value;
         }
@@ -70,7 +70,7 @@ class CastingTest extends EmittingTest {
 
   #[Test, Expect(ClassCastException::class)]
   public function cannot_cast_object_to_int_array() {
-    $this->run('class <T> {
+    $this->run('class %T {
       public function run() {
         return (array<int>)$this;
       }
@@ -80,7 +80,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values([null, 'test'])]
   public function nullable_string_cast_of($value) {
     Assert::equals($value, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (?string)$value;
         }
@@ -92,7 +92,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values([null, 'test'])]
   public function nullable_string_cast_of_expression_returning($value) {
     Assert::equals($value, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           $values= [$value];
           return (?string)array_pop($values);
@@ -105,7 +105,7 @@ class CastingTest extends EmittingTest {
   #[Test]
   public function cast_braced() {
     Assert::equals(['test'], $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (array<string>)($value);
         }
@@ -117,7 +117,7 @@ class CastingTest extends EmittingTest {
   #[Test]
   public function cast_to_function_type_and_invoke() {
     Assert::equals($this->test(), $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return ((function(): string)($value))();
         }
@@ -129,7 +129,7 @@ class CastingTest extends EmittingTest {
   #[Test]
   public function object_cast_on_literal() {
     Assert::equals((object)['key' => 'value'], $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (object)["key" => "value"];
         }
@@ -141,7 +141,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values([[1, 1], ['123', 123], [null, null]])]
   public function nullable_int($value, $expected) {
     Assert::equals($expected, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (?int)$value;
         }
@@ -153,7 +153,7 @@ class CastingTest extends EmittingTest {
   #[Test, Values(eval: '[new Handle(10), null]')]
   public function nullable_value($value) {
     Assert::equals($value, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return (?\lang\ast\unittest\emit\Handle)$value;
         }

--- a/src/test/php/lang/ast/unittest/emit/ClassLiteralTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ClassLiteralTest.class.php
@@ -12,7 +12,7 @@ class ClassLiteralTest extends EmittingTest {
 
   #[Test]
   public function on_name() {
-    $r= $this->run('use lang\Primitive; class <T> {
+    $r= $this->run('use lang\Primitive; class %T {
       public function run() { return Primitive::class; }
     }');
     Assert::equals(Primitive::class, $r);
@@ -20,33 +20,33 @@ class ClassLiteralTest extends EmittingTest {
 
   #[Test]
   public function on_self() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() { return self::class; }
     }');
-    Assert::equals($t->getName(), $t->newInstance()->run());
+    Assert::equals($t->literal(), $t->newInstance()->run());
   }
 
   #[Test]
   public function on_object() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() { return $this::class; }
     }');
-    Assert::equals($t->getName(), $t->newInstance()->run());
+    Assert::equals($t->literal(), $t->newInstance()->run());
   }
 
   #[Test]
   public function on_instantiation() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() { return new self()::class; }
     }');
-    Assert::equals($t->getName(), $t->newInstance()->run());
+    Assert::equals($t->literal(), $t->newInstance()->run());
   }
 
   #[Test]
   public function on_braced_expression() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() { return (new self())::class; }
     }');
-    Assert::equals($t->getName(), $t->newInstance()->run());
+    Assert::equals($t->literal(), $t->newInstance()->run());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/CommentsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CommentsTest.class.php
@@ -6,31 +6,31 @@ class CommentsTest extends EmittingTest {
 
   #[Test]
   public function on_class() {
-    $t= $this->type('/** Test */ class <T> { }');
-    Assert::equals('Test', $t->getComment());
+    $t= $this->declare('/** Test */ class %T { }');
+    Assert::equals('Test', $t->comment());
   }
 
   #[Test]
   public function on_interface() {
-    $t= $this->type('/** Test */ interface <T> { }');
-    Assert::equals('Test', $t->getComment());
+    $t= $this->declare('/** Test */ interface %T { }');
+    Assert::equals('Test', $t->comment());
   }
 
   #[Test]
   public function on_trait() {
-    $t= $this->type('/** Test */ trait <T> { }');
-    Assert::equals('Test', $t->getComment());
+    $t= $this->declare('/** Test */ trait %T { }');
+    Assert::equals('Test', $t->comment());
   }
 
   #[Test]
   public function on_enum() {
-    $t= $this->type('/** Test */ enum <T> { }');
-    Assert::equals('Test', $t->getComment());
+    $t= $this->declare('/** Test */ enum %T { }');
+    Assert::equals('Test', $t->comment());
   }
 
   #[Test]
   public function on_method() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
 
       /** Test */
       public function fixture() {
@@ -38,18 +38,18 @@ class CommentsTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('Test', $t->getMethod('fixture')->getComment());
+    Assert::equals('Test', $t->method('fixture')->comment());
   }
 
   #[Test]
   public function comments_are_escaped() {
-    $t= $this->type("/** Timm's test */ class <T> { }");
-    Assert::equals("Timm's test", $t->getComment());
+    $t= $this->declare("/** Timm's test */ class %T { }");
+    Assert::equals("Timm's test", $t->comment());
   }
 
   #[Test]
   public function only_last_comment_is_considered() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
 
       /** Not the right comment */
 
@@ -59,12 +59,12 @@ class CommentsTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('Test', $t->getMethod('fixture')->getComment());
+    Assert::equals('Test', $t->method('fixture')->comment());
   }
 
   #[Test]
   public function next_comment_is_not_considered() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
 
       /** Test */
       public function fixture() {
@@ -74,12 +74,12 @@ class CommentsTest extends EmittingTest {
       /** Not the right comment */
     }');
 
-    Assert::equals('Test', $t->getMethod('fixture')->getComment());
+    Assert::equals('Test', $t->method('fixture')->comment());
   }
 
   #[Test]
   public function inline_apidoc_comment_is_not_considered() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
 
       /** Test */
       public function fixture() {
@@ -87,6 +87,6 @@ class CommentsTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('Test', $t->getMethod('fixture')->getComment());
+    Assert::equals('Test', $t->method('fixture')->comment());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ControlStructuresTest.class.php
@@ -7,7 +7,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[0, 'no items'], [1, 'one item'], [2, '2 items'], [3, '3 items'],])]
   public function if_else_cascade($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         if (0 === $arg) {
           return "no items";
@@ -24,7 +24,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[0, 'no items'], [1, 'one item'], [2, '2 items'], [3, '3 items'],])]
   public function switch_case($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         switch ($arg) {
           case 0: return "no items";
@@ -39,7 +39,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[SEEK_SET, 10], [SEEK_CUR, 11]])]
   public function switch_case_goto_label_ambiguity($whence, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         $position= 1;
         switch ($arg) {
@@ -55,7 +55,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[SEEK_SET, 10], [SEEK_CUR, 11]])]
   public function switch_case_constant_ambiguity($whence, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       const SET = SEEK_SET;
       const CURRENT = SEEK_CUR;
       public function run($arg) {
@@ -73,7 +73,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[0, 'no items'], [1, 'one item'], [2, '2 items'], [3, '3 items']])]
   public function match($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         return match ($arg) {
           0 => "no items",
@@ -88,7 +88,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[200, 'OK'], [302, 'Redirect'], [404, 'Error #404']])]
   public function match_with_multiple_cases($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         return match ($arg) {
           200, 201, 202, 203, 204 => "OK",
@@ -103,7 +103,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([['PING', '+PONG'], ['MSG', '+OK Re: Test'], ['XFER', '-ERR Unknown XFER']])]
   public function match_with_multiple_statements($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($type) {
         $value= "Test";
         return match ($type) {
@@ -124,7 +124,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Values([[0, 'no items'], [1, 'one item'], [5, '5 items'], [10, '10+ items'],])]
   public function match_with_binary($input, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         return match (true) {
           $arg >= 10 => "10+ items",
@@ -140,7 +140,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test]
   public function match_allows_dropping_true() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         return match {
           $arg >= 10 => "10+ items",
@@ -156,7 +156,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Expect(class: Throwable::class, message: '/Unhandled match (value of type .+|case .+)/')]
   public function unhandled_match() {
-    $this->run('class <T> {
+    $this->run('class %T {
       public function run($arg) {
         $position= 1;
         return match ($arg) {
@@ -169,7 +169,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test, Expect(class: Throwable::class, message: '/Unknown seek mode .+/')]
   public function match_with_throw_expression() {
-    $this->run('class <T> {
+    $this->run('class %T {
       public function run($arg) {
         $position= 1;
         return match ($arg) {
@@ -183,7 +183,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test]
   public function match_without_arg_inside_fn() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn($arg) => match {
           $arg >= 10 => "10+ items",
@@ -199,7 +199,7 @@ class ControlStructuresTest extends EmittingTest {
 
   #[Test]
   public function match_with_arg_inside_fn() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn($arg) => match ($arg) {
           0 => "no items",

--- a/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/DeclareTest.class.php
@@ -7,7 +7,7 @@ class DeclareTest extends EmittingTest {
 
   #[Test]
   public function no_strict_types() {
-    Assert::equals(1, $this->run('class <T> {
+    Assert::equals(1, $this->run('class %T {
       public static function number(int $n) { return $n; }
       public function run() { return self::number("1"); }
     }'));
@@ -15,7 +15,7 @@ class DeclareTest extends EmittingTest {
 
   #[Test]
   public function strict_types_off() {
-    Assert::equals(1, $this->run('declare(strict_types = 0); class <T> {
+    Assert::equals(1, $this->run('declare(strict_types = 0); class %T {
       public static function number(int $n) { return $n; }
       public function run() { return self::number("1"); }
     }'));
@@ -23,7 +23,7 @@ class DeclareTest extends EmittingTest {
 
   #[Test, Expect(class: Error::class, message: '/must be of (the )?type int(eger)?, string given/')]
   public function strict_types_on() {
-    $this->run('declare(strict_types = 1); class <T> {
+    $this->run('declare(strict_types = 1); class %T {
       public static function number(int $n) { return $n; }
       public function run() { return self::number("1"); }
     }');

--- a/src/test/php/lang/ast/unittest/emit/EchoTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EchoTest.class.php
@@ -15,7 +15,7 @@ class EchoTest extends EmittingTest {
   private function assertEchoes($expected, $statement) {
     ob_start();
     try {
-      $this->run('class <T> {
+      $this->run('class %T {
         private function hello() { return "Hello"; }
         public function run() { '.$statement.' }
       }');

--- a/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EmittingTest.class.php
@@ -70,35 +70,6 @@ abstract class EmittingTest {
   }
 
   /**
-   * Declare a type
-   *
-   * @deprecated Use `declare()` instead
-   * @param  string $code
-   * @return lang.XPClass
-   */
-  protected function type($code) {
-    $name= 'T'.(self::$id++);
-    $tree= $this->language->parse(new Tokens(str_replace('<T>', $name, $code), static::class))->tree();
-    if (isset($this->output['ast'])) {
-      Console::writeLine();
-      Console::writeLine('=== ', static::class, ' ===');
-      Console::writeLine($tree);
-    }
-
-    $out= new MemoryOutputStream();
-    $this->emitter->emitAll(new GeneratedCode($out, ''), $tree->children());
-    if (isset($this->output['code'])) {
-      Console::writeLine();
-      Console::writeLine('=== ', static::class, ' ===');
-      Console::writeLine($out->bytes());
-    }
-
-    $class= ($package= $tree->scope()->package) ? strtr(substr($package, 1), '\\', '.').'.'.$name : $name;
-    $this->cl->setClassBytes($class, $out->bytes());
-    return $this->cl->loadClass($class);
-  }
-
-  /**
    * Declare a type with a unique type name (which may be referenced by `%T`)
    * and return a reflection instance referencing it.
    *
@@ -140,7 +111,7 @@ abstract class EmittingTest {
    * @return var
    */
   protected function run($code, ... $args) {
-    return $this->type($code)->newInstance()->run(...$args);
+    return $this->declare($code)->newInstance()->run(...$args);
   }
 
   #[After]

--- a/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
@@ -2,8 +2,8 @@
 
 use lang\reflection\{Kind, InvocationFailed};
 use lang\{Enum, Error};
-use test\verify\Condition;
-use test\{Action, Assert, Expect, Ignore, Test, Values};
+use test\verify\{Condition, Runtime};
+use test\{Action, Assert, Expect, Test, Values};
 
 #[Condition(assert: 'function_exists("enum_exists")')]
 class EnumTest extends EmittingTest {
@@ -207,7 +207,7 @@ class EnumTest extends EmittingTest {
     Assert::equals(['Test' => []], $this->annotations($t));
   }
 
-  #[Test, Ignore('XP reflection does not support constant annotations')]
+  #[Test, Runtime(php: '>=8.1')]
   public function enum_member_annotations() {
     $t= $this->declare('enum %T { #[Test] case ONE; }');
     Assert::equals(['Test' => []], $this->annotations($t->constant('ONE')));

--- a/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\reflect\TargetInvocationException;
+use lang\reflection\{Kind, InvocationFailed};
 use lang\{Enum, Error};
 use test\verify\Condition;
 use test\{Action, Assert, Expect, Ignore, Test, Values};
@@ -8,14 +8,28 @@ use test\{Action, Assert, Expect, Ignore, Test, Values};
 #[Condition(assert: 'function_exists("enum_exists")')]
 class EnumTest extends EmittingTest {
 
+  /**
+   * Returns annotations present in the given type
+   *
+   * @param  lang.reflection.Annotated $annotated
+   * @return [:var[]]
+   */
+  private function annotations($annotated) {
+    $r= [];
+    foreach ($annotated->annotations() as $name => $annotation) {
+      $r[$name]= $annotation->arguments();
+    }
+    return $r;
+  }
+
   #[Test]
   public function enum_type() {
-    Assert::true($this->type('enum <T> { }')->isEnum());
+    Assert::equals(Kind::$ENUM, $this->declare('enum %T { }')->kind());
   }
 
   #[Test]
   public function name_property() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case Hearts;
       case Diamonds;
       case Clubs;
@@ -26,12 +40,12 @@ class EnumTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('Hearts', $t->getMethod('run')->invoke(null));
+    Assert::equals('Hearts', $t->method('run')->invoke(null));
   }
 
   #[Test]
   public function cases_method_for_unit_enums() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case Hearts;
       case Diamonds;
       case Clubs;
@@ -40,13 +54,13 @@ class EnumTest extends EmittingTest {
 
     Assert::equals(
       ['Hearts', 'Diamonds', 'Clubs', 'Spades'],
-      array_map(function($suit) { return $suit->name; }, $t->getMethod('cases')->invoke(null))
+      array_map(function($suit) { return $suit->name; }, $t->method('cases')->invoke(null))
     );
   }
 
   #[Test]
   public function cases_method_for_backed_enums() {
-    $t= $this->type('enum <T>: string {
+    $t= $this->declare('enum %T: string {
       case Hearts = "♥";
       case Diamonds = "♦";
       case Clubs = "♣";
@@ -55,13 +69,13 @@ class EnumTest extends EmittingTest {
 
     Assert::equals(
       ['Hearts', 'Diamonds', 'Clubs', 'Spades'],
-      array_map(function($suit) { return $suit->name; }, $t->getMethod('cases')->invoke(null))
+      array_map(function($suit) { return $suit->name; }, $t->method('cases')->invoke(null))
     );
   }
 
   #[Test]
   public function cases_method_does_not_yield_constants() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case Hearts;
       case Diamonds;
       case Clubs;
@@ -72,13 +86,13 @@ class EnumTest extends EmittingTest {
 
     Assert::equals(
       ['Hearts', 'Diamonds', 'Clubs', 'Spades'],
-      array_map(function($suit) { return $suit->name; }, $t->getMethod('cases')->invoke(null))
+      array_map(function($suit) { return $suit->name; }, $t->method('cases')->invoke(null))
     );
   }
 
   #[Test]
   public function used_as_parameter_default() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case ASC;
       case DESC;
 
@@ -87,12 +101,12 @@ class EnumTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('ASC', $t->getMethod('run')->invoke(null));
+    Assert::equals('ASC', $t->method('run')->invoke(null));
   }
 
   #[Test]
   public function overwritten_parameter_default_value() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case ASC;
       case DESC;
 
@@ -101,12 +115,12 @@ class EnumTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('DESC', $t->getMethod('run')->invoke(null, [Enum::valueOf($t, 'DESC')]));
+    Assert::equals('DESC', $t->method('run')->invoke(null, [Enum::valueOf($t, 'DESC')]));
   }
 
   #[Test]
   public function value_property_of_backed_enum() {
-    $t= $this->type('enum <T>: string {
+    $t= $this->declare('enum %T: string {
       case ASC  = "asc";
       case DESC = "desc";
 
@@ -115,45 +129,45 @@ class EnumTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('desc', $t->getMethod('run')->invoke(null));
+    Assert::equals('desc', $t->method('run')->invoke(null));
   }
 
   #[Test, Values([[0, 'NO'], [1, 'YES']])]
   public function backed_enum_from_int($arg, $expected) {
-    $t= $this->type('enum <T>: int {
+    $t= $this->declare('enum %T: int {
       case NO  = 0;
       case YES = 1;
     }');
 
-    Assert::equals($expected, $t->getMethod('from')->invoke(null, [$arg])->name);
+    Assert::equals($expected, $t->method('from')->invoke(null, [$arg])->name);
   }
 
   #[Test, Values([['asc', 'ASC'], ['desc', 'DESC']])]
   public function backed_enum_from_string($arg, $expected) {
-    $t= $this->type('enum <T>: string {
+    $t= $this->declare('enum %T: string {
       case ASC  = "asc";
       case DESC = "desc";
     }');
 
-    Assert::equals($expected, $t->getMethod('from')->invoke(null, [$arg])->name);
+    Assert::equals($expected, $t->method('from')->invoke(null, [$arg])->name);
   }
 
   #[Test, Expect(class: Error::class, message: '/"illegal" is not a valid backing value for enum .+/')]
   public function backed_enum_from_nonexistant() {
-    $t= $this->type('enum <T>: string {
+    $t= $this->declare('enum %T: string {
       case ASC  = "asc";
       case DESC = "desc";
     }');
     try {
-      $t->getMethod('from')->invoke(null, ['illegal']);
-    } catch (TargetInvocationException $e) {
+      $t->method('from')->invoke(null, ['illegal']);
+    } catch (InvocationFailed $e) {
       throw $e->getCause();
     }
   }
 
   #[Test, Values([['asc', 'ASC'], ['desc', 'DESC'], ['illegal', null]])]
   public function backed_enum_tryFrom($arg, $expected) {
-    $t= $this->type('enum <T>: string {
+    $t= $this->declare('enum %T: string {
       case ASC  = "asc";
       case DESC = "desc";
 
@@ -162,12 +176,12 @@ class EnumTest extends EmittingTest {
       }
     }');
 
-    Assert::equals($expected, $t->getMethod('run')->invoke(null, [$arg]));
+    Assert::equals($expected, $t->method('run')->invoke(null, [$arg]));
   }
 
   #[Test]
   public function declare_method_on_enum() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case Hearts;
       case Diamonds;
       case Clubs;
@@ -185,36 +199,36 @@ class EnumTest extends EmittingTest {
       }
     }');
 
-    Assert::equals('red', $t->getMethod('run')->invoke(null));
+    Assert::equals('red', $t->method('run')->invoke(null));
   }
 
   #[Test]
   public function enum_implementing_interface() {
-    $t= $this->type('use lang\Closeable; enum <T> implements Closeable {
+    $t= $this->declare('use lang\Closeable; enum %T implements Closeable {
       case File;
       case Stream;
 
       public function close() { }
     }');
 
-    Assert::true($t->isSubclassOf('lang.Closeable'));
+    Assert::true($t->is('lang.Closeable'));
   }
 
   #[Test]
   public function enum_annotations() {
-    $t= $this->type('#[Test] enum <T> { }');
-    Assert::equals(['test' => null], $t->getAnnotations());
+    $t= $this->declare('#[Test] enum %T { }');
+    Assert::equals(['Test' => []], $this->annotations($t));
   }
 
-  #[Test, Ignore('XP core reflection does not support constant annotations')]
+  #[Test, Ignore('XP reflection does not support constant annotations')]
   public function enum_member_annotations() {
-    $t= $this->type('enum <T> { #[Test] case ONE; }');
-    Assert::equals(['test' => null], $t->getConstant('ONE')->getAnnotations());
+    $t= $this->declare('enum %T { #[Test] case ONE; }');
+    Assert::equals(['Test' => []], $this->annotations($t->constant('ONE')));
   }
 
   #[Test]
   public function cannot_be_cloned() {
-    $t= $this->type('use lang\IllegalStateException; enum <T> {
+    $t= $this->declare('use lang\IllegalStateException; enum %T {
       case ONE;
 
       public static function run() {
@@ -229,13 +243,13 @@ class EnumTest extends EmittingTest {
 
     Assert::equals(
       'Trying to clone an uncloneable object of class '.$t->literal(),
-      $t->getMethod('run')->invoke(null)
+      $t->method('run')->invoke(null)
     );
   }
 
   #[Test]
   public function enum_values() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case Hearts;
       case Diamonds;
       case Clubs;
@@ -250,7 +264,7 @@ class EnumTest extends EmittingTest {
 
   #[Test]
   public function enum_value() {
-    $t= $this->type('enum <T> {
+    $t= $this->declare('enum %T {
       case Hearts;
       case Diamonds;
       case Clubs;

--- a/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/EnumTest.class.php
@@ -7,20 +7,7 @@ use test\{Action, Assert, Expect, Ignore, Test, Values};
 
 #[Condition(assert: 'function_exists("enum_exists")')]
 class EnumTest extends EmittingTest {
-
-  /**
-   * Returns annotations present in the given type
-   *
-   * @param  lang.reflection.Annotated $annotated
-   * @return [:var[]]
-   */
-  private function annotations($annotated) {
-    $r= [];
-    foreach ($annotated->annotations() as $name => $annotation) {
-      $r[$name]= $annotation->arguments();
-    }
-    return $r;
-  }
+  use AnnotationsOf;
 
   #[Test]
   public function enum_type() {

--- a/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ExceptionsTest.class.php
@@ -7,7 +7,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function catch_exception() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() {
         try {
           throw new \\lang\\IllegalArgumentException("test");
@@ -22,7 +22,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function line_number_matches() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() {
         try {
           throw new \\lang\\IllegalArgumentException("test");
@@ -37,7 +37,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function catch_without_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() {
         try {
           throw new \\lang\\IllegalArgumentException("test");
@@ -52,7 +52,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function non_capturing_catch() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() {
         try {
           throw new \\lang\\IllegalArgumentException("test");
@@ -67,7 +67,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function finally_without_exception() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public $closed= false;
       public function run() {
         try {
@@ -85,7 +85,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function finally_with_exception() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public $closed= false;
       public function run() {
         try {
@@ -107,7 +107,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_this() {
-    $this->run('class <T> {
+    $this->run('class %T {
       private $message= "test";
       public function run($user= null) {
         return $user ?? throw new \\lang\\IllegalArgumentException($this->message);
@@ -117,7 +117,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_null_coalesce() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($user) {
         return $user ?? throw new \\lang\\IllegalArgumentException("test");
       }
@@ -127,7 +127,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_short_ternary() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($user) {
         return $user ?: throw new \\lang\\IllegalArgumentException("test");
       }
@@ -137,7 +137,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_normal_ternary() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($user) {
         return $user ? new User($user) : throw new \\lang\\IllegalArgumentException("test");
       }
@@ -147,7 +147,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_binary_or() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($user) {
         return $user || throw new \\lang\\IllegalArgumentException("test");
       }
@@ -157,7 +157,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_binary_and() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($error) {
         return $error && throw new \\lang\\IllegalArgumentException("test");
       }
@@ -167,7 +167,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_lambda() {
-    $this->run('use lang\IllegalArgumentException; class <T> {
+    $this->run('use lang\IllegalArgumentException; class %T {
       public function run() {
         $f= fn() => throw new IllegalArgumentException("test");
         $f();
@@ -177,7 +177,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_lambda_throwing_variable() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($e) {
         $f= fn() => throw $e;
         $f();
@@ -188,7 +188,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_lambda_capturing_variable() {
-    $this->run('use lang\IllegalArgumentException; class <T> {
+    $this->run('use lang\IllegalArgumentException; class %T {
       public function run() {
         $f= fn($message) => throw new IllegalArgumentException($message);
         $f("test");
@@ -198,7 +198,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function throw_expression_with_lambda_capturing_parameter() {
-    $t= $this->type('use lang\IllegalArgumentException; class <T> {
+    $t= $this->declare('use lang\IllegalArgumentException; class %T {
       public function run($message) {
         $f= fn() => throw new IllegalArgumentException($message);
         $f();
@@ -209,7 +209,7 @@ class ExceptionsTest extends EmittingTest {
 
   #[Test]
   public function try_catch_nested_inside_catch() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() {
         try {
           throw new \\lang\\IllegalArgumentException("test");

--- a/src/test/php/lang/ast/unittest/emit/FunctionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/FunctionTypesTest.class.php
@@ -13,25 +13,25 @@ class FunctionTypesTest extends EmittingTest {
 
   #[Test]
   public function function_without_parameters() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private (function(): string) $test;
     }');
 
     Assert::equals(
       new FunctionType([], Primitive::$STRING),
-      $t->getField('test')->getType()
+      $t->property('test')->constraint()->type()
     );
   }
 
   #[Test]
   public function function_with_parameters() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private (function(int, string): string) $test;
     }');
 
     Assert::equals(
       new FunctionType([Primitive::$INT, Primitive::$STRING], Primitive::$STRING),
-      $t->getField('test')->getType()
+      $t->property('test')->constraint()->type()
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/GotoTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/GotoTest.class.php
@@ -6,7 +6,7 @@ class GotoTest extends EmittingTest {
 
   #[Test]
   public function skip_forward() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         goto skip;
         return false;
@@ -19,7 +19,7 @@ class GotoTest extends EmittingTest {
 
   #[Test]
   public function skip_backward() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $return= false;
         retry: if ($return) return true;

--- a/src/test/php/lang/ast/unittest/emit/ImportTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ImportTest.class.php
@@ -16,7 +16,7 @@ class ImportTest extends EmittingTest {
     Assert::equals(Date::class, $this->run('
       use util\Date;
 
-      class <T> {
+      class %T {
         public function run() { return Date::class; }
       }'
     ));
@@ -27,7 +27,7 @@ class ImportTest extends EmittingTest {
     Assert::equals(Date::class, $this->run('
       use util\Date as D;
 
-      class <T> {
+      class %T {
         public function run() { return D::class; }
       }'
     ));
@@ -38,7 +38,7 @@ class ImportTest extends EmittingTest {
     Assert::equals('imported', $this->run('
       use const lang\ast\unittest\emit\FIXTURE;
 
-      class <T> {
+      class %T {
         public function run() { return FIXTURE; }
       }'
     ));
@@ -49,7 +49,7 @@ class ImportTest extends EmittingTest {
     Assert::equals('imported', $this->run('
       use function lang\ast\unittest\emit\fixture;
 
-      class <T> {
+      class %T {
         public function run() { return fixture(); }
       }'
     ));
@@ -60,7 +60,7 @@ class ImportTest extends EmittingTest {
     Assert::equals(Traversable::class, $this->run('namespace test;
       use Traversable;
 
-      class <T> {
+      class %T {
         public function run() { return Traversable::class; }
       }'
     ));
@@ -71,7 +71,7 @@ class ImportTest extends EmittingTest {
     Assert::equals([Traversable::class, Iterator::class], $this->run('namespace test;
       use Traversable, Iterator;
 
-      class <T> {
+      class %T {
         public function run() { return [Traversable::class, Iterator::class]; }
       }'
     ));

--- a/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InitializeWithExpressionsTest.class.php
@@ -29,43 +29,43 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test, Values(from: 'expressions')]
   public function property($declaration, $expected) {
-    Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\{FileInput, Handle}; class <T> {
+    Assert::equals($expected, $this->run(strtr('use lang\ast\unittest\emit\{FileInput, Handle}; class %T {
       const INITIAL= "initial";
-      private $h= %s;
+      private $h= %D;
 
       public function run() {
         return $this->h;
       }
-    }', $declaration)));
+    }', ['%D' => $declaration])));
   }
 
   #[Test, Values(from: 'expressions')]
   public function reflective_access_to_property($declaration, $expected) {
-    Assert::equals($expected, $this->run(sprintf('use lang\ast\unittest\emit\{FileInput, Handle}; class <T> {
+    Assert::equals($expected, $this->run(strtr('use lang\ast\unittest\emit\{FileInput, Handle}; class %T {
       const INITIAL= "initial";
-      private $h= %s;
+      private $h= %D;
 
       public function run() {
         return typeof($this)->getField("h")->get($this);
       }
-    }', $declaration)));
+    }', ['%D' => $declaration])));
   }
 
   #[Test, Values(['fn($arg) => $arg->redirect(1)', 'function($arg) { return $arg->redirect(1); }'])]
   public function using_closures($declaration) {
-    $r= $this->run(sprintf('class <T> {
-      private $h= %s;
+    $r= $this->run(strtr('class %T {
+      private $h= %D;
 
       public function run() {
         return $this->h;
       }
-    }', $declaration));
+    }', ['%D' => $declaration]));
     Assert::equals(new Handle(1), $r(new Handle(0)));
   }
 
   #[Test]
   public function using_closures_referencing_this() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private $id= 1;
       private $h= fn() => new Handle($this->id);
 
@@ -78,7 +78,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function using_new_referencing_this() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private $id= 1;
       private $h= new Handle($this->id);
 
@@ -91,7 +91,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function using_anonymous_classes() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $h= new class() { public function pipe($h) { return $h->redirect(1); } };
 
       public function run() {
@@ -103,7 +103,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function property_initialization_accessible_inside_constructor() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private $h= new Handle(0);
 
       public function __construct() {
@@ -119,7 +119,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function promoted_property() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function __construct(private $h= new Handle(0)) { }
 
       public function run() {
@@ -131,7 +131,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function parameter_default_when_omitted() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run($h= new Handle(0)) {
         return $h;
       }
@@ -141,7 +141,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function parameter_default_when_passed() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run($h= new Handle(0)) {
         return $h;
       }
@@ -151,7 +151,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function parameter_default_reflective_access() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run($h= new Handle(0)) {
         return typeof($this)->getMethod("run")->getParameter(0)->getDefaultValue();
       }
@@ -161,7 +161,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function property_reference_as_parameter_default() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private static $h= new Handle(0);
 
       public function run($h= self::$h) {
@@ -173,7 +173,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function typed_proprety() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private Handle $h= new Handle(0);
 
       public function run() {
@@ -185,7 +185,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function typed_parameter() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run(Handle $h= new Handle(0)) {
         return $h;
       }
@@ -195,7 +195,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function static_variable() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         static $h= new Handle(0);
 
@@ -207,7 +207,7 @@ class InitializeWithExpressionsTest extends EmittingTest {
 
   #[Test]
   public function with_argument_promotion() {
-    $t= $this->type('use lang\ast\unittest\emit\Handle; class <T> {
+    $t= $this->declare('use lang\ast\unittest\emit\Handle; class %T {
       private $h= new Handle(0);
 
       public function __construct(private Handle $p) { }

--- a/src/test/php/lang/ast/unittest/emit/InstanceOfTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstanceOfTest.class.php
@@ -6,7 +6,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function this_is_instanceof_self() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return $this instanceof self;
       }
@@ -17,7 +17,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function new_self_is_instanceof_this() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new self() instanceof $this;
       }
@@ -28,7 +28,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function instanceof_qualified_type() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new \util\Date() instanceof \util\Date;
       }
@@ -39,7 +39,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function instanceof_imported_type() {
-    $r= $this->run('use util\Date; class <T> {
+    $r= $this->run('use util\Date; class %T {
       public function run() {
         return new Date() instanceof Date;
       }
@@ -50,7 +50,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function instanceof_aliased_type() {
-    $r= $this->run('use util\Date as D; class <T> {
+    $r= $this->run('use util\Date as D; class %T {
       public function run() {
         return new D() instanceof D;
       }
@@ -61,7 +61,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function instanceof_instance_expr() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $type= self::class;
 
       public function run() {
@@ -74,7 +74,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function instanceof_scope_expr() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static $type= self::class;
 
       public function run() {
@@ -87,7 +87,7 @@ class InstanceOfTest extends EmittingTest {
 
   #[Test]
   public function instanceof_expr() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function type() { return self::class; }
 
       public function run() {

--- a/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InstantiationTest.class.php
@@ -7,7 +7,7 @@ class InstantiationTest extends EmittingTest {
 
   #[Test]
   public function new_type() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new \\util\\Date();
       }
@@ -17,7 +17,7 @@ class InstantiationTest extends EmittingTest {
 
   #[Test]
   public function new_var() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $class= \\util\\Date::class;
         return new $class();
@@ -28,7 +28,7 @@ class InstantiationTest extends EmittingTest {
 
   #[Test]
   public function new_dynamic_var() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $class= \\util\\Date::class;
         $var= "class";
@@ -40,7 +40,7 @@ class InstantiationTest extends EmittingTest {
 
   #[Test]
   public function new_var_expr() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $class= \\util\\Date::class;
         $var= "class";
@@ -52,7 +52,7 @@ class InstantiationTest extends EmittingTest {
 
   #[Test]
   public function new_expr() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function factory() { return \\util\\Date::class; }
 
       public function run() {
@@ -64,7 +64,7 @@ class InstantiationTest extends EmittingTest {
 
   #[Test]
   public function passing_argument() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public $value;
 
       public function __construct($value= null) { $this->value= $value; }

--- a/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/IntersectionTypesTest.class.php
@@ -13,73 +13,73 @@ class IntersectionTypesTest extends EmittingTest {
 
   #[Test]
   public function field_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private Traversable&Countable $test;
     }');
 
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getField('test')->getType()
+      $t->property('test')->constraint()->type()
     );
   }
 
   #[Test]
   public function parameter_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(Traversable&Countable $arg) { }
     }');
 
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getMethod('test')->getParameter(0)->getType()
+      $t->method('test')->parameter(0)->constraint()->type()
     );
   }
 
   #[Test]
   public function return_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): Traversable&Countable { }
     }');
 
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getMethod('test')->getReturnType()
+      $t->method('test')->returns()->type()
     );
   }
 
   #[Test, Runtime(php: '>=8.1.0-dev')]
   public function field_type_restriction_with_php81() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private Traversable&Countable $test;
     }');
 
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getField('test')->getTypeRestriction()
+      $t->property('test')->constraint()->type()
     );
   }
 
-  #[Test, Runtime(php: '>=8.1.0-dev')]
+  #[Test, Runtime(php: '>=8.1.0')]
   public function parameter_type_restriction_with_php81() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(Traversable&Countable $arg) { }
     }');
 
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getMethod('test')->getParameter(0)->getTypeRestriction()
+      $t->method('test')->parameter(0)->constraint()->type()
     );
   }
 
-  #[Test, Runtime(php: '>=8.1.0-dev')]
+  #[Test, Runtime(php: '>=8.1.0')]
   public function return_type_restriction_with_php81() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): Traversable&Countable { }
     }');
 
     Assert::equals(
       new TypeIntersection([new XPClass('Traversable'), new XPClass('Countable')]),
-      $t->getMethod('test')->getReturnTypeRestriction()
+      $t->method('test')->returns()->type()
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/InvocationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/InvocationTest.class.php
@@ -8,7 +8,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function instance_method() {
     Assert::equals('instance', $this->run(
-      'class <T> {
+      'class %T {
 
         public function instanceMethod() { return "instance"; }
 
@@ -22,7 +22,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function instance_method_dynamic_variable() {
     Assert::equals('instance', $this->run(
-      'class <T> {
+      'class %T {
 
         public function instanceMethod() { return "instance"; }
 
@@ -37,7 +37,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function instance_method_dynamic_expression() {
     Assert::equals('instance', $this->run(
-      'class <T> {
+      'class %T {
 
         public function instanceMethod() { return "instance"; }
 
@@ -52,7 +52,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function static_method() {
     Assert::equals('static', $this->run(
-      'class <T> {
+      'class %T {
 
         public function staticMethod() { return "static"; }
 
@@ -66,7 +66,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function static_method_dynamic() {
     Assert::equals('static', $this->run(
-      'class <T> {
+      'class %T {
 
         public static function staticMethod() { return "static"; }
 
@@ -81,7 +81,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function closure() {
     Assert::equals('closure', $this->run(
-      'class <T> {
+      'class %T {
 
         public function run() {
           $f= function() { return "closure"; };
@@ -95,7 +95,7 @@ class InvocationTest extends EmittingTest {
   public function global_function() {
     Assert::equals('function', $this->run(
       'function fixture() { return "function"; }
-      class <T> {
+      class %T {
 
         public function run() {
           return fixture();
@@ -107,7 +107,7 @@ class InvocationTest extends EmittingTest {
   #[Test]
   public function function_self_reference() {
     Assert::equals(13, $this->run(
-      'class <T> {
+      'class %T {
 
         public function run() {
           $fib= function($i) use(&$fib) {
@@ -126,7 +126,7 @@ class InvocationTest extends EmittingTest {
   #[Test, Values(['"html(<) = &lt;", flags: ENT_HTML5', '"html(<) = &lt;", ENT_HTML5, double: true', 'string: "html(<) = &lt;", flags: ENT_HTML5', 'string: "html(<) = &lt;", flags: ENT_HTML5, double: true',])]
   public function named_arguments_in_exact_order($arguments) {
     Assert::equals('html(&lt;) = &amp;lt;', $this->run(
-      'class <T> {
+      'class %T {
 
         public function escape($string, $flags= ENT_HTML5, $double= true) {
           return htmlspecialchars($string, $flags, null, $double);
@@ -142,7 +142,7 @@ class InvocationTest extends EmittingTest {
   #[Test, Runtime(php: '>=8.0')]
   public function named_arguments_in_reverse_order() {
     Assert::equals('html(&lt;) = &amp;lt;', $this->run(
-      'class <T> {
+      'class %T {
 
         public function escape($string, $flags= ENT_HTML5, $double= true) {
           return htmlspecialchars($string, $flags, null, $double);
@@ -158,7 +158,7 @@ class InvocationTest extends EmittingTest {
   #[Test, Runtime(php: '>=8.0')]
   public function named_arguments_omitting_one() {
     Assert::equals('html(&lt;) = &lt;', $this->run(
-      'class <T> {
+      'class %T {
 
         public function escape($string, $flags= ENT_HTML5, $double= true) {
           return htmlspecialchars($string, $flags, null, $double);

--- a/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LambdasTest.class.php
@@ -15,7 +15,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function inc() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn($a) => $a + 1;
       }
@@ -26,7 +26,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function add() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn($a, $b) => $a + $b;
       }
@@ -37,7 +37,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_this() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $addend= 2;
 
       public function run() {
@@ -50,7 +50,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test, Condition(assert: 'property_exists(LambdaExpression::class, "static")')]
   public function static_fn_does_not_capture_this() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return static fn() => isset($this);
       }
@@ -61,7 +61,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test, Condition(assert: 'property_exists(ClosureExpression::class, "static")')]
   public function static_function_does_not_capture_this() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return static function() { return isset($this); };
       }
@@ -72,7 +72,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_local() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $addend= 2;
         return fn($a) => $a + $addend;
@@ -84,7 +84,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_local_from_use_list() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $addend= 2;
         $f= function() use($addend) {
@@ -99,7 +99,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_local_from_lambda() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $addend= 2;
         $f= fn() => fn($a) => $a + $addend;
@@ -112,7 +112,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_local_assigned_via_list() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         [$addend]= [2];
         return fn($a) => $a + $addend;
@@ -124,7 +124,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_param() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($addend) {
         return fn($a) => $a + $addend;
       }
@@ -135,7 +135,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function captures_braced_local() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $addend= 2;
         return fn($a) => $a + ($addend);
@@ -147,7 +147,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function typed_parameters() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn(\\lang\\Value $in) => $in;
       }
@@ -158,7 +158,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function typed_return() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn($in): \\lang\\Value => $in;
       }
@@ -169,7 +169,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function without_params() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn() => 1;
       }
@@ -180,7 +180,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function immediately_invoked_function_expression() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return (fn() => "IIFE")();
       }
@@ -191,7 +191,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function with_block() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return fn() => {
           $a= 1;
@@ -205,7 +205,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test]
   public function capturing_with_block() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $a= 1;
         return fn() => {
@@ -219,7 +219,7 @@ class LambdasTest extends EmittingTest {
 
   #[Test, Expect(Errors::class)]
   public function no_longer_supports_hacklang_variant() {
-    $this->run('class <T> {
+    $this->run('class %T {
       public function run() {
         $func= ($arg) ==> { return 1; };
       }

--- a/src/test/php/lang/ast/unittest/emit/LoopsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/LoopsTest.class.php
@@ -6,7 +6,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_value() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         foreach ([1, 2, 3] as $number) {
@@ -21,7 +21,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_key_and_value() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         foreach (["a" => 1, "b" => 2, "c" => 3] as $key => $number) {
@@ -36,7 +36,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_single_expression() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         foreach ([1, 2, 3] as $number) $result.= ",".$number;
@@ -49,7 +49,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_destructuring() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         foreach ([[1, 2], [3, 4]] as [$a, $b]) $result.= ",".$a." & ".$b;
@@ -62,7 +62,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_destructuring_and_missing_expressions() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         foreach ([[1, 2, 3], [4, 5, 6]] as [$a, , $b]) $result.= ",".$a." & ".$b;
@@ -75,7 +75,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_destructuring_keys() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         foreach ([["a" => 1, "b" => 2], ["a" => 3, "b" => 4]] as ["a" => $a, "b" => $b]) $result.= ",".$a." & ".$b;
@@ -88,7 +88,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function foreach_with_destructuring_references() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $list= [[1, 2], [3, 4]];
 
       public function run() {
@@ -105,7 +105,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function for_loop() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         for ($i= 1; $i < 4; $i++) {
@@ -120,7 +120,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function while_loop() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         $i= 0;
@@ -136,7 +136,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function do_loop() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $result= "";
         $i= 1;
@@ -152,7 +152,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function break_while_loop() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $i= 0;
         $r= [];
@@ -172,7 +172,7 @@ class LoopsTest extends EmittingTest {
 
   #[Test]
   public function continue_while_loop() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $i= 0;
         $r= [];

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -7,7 +7,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function class_property() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static $MEMBER= "Test";
 
       public function run() {
@@ -20,7 +20,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function typed_class_property() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static string $MEMBER= "Test";
 
       public function run() {
@@ -33,7 +33,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function class_method() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static function member() { return "Test"; }
 
       public function run() {
@@ -46,7 +46,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function class_constant() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private const MEMBER = "Test";
 
       public function run() {
@@ -59,9 +59,9 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function typed_class_constant() {
-    $t= Reflection::type($this->type('class <T> {
+    $t= $this->declare('class %T {
       private const string MEMBER = "Test";
-    }'));
+    }');
     $const= $t->constant('MEMBER');
 
     Assert::equals('Test', $const->value());
@@ -70,7 +70,7 @@ class MembersTest extends EmittingTest {
 
   #[Test, Values(['$this->$member', '$this->{$member}', '$this->{strtoupper($member)}'])]
   public function dynamic_instance_property($syntax) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $MEMBER= "Test";
 
       public function run() {
@@ -84,7 +84,7 @@ class MembersTest extends EmittingTest {
 
   #[Test, Values(['self::$$member', 'self::${$member}', 'self::${strtoupper($member)}'])]
   public function dynamic_class_property($syntax) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static $MEMBER= "Test";
 
       public function run() {
@@ -98,7 +98,7 @@ class MembersTest extends EmittingTest {
 
   #[Test, Values(['$this->$method()', '$this->{$method}()', '$this->{strtolower($method)}()'])]
   public function dynamic_instance_method($syntax) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function test() { return "Test"; }
 
       public function run() {
@@ -112,7 +112,7 @@ class MembersTest extends EmittingTest {
 
   #[Test, Values(['self::$method()', 'self::{$method}()', 'self::{strtolower($method)}()'])]
   public function dynamic_class_method($syntax) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static function test() { return "Test"; }
 
       public function run() {
@@ -126,7 +126,7 @@ class MembersTest extends EmittingTest {
 
   #[Test, Values(['self::{$member}', 'self::{strtoupper($member)}'])]
   public function dynamic_class_constant($syntax) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       const MEMBER= "Test";
 
       public function run() {
@@ -140,7 +140,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function property_of_dynamic_class() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static $MEMBER= "Test";
 
       public function run() {
@@ -154,7 +154,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function method_of_dynamic_class() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static function member() { return "Test"; }
 
       public function run() {
@@ -168,7 +168,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function constant_of_dynamic_class() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private const MEMBER = "Test";
 
       public function run() {
@@ -182,7 +182,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function object_class_constant() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private const MEMBER = "Test";
 
       public function run() {
@@ -195,7 +195,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function list_property() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $list= [1, 2, 3];
 
       public function run() {
@@ -208,7 +208,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function list_method() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function list() { return [1, 2, 3]; }
 
       public function run() {
@@ -221,7 +221,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function return_by_reference() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $list= [];
 
       public function &list() { return $this->list; }
@@ -238,7 +238,7 @@ class MembersTest extends EmittingTest {
 
   #[Test, Values(['variable', 'invocation', 'array'])]
   public function class_on_objects($via) {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private function this() { return $this; }
 
       public function variable() { return $this::class; }
@@ -249,12 +249,12 @@ class MembersTest extends EmittingTest {
     }');
 
     $fixture= $t->newInstance();
-    Assert::equals(get_class($fixture), $t->getMethod($via)->invoke($fixture));
+    Assert::equals(get_class($fixture), $t->method($via)->invoke($fixture));
   }
 
   #[Test]
   public function instance_property() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $member= "Test";
 
       public function run() {
@@ -267,7 +267,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function typed_instance_property() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private string $member= "Test";
 
       public function run() {
@@ -280,7 +280,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function instance_method() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function member() { return "Test"; }
 
       public function run() {
@@ -293,7 +293,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function static_initializer_run() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private static $MEMBER;
 
       static function __static() {
@@ -310,7 +310,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function enum_members() {
-    $r= $this->run('class <T> extends \lang\Enum {
+    $r= $this->run('class %T extends \lang\Enum {
       public static $MON, $TUE, $WED, $THU, $FRI, $SAT, $SUN;
 
       public function run() {
@@ -323,11 +323,11 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function allow_constant_syntax_for_members() {
-    $r= $this->run('use lang\{Enum, CommandLine}; class <T> extends Enum {
+    $r= $this->run('use lang\{Enum, CommandLine}; class %T extends Enum {
       public static $MON, $TUE, $WED, $THU, $FRI, $SAT, $SUN;
 
       public function run() {
-        return [self::MON->name(), <T>::TUE->name(), CommandLine::WINDOWS->name()];
+        return [self::MON->name(), %T::TUE->name(), CommandLine::WINDOWS->name()];
       }
     }');
 
@@ -336,7 +336,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function method_with_static() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         static $var= "Test";
         return $var;
@@ -348,7 +348,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function method_with_static_without_initializer() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         static $var;
         return $var;
@@ -360,7 +360,7 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function chaining_sccope_operators() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private const TYPE = self::class;
 
       private const NAME = "Test";
@@ -380,26 +380,26 @@ class MembersTest extends EmittingTest {
 
   #[Test]
   public function self_return_type() {
-    $t= $this->type('
-      class <T> { public function run(): self { return $this; } }
+    $t= $this->declare('
+      class %T { public function run(): self { return $this; } }
     ');
-    Assert::equals($t, $t->getMethod('run')->getReturnType());
+    Assert::equals($t->class(), $t->method('run')->returns()->type());
   }
 
   #[Test]
   public function static_return_type() {
-    $t= $this->type('
-      class <T>Base { public function run(): static { return $this; } }
-      class <T> extends <T>Base { }
+    $t= $this->declare('
+      class %TBase { public function run(): static { return $this; } }
+      class %T extends %TBase { }
     ');
-    Assert::equals($t, $t->getMethod('run')->getReturnType());
+    Assert::equals($t->parent()->class(), $t->method('run')->returns()->type());
   }
 
   #[Test]
   public function array_of_self_return_type() {
-    $t= $this->type('
-      class <T> { public function run(): array<self> { return [$this]; } }
+    $t= $this->declare('
+      class %T { public function run(): array<self> { return [$this]; } }
     ');
-    Assert::equals(new ArrayType($t), $t->getMethod('run')->getReturnType());
+    Assert::equals(new ArrayType($t->class()), $t->method('run')->returns()->type());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/MultipleCatchTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MultipleCatchTest.class.php
@@ -12,7 +12,7 @@ class MultipleCatchTest extends EmittingTest {
 
   #[Test, Values([IllegalArgumentException::class, IllegalStateException::class])]
   public function catch_both($type) {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($t) {
         try {
           throw new $t("test");

--- a/src/test/php/lang/ast/unittest/emit/NamespacesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NamespacesTest.class.php
@@ -7,17 +7,17 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function without_namespace() {
-    Assert::equals('', $this->type('class <T> { }')->getPackage()->getName());
+    Assert::null($this->declare('class %T { }')->package());
   }
 
   #[Test]
   public function with_namespace() {
-    Assert::equals('test', $this->type('namespace test; class <T> { }')->getPackage()->getName());
+    Assert::equals('test', $this->declare('namespace test; class %T { }')->package()->name());
   }
 
   #[Test]
   public function resolves_unqualified() {
-    $r= $this->run('namespace util; class <T> {
+    $r= $this->run('namespace util; class %T {
       public function run() {
         return new Date("1977-12-14");
       }
@@ -27,7 +27,7 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function resolves_relative() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new util\Date("1977-12-14");
       }
@@ -37,7 +37,7 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function resolves_absolute() {
-    $r= $this->run('namespace test; class <T> {
+    $r= $this->run('namespace test; class %T {
       public function run() {
         return new \util\Date("1977-12-14");
       }
@@ -47,7 +47,7 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function resolves_import() {
-    $r= $this->run('namespace test; use util\Date; class <T> {
+    $r= $this->run('namespace test; use util\Date; class %T {
       public function run() {
         return new Date("1977-12-14");
       }
@@ -57,7 +57,7 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function resolves_alias() {
-    $r= $this->run('namespace test; use util\Date as DateTime; class <T> {
+    $r= $this->run('namespace test; use util\Date as DateTime; class %T {
       public function run() {
         return new DateTime("1977-12-14");
       }
@@ -67,7 +67,7 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function resolves_namespace_keyword() {
-    $r= $this->run('namespace util; class <T> {
+    $r= $this->run('namespace util; class %T {
       public function run() {
         return new namespace\Date("1977-12-14");
       }
@@ -77,7 +77,7 @@ class NamespacesTest extends EmittingTest {
 
   #[Test]
   public function resolves_sub_namespace() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return new namespace\util\Date("1977-12-14");
       }

--- a/src/test/php/lang/ast/unittest/emit/NullCoalesceAssignmentTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NullCoalesceAssignmentTest.class.php
@@ -6,7 +6,7 @@ class NullCoalesceAssignmentTest extends EmittingTest {
 
   #[Test, Values([[null, true], [false, false], ['Test', 'Test']])]
   public function assigns_true_if_null($value, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         $arg??= true;
         return $arg;
@@ -18,7 +18,7 @@ class NullCoalesceAssignmentTest extends EmittingTest {
 
   #[Test, Values([[[], true], [[null], true], [[false], false], [['Test'], 'Test']])]
   public function fills_array_if_non_existant_or_null($value, $expected) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run($arg) {
         $arg[0]??= true;
         return $arg;

--- a/src/test/php/lang/ast/unittest/emit/NullCoalesceTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NullCoalesceTest.class.php
@@ -6,7 +6,7 @@ class NullCoalesceTest extends EmittingTest {
 
   #[Test]
   public function on_null() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return null ?? true;
       }
@@ -17,7 +17,7 @@ class NullCoalesceTest extends EmittingTest {
 
   #[Test]
   public function on_unset_array_key() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return $array["key"] ?? true;
       }
@@ -28,7 +28,7 @@ class NullCoalesceTest extends EmittingTest {
 
   #[Test]
   public function assignment_operator() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $array["key"] ??= true;
         return $array;

--- a/src/test/php/lang/ast/unittest/emit/NullSafeTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/NullSafeTest.class.php
@@ -14,7 +14,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function method_call_on_null() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $object= null;
         return $object?->method();
@@ -26,7 +26,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function method_call_on_object() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $object= new class() {
           public function method() { return true; }
@@ -40,7 +40,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function member_access_on_null() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $object= null;
         return $object?->member;
@@ -52,7 +52,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function member_access_on_object() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $object= new class() {
           public $member= true;
@@ -67,17 +67,17 @@ class NullSafeTest extends EmittingTest {
   #[Test]
   public function chained_method_call() {
     $r= $this->run('
-      class <T>Invocation {
+      class %TInvocation {
         public static $invoked= [];
         public function __construct(private $name, private $chained) { }
         public function chained() { self::$invoked[]= $this->name; return $this->chained; }
       }
 
-      class <T> {
+      class %T {
         public function run() {
-          $invokation= new <T>Invocation("outer", new <T>Invocation("inner", null));
+          $invokation= new %TInvocation("outer", new %TInvocation("inner", null));
           $return= $invokation?->chained()?->chained()?->chained();
-          return [$return, <T>Invocation::$invoked];
+          return [$return, %TInvocation::$invoked];
         }
       }
     ');
@@ -87,7 +87,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function dynamic_member_access_on_object() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $object= new class() {
           public $member= true;
@@ -104,7 +104,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function short_circuiting_chain() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         $null= null;
         return $null?->method($undefined->method());
@@ -116,7 +116,7 @@ class NullSafeTest extends EmittingTest {
 
   #[Test]
   public function short_circuiting_parameter() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function pass($object) {
         return $object;
       }

--- a/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ParameterTest.class.php
@@ -5,21 +5,7 @@ use test\verify\Runtime;
 use test\{Action, Assert, Test, Values};
 
 class ParameterTest extends EmittingTest {
-  use NullableSupport;
-
-  /**
-   * Returns annotations present in the given type
-   *
-   * @param  lang.reflection.Annotated $annotated
-   * @return [:var[]]
-   */
-  private function annotations($annotated) {
-    $r= [];
-    foreach ($annotated->annotations() as $name => $annotation) {
-      $r[$name]= $annotation->arguments();
-    }
-    return $r;
-  }
+  use AnnotationsOf, NullableSupport;
 
   /**
    * Helper to declare a type and return a parameter reflection object

--- a/src/test/php/lang/ast/unittest/emit/PrecedenceTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PrecedenceTest.class.php
@@ -7,7 +7,7 @@ class PrecedenceTest extends EmittingTest {
   #[Test, Values([['2 + 3 * 4', 14], ['2 + 8 / 4', 4], ['2 + 3 ** 2', 11], ['2 + 5 % 2', 3]])]
   public function mathematical($input, $result) {
     Assert::equals($result, $this->run(
-      'class <T> {
+      'class %T {
         public function run() {
           return '.$input.';
         }
@@ -17,8 +17,8 @@ class PrecedenceTest extends EmittingTest {
 
   #[Test]
   public function concatenation() {
-    $t= $this->type(
-      'class <T> {
+    $t= $this->declare(
+      'class %T {
         public function run() {
           return "(".self::class.")";
         }
@@ -29,8 +29,8 @@ class PrecedenceTest extends EmittingTest {
 
   #[Test]
   public function plusplus() {
-    $t= $this->type(
-      'class <T> {
+    $t= $this->declare(
+      'class %T {
         private $number= 1;
 
         public function run() {

--- a/src/test/php/lang/ast/unittest/emit/PropertyTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PropertyTypesTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
+use lang\{XPClass, Primitive};
 use test\{Assert, Test};
 
 /**
@@ -12,28 +13,28 @@ class PropertyTypesTest extends EmittingTest {
 
   #[Test]
   public function int_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $test;
     }');
 
-    Assert::equals('int', $t->getField('test')->getTypeName());
+    Assert::equals(Primitive::$INT, $t->property('test')->constraint()->type());
   }
 
   #[Test]
   public function self_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private static self $instance;
     }');
 
-    Assert::equals('self', $t->getField('instance')->getTypeName());
+    Assert::equals($t->class(), $t->property('instance')->constraint()->type());
   }
 
   #[Test]
   public function interface_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private \\lang\\Value $value;
     }');
 
-    Assert::equals('lang.Value', $t->getField('value')->getTypeName());
+    Assert::equals(XPClass::forName('lang.Value'), $t->property('value')->constraint()->type());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/ReturnTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReturnTest.class.php
@@ -6,7 +6,7 @@ class ReturnTest extends EmittingTest {
 
   #[Test]
   public function return_literal() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return "Test";
       }
@@ -16,7 +16,7 @@ class ReturnTest extends EmittingTest {
 
   #[Test]
   public function return_member() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private $member= "Test";
 
       public function run() {
@@ -28,7 +28,7 @@ class ReturnTest extends EmittingTest {
 
   #[Test]
   public function return_without_expression() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return;
       }

--- a/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ScalarsTest.class.php
@@ -6,36 +6,36 @@ class ScalarsTest extends EmittingTest {
 
   #[Test, Values([['0', 0], ['1', 1], ['-1', -1], ['1.5', 1.5], ['-1.5', -1.5],])]
   public function numbers($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 
   #[Test, Values([['0b0', 0], ['0b10', 2], ['0B10', 2]])]
   public function binary_numbers($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 
   #[Test, Values([['0x0', 0], ['0xff', 255], ['0xFF', 255], ['0XFF', 255]])]
   public function hexadecimal_numbers($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 
   #[Test, Values([['0755', 493], ['0o16', 14], ['0O16', 14]])]
   public function octal_numbers($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 
   #[Test, Values([['135_99', 13599], ['107_925_284.88', 107925284.88], ['0xCAFE_F00D', 3405705229], ['0b0101_1111', 95], ['0137_041', 48673],])]
   public function numeric_literal_separator($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 
   #[Test, Values([['""', ''], ['"Test"', 'Test'],])]
   public function strings($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 
   #[Test, Values([['true', true], ['false', false], ['null', null],])]
   public function constants($literal, $result) {
-    Assert::equals($result, $this->run('class <T> { public function run() { return '.$literal.'; } }'));
+    Assert::equals($result, $this->run('class %T { public function run() { return '.$literal.'; } }'));
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/StaticLocalsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/StaticLocalsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\reflect\TargetInvocationException;
+use lang\reflection\InvocationFailed;
 use test\{Assert, Test};
 use util\Date;
 
@@ -15,12 +15,12 @@ class StaticLocalsTest extends EmittingTest {
    * @return var[]
    */
   private function apply($t, ... $args) {
-    return $t->getMethod('run')->invoke($t->newInstance(), $args);
+    return $t->method('run')->invoke($t->newInstance(), $args);
   }
 
   #[Test]
   public function constant_static() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run() {
         static $i= 0;
 
@@ -35,7 +35,7 @@ class StaticLocalsTest extends EmittingTest {
 
   #[Test]
   public function initialization_to_new() {
-    $t= $this->type('use util\\{Date, Dates}; class <T> {
+    $t= $this->declare('use util\\{Date, Dates}; class %T {
       public function run() {
         static $t= new Date(0);
 
@@ -49,7 +49,7 @@ class StaticLocalsTest extends EmittingTest {
 
   #[Test]
   public function initialization_to_parameter() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function run($initial) {
         static $t= $initial;
 
@@ -64,7 +64,7 @@ class StaticLocalsTest extends EmittingTest {
 
   #[Test]
   public function initialization_when_throwing() {
-    $t= $this->type('use lang\\IllegalArgumentException; class <T> {
+    $t= $this->declare('use lang\\IllegalArgumentException; class %T {
       public function run($initial) {
         static $t= $initial ?? throw new IllegalArgumentException("May not be null");
 
@@ -73,7 +73,7 @@ class StaticLocalsTest extends EmittingTest {
     }');
 
     // This does not initialize the static
-    Assert::throws(TargetInvocationException::class, function() use($t) {
+    Assert::throws(InvocationFailed::class, function() use($t) {
       $this->apply($t, null);
     });
 

--- a/src/test/php/lang/ast/unittest/emit/TernaryTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TernaryTest.class.php
@@ -8,7 +8,7 @@ class TernaryTest extends EmittingTest {
   #[Test, Values([[true, 'OK'], [false, 'Fail']])]
   public function ternary($value, $result) {
     Assert::equals($result, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return $value ? "OK" : "Fail";
         }
@@ -20,7 +20,7 @@ class TernaryTest extends EmittingTest {
   #[Test, Values([[true, MODIFIER_PUBLIC], [false, MODIFIER_PRIVATE]])]
   public function ternary_constants_goto_label_ambiguity($value, $result) {
     Assert::equals($result, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return $value ?  MODIFIER_PUBLIC : MODIFIER_PRIVATE;
         }
@@ -32,7 +32,7 @@ class TernaryTest extends EmittingTest {
   #[Test, Values([['OK', 'OK'], [null, 'Fail']])]
   public function short_ternary($value, $result) {
     Assert::equals($result, $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return $value ?: "Fail";
         }
@@ -44,7 +44,7 @@ class TernaryTest extends EmittingTest {
   #[Test, Values([[['OK']], [[]]])]
   public function null_coalesce($value) {
     Assert::equals('OK', $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return $value[0] ?? "OK";
         }
@@ -56,7 +56,7 @@ class TernaryTest extends EmittingTest {
   #[Test, Values(eval: '[["."], [new Path(".")]]')]
   public function with_instanceof($value) {
     Assert::equals(new Path('.'), $this->run(
-      'class <T> {
+      'class %T {
         public function run($value) {
           return $value instanceof \\io\\Path ? $value : new \\io\\Path($value);
         }

--- a/src/test/php/lang/ast/unittest/emit/TrailingCommasTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TrailingCommasTest.class.php
@@ -6,49 +6,49 @@ class TrailingCommasTest extends EmittingTest {
 
   #[Test]
   public function in_array() {
-    $r= $this->run('class <T> { public function run() { return ["test", ]; } }');
+    $r= $this->run('class %T { public function run() { return ["test", ]; } }');
     Assert::equals(['test'], $r);
   }
 
   #[Test]
   public function in_map() {
-    $r= $this->run('class <T> { public function run() { return ["test" => true, ]; } }');
+    $r= $this->run('class %T { public function run() { return ["test" => true, ]; } }');
     Assert::equals(['test' => true], $r);
   }
 
   #[Test]
   public function in_function_call() {
-    $r= $this->run('class <T> { public function run() { return sprintf("Hello %s", "test", ); } }');
+    $r= $this->run('class %T { public function run() { return sprintf("Hello %s", "test", ); } }');
     Assert::equals('Hello test', $r);
   }
 
   #[Test]
   public function in_parameter_list() {
-    $r= $this->run('class <T> { public function run($a, ) { return $a; } }', 'Test');
+    $r= $this->run('class %T { public function run($a, ) { return $a; } }', 'Test');
     Assert::equals('Test', $r);
   }
 
   #[Test]
   public function in_isset() {
-    $r= $this->run('class <T> { public function run() { return isset($a, ); } }');
+    $r= $this->run('class %T { public function run() { return isset($a, ); } }');
     Assert::equals(false, $r);
   }
 
   #[Test]
   public function in_list() {
-    $r= $this->run('class <T> { public function run() { list($a, )= [1, 2]; return $a; } }');
+    $r= $this->run('class %T { public function run() { list($a, )= [1, 2]; return $a; } }');
     Assert::equals(1, $r);
   }
 
   #[Test]
   public function in_short_list() {
-    $r= $this->run('class <T> { public function run() { [$a, ]= [1, 2]; return $a; } }');
+    $r= $this->run('class %T { public function run() { [$a, ]= [1, 2]; return $a; } }');
     Assert::equals(1, $r);
   }
 
   #[Test]
   public function in_namespace_group() {
-    $r= $this->run('use lang\\{Type, }; class <T> { public function run() { return Type::$ARRAY->getName(); } }');
+    $r= $this->run('use lang\\{Type, }; class %T { public function run() { return Type::$ARRAY->getName(); } }');
     Assert::equals('array', $r);
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/TraitsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TraitsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\XPClass;
+use lang\Reflection;
 use test\verify\Runtime;
 use test\{Action, Assert, Test};
 
@@ -14,58 +14,58 @@ class TraitsTest extends EmittingTest {
 
   #[Test]
   public function trait_is_included() {
-    $t= $this->type('class <T> { use \lang\ast\unittest\emit\Loading; }');
-    Assert::equals([new XPClass(Loading::class)], $t->getTraits());
+    $t= $this->declare('class %T { use \lang\ast\unittest\emit\Loading; }');
+    Assert::equals([Reflection::type(Loading::class)], $t->traits());
   }
 
   #[Test]
   public function trait_method_is_part_of_type() {
-    $t= $this->type('class <T> { use \lang\ast\unittest\emit\Loading; }');
-    Assert::true($t->hasMethod('loaded'));
+    $t= $this->declare('class %T { use \lang\ast\unittest\emit\Loading; }');
+    Assert::notEquals(null, $t->method('loaded'));
   }
 
   #[Test]
   public function trait_is_resolved() {
-    $t= $this->type('use lang\ast\unittest\emit\Loading; class <T> { use Loading; }');
-    Assert::equals([new XPClass(Loading::class)], $t->getTraits());
+    $t= $this->declare('use lang\ast\unittest\emit\Loading; class %T { use Loading; }');
+    Assert::equals([Reflection::type(Loading::class)], $t->traits());
   }
 
   #[Test]
   public function trait_method_aliased() {
-    $t= $this->type('use lang\ast\unittest\emit\Loading; class <T> {
+    $t= $this->declare('use lang\ast\unittest\emit\Loading; class %T {
       use Loading {
         loaded as hasLoaded;
       }
     }');
-    Assert::true($t->hasMethod('hasLoaded'));
+    Assert::notEquals(null, $t->method('hasLoaded'));
   }
 
   #[Test]
   public function trait_method_aliased_qualified() {
-    $t= $this->type('use lang\ast\unittest\emit\Loading; class <T> {
+    $t= $this->declare('use lang\ast\unittest\emit\Loading; class %T {
       use Loading {
         Loading::loaded as hasLoaded;
       }
     }');
-    Assert::true($t->hasMethod('hasLoaded'));
+    Assert::notEquals(null, $t->method('hasLoaded'));
   }
 
   #[Test]
   public function trait_method_insteadof() {
-    $t= $this->type('use lang\ast\unittest\emit\{Loading, Spinner}; class <T> {
+    $t= $this->declare('use lang\ast\unittest\emit\{Loading, Spinner}; class %T {
       use Loading, Spinner {
         Spinner::loaded as noLongerSpinning;
         Loading::loaded insteadof Spinner;
       }
     }');
     $instance= $t->newInstance();
-    Assert::equals('Loaded', $t->getMethod('loaded')->invoke($instance));
-    Assert::equals('Not spinning', $t->getMethod('noLongerSpinning')->invoke($instance));
+    Assert::equals('Loaded', $t->method('loaded')->invoke($instance));
+    Assert::equals('Not spinning', $t->method('noLongerSpinning')->invoke($instance));
   }
 
   #[Test, Runtime(php: '>=8.2.0-dev')]
   public function can_have_constants() {
-    $t= $this->type('trait <T> { const FIXTURE = 1; }');
-    Assert::equals(1, $t->getConstant('FIXTURE'));
+    $t= $this->declare('trait %T { const FIXTURE = 1; }');
+    Assert::equals(1, $t->constant('FIXTURE')->value());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TransformationsTest.class.php
@@ -38,19 +38,19 @@ class TransformationsTest extends EmittingTest {
 
   #[Test]
   public function leaves_class_without_annotations() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $id;
 
       public function __construct(int $id) {
         $this->id= $id;
       }
     }');
-    Assert::false($t->hasMethod('id'));
+    Assert::equals(null, $t->method('id'));
   }
 
   #[Test]
   public function generates_string_representation() {
-    $t= $this->type('#[Repr] class <T> {
+    $t= $this->declare('#[Repr] class %T {
       private int $id;
       private string $name;
 
@@ -59,16 +59,16 @@ class TransformationsTest extends EmittingTest {
         $this->name= $name;
       }
     }');
-    Assert::true($t->hasMethod('toString'));
+    Assert::notEquals(null, $t->method('toString'));
     Assert::equals(
       "T@[\n  id => 1\n  name => \"Test\"\n]",
-      $t->getMethod('toString')->invoke($t->newInstance(1, 'Test'))
+      $t->method('toString')->invoke($t->newInstance(1, 'Test'))
     );
   }
 
   #[Test, Values([['id', 1], ['name', 'Test']])]
   public function generates_accessor($name, $expected) {
-    $t= $this->type('#[Getters] class <T> {
+    $t= $this->declare('#[Getters] class %T {
       private int $id;
       private string $name;
 
@@ -77,13 +77,13 @@ class TransformationsTest extends EmittingTest {
         $this->name= $name;
       }
     }');
-    Assert::true($t->hasMethod($name));
-    Assert::equals($expected, $t->getMethod($name)->invoke($t->newInstance(1, 'Test')));
+    Assert::notEquals(null, $t->method($name));
+    Assert::equals($expected, $t->method($name)->invoke($t->newInstance(1, 'Test')));
   }
 
   #[Test]
   public function generates_both() {
-    $t= $this->type('#[Repr, Getters] class <T> {
+    $t= $this->declare('#[Repr, Getters] class %T {
       private int $id;
       private string $name;
 
@@ -94,11 +94,11 @@ class TransformationsTest extends EmittingTest {
     }');
 
     $instance= $t->newInstance(1, 'Test');
-    Assert::equals(1, $t->getMethod('id')->invoke($instance));
-    Assert::equals('Test', $t->getMethod('name')->invoke($instance));
+    Assert::equals(1, $t->method('id')->invoke($instance));
+    Assert::equals('Test', $t->method('name')->invoke($instance));
     Assert::equals(
       "T@[\n  id => 1\n  name => \"Test\"\n]",
-      $t->getMethod('toString')->invoke($instance)
+      $t->method('toString')->invoke($instance)
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/TypeDeclarationTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/TypeDeclarationTest.class.php
@@ -1,98 +1,110 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\XPClass;
-use lang\reflect\Modifiers;
+use lang\reflection\Kind;
+use lang\{XPClass, Type};
+use test\verify\Runtime;
 use test\{Assert, Test, Values};
 
 class TypeDeclarationTest extends EmittingTest {
 
   #[Test, Values(['class', 'interface', 'trait'])]
   public function empty_type($kind) {
-    $t= $this->type($kind.' <T> { }');
+    $t= $this->declare($kind.' %T { }');
     Assert::equals(
-      ['const' => [], 'fields' => [], 'methods' => []],
-      ['const' => $t->getConstants(), 'fields' => $t->getFields(), 'methods' => $t->getMethods()]
+      ['constants' => [], 'properties' => [], 'methods' => []],
+      [
+        'constants'  => iterator_to_array($t->constants()),
+        'properties' => iterator_to_array($t->properties()),
+        'methods'    => iterator_to_array($t->methods())
+      ]
     );
   }
 
   #[Test]
   public function abstract_class_type() {
-    Assert::true(Modifiers::isAbstract($this->type('abstract class <T> { }')->getModifiers()));
+    Assert::true($this->declare('abstract class %T { }')->modifiers()->isAbstract());
   }
 
   #[Test]
   public function final_class_type() {
-    Assert::true(Modifiers::isFinal($this->type('final class <T> { }')->getModifiers()));
+    Assert::true($this->declare('final class %T { }')->modifiers()->isFinal());
   }
 
   #[Test]
   public function class_without_parent() {
-    Assert::null($this->type('class <T> { }')->getParentclass());
+    Assert::null($this->declare('class %T { }')->parent());
   }
 
   #[Test]
   public function class_with_parent() {
     Assert::equals(
-      new XPClass(EmittingTest::class),
-      $this->type('class <T> extends \\lang\\ast\\unittest\\emit\\EmittingTest { }')->getParentclass()
+      EmittingTest::class,
+      $this->declare('class %T extends \\lang\\ast\\unittest\\emit\\EmittingTest { }')->parent()->literal()
     );
   }
 
   #[Test]
   public function trait_type() {
-    Assert::true($this->type('trait <T> { }')->isTrait());
+    Assert::equals(Kind::$TRAIT, $this->declare('trait %T { }')->kind());
   }
 
   #[Test]
   public function trait_type_with_method() {
-    Assert::true($this->type('trait <T> { public function name() { return "Test"; }}')->isTrait());
+    Assert::equals(
+      Kind::$TRAIT,
+      $this->declare('trait %T { public function name() { return "Test"; }}')->kind()
+    );
   }
 
   #[Test]
   public function interface_type() {
-    Assert::true($this->type('interface <T> { }')->isInterface());
+    Assert::equals(Kind::$INTERFACE, $this->declare('interface %T { }')->kind());
   }
 
   #[Test]
   public function interface_type_with_method() {
-    Assert::true($this->type('interface <T> { public function name(); }')->isInterface());
+    Assert::equals(
+      Kind::$INTERFACE,
+      $this->declare('interface %T { public function name(); }')->kind()
+    );
   }
 
-  #[Test, Values(['public', 'private', 'protected'])]
+  #[Test, Values(['public', 'private', 'protected']), Runtime(php: '>=7.1.0')]
   public function constant($modifiers) {
-    $c= $this->type('class <T> { '.$modifiers.' const test = 1; }')->getConstant('test');
-    Assert::equals(1, $c);
+    $c= $this->declare('class %T { '.$modifiers.' const test = 1; }')->constant('test');
+    Assert::equals(
+      ['name' => 'test', 'type' => Type::$VAR, 'modifiers' => $modifiers],
+      ['name' => $c->name(), 'type' => $c->constraint()->type(), 'modifiers' => $c->modifiers()->names()]
+    );
   }
 
   #[Test, Values(['public', 'private', 'protected', 'public static', 'private static', 'protected static'])]
-  public function field($modifiers) {
-    $f= $this->type('class <T> { '.$modifiers.' $test; }')->getField('test');
-    $n= implode(' ', Modifiers::namesOf($f->getModifiers()));
+  public function property($modifiers) {
+    $p= $this->declare('class %T { '.$modifiers.' $test; }')->property('test');
     Assert::equals(
-      ['name' => 'test', 'type' => 'var', 'modifiers' => $modifiers],
-      ['name' => $f->getName(), 'type' => $f->getTypeName(), 'modifiers' => $n]
+      ['name' => 'test', 'type' => Type::$VAR, 'modifiers' => $modifiers],
+      ['name' => $p->name(), 'type' => $p->constraint()->type(), 'modifiers' => $p->modifiers()->names()]
     );
   }
 
   #[Test, Values(['public', 'protected', 'private', 'public final', 'protected final', 'public static', 'protected static', 'private static'])]
   public function method($modifiers) {
-    $m= $this->type('class <T> { '.$modifiers.' function test() { } }')->getMethod('test');
-    $n= implode(' ', Modifiers::namesOf($m->getModifiers()));
+    $m= $this->declare('class %T { '.$modifiers.' function test() { } }')->method('test');
     Assert::equals(
-      ['name' => 'test', 'type' => 'var', 'modifiers' => $modifiers],
-      ['name' => $m->getName(), 'type' => $m->getReturnTypeName(), 'modifiers' => $n]
+      ['name' => 'test', 'type' => Type::$VAR, 'modifiers' => $modifiers],
+      ['name' => $m->name(), 'type' => $m->returns()->type(), 'modifiers' => $m->modifiers()->names()]
     );
   }
 
   #[Test]
   public function abstract_method() {
-    $m= $this->type('abstract class <T> { abstract function test(); }')->getMethod('test');
-    Assert::true(Modifiers::isAbstract($m->getModifiers()));
+    $m= $this->declare('abstract class %T { abstract function test(); }')->method('test');
+    Assert::true($m->modifiers()->isAbstract());
   }
 
   #[Test]
   public function method_with_keyword() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private $items;
 
       public static function new($items) {
@@ -109,6 +121,6 @@ class TypeDeclarationTest extends EmittingTest {
         return self::new($values)->forEach(function($a) { return $a * 2; });
       }
     }');
-    Assert::equals([2, 4, 6], $t->getMethod('run')->invoke(null, [[1, 2, 3]]));
+    Assert::equals([2, 4, 6], $t->method('run')->invoke(null, [[1, 2, 3]]));
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/UnicodeEscapesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UnicodeEscapesTest.class.php
@@ -6,7 +6,7 @@ class UnicodeEscapesTest extends EmittingTest {
 
   #[Test]
   public function spanish_ñ() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return "ma\u{00F1}ana";
       }
@@ -17,7 +17,7 @@ class UnicodeEscapesTest extends EmittingTest {
 
   #[Test]
   public function emoji() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         return "Smile! \u{1F602}";
       }

--- a/src/test/php/lang/ast/unittest/emit/UnionTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UnionTypesTest.class.php
@@ -13,109 +13,109 @@ class UnionTypesTest extends EmittingTest {
 
   #[Test]
   public function field_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int|string $test;
     }');
 
     Assert::equals(
       new TypeUnion([Primitive::$INT, Primitive::$STRING]),
-      $t->getField('test')->getType()
+      $t->property('test')->constraint()->type()
     );
   }
 
   #[Test]
   public function parameter_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(int|string $arg) { }
     }');
 
     Assert::equals(
       new TypeUnion([Primitive::$INT, Primitive::$STRING]),
-      $t->getMethod('test')->getParameter(0)->getType()
+      $t->method('test')->parameter(0)->constraint()->type()
     );
   }
 
   #[Test]
   public function return_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): int|string { }
     }');
 
     Assert::equals(
       new TypeUnion([Primitive::$INT, Primitive::$STRING]),
-      $t->getMethod('test')->getReturnType()
+      $t->method('test')->returns()->type()
     );
   }
 
   #[Test]
   public function nullable_union_type() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): int|string|null { }
     }');
 
     Assert::equals(
       new Nullable(new TypeUnion([Primitive::$INT, Primitive::$STRING])),
-      $t->getMethod('test')->getReturnType()
+      $t->method('test')->returns()->type()
     );
   }
 
   #[Test]
   public function nullable_union_type_alternative_syntax() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): ?(int|string) { }
     }');
 
     Assert::equals(
       new Nullable(new TypeUnion([Primitive::$INT, Primitive::$STRING])),
-      $t->getMethod('test')->getReturnType()
+      $t->method('test')->returns()->type()
     );
   }
 
   #[Test, Runtime(php: '>=8.0.0-dev')]
   public function nullable_union_type_restriction() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): int|string|null { }
     }');
 
     Assert::equals(
       new Nullable(new TypeUnion([Primitive::$INT, Primitive::$STRING])),
-      $t->getMethod('test')->getReturnTypeRestriction()
+      $t->method('test')->returns()->type()
     );
   }
 
   #[Test, Runtime(php: '>=8.0.0-dev')]
   public function parameter_type_restriction_with_php8() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(int|string|array<string> $arg) { }
     }');
 
     Assert::equals(
       new TypeUnion([Primitive::$INT, Primitive::$STRING, Type::$ARRAY]),
-      $t->getMethod('test')->getParameter(0)->getTypeRestriction()
+      $t->method('test')->parameter(0)->constraint()->type()
     );
   }
 
   #[Test, Runtime(php: '>=8.0.0-dev')]
   public function parameter_function_type_restriction_with_php8() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): string|(function(): string) { }
     }');
 
     Assert::equals(
       new TypeUnion([Primitive::$STRING, Type::$CALLABLE]),
-      $t->getMethod('test')->getReturnTypeRestriction()
+      $t->method('test')->returns()->type()
     );
   }
 
   #[Test, Runtime(php: '>=8.0.0-dev')]
   public function return_type_restriction_with_php8() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       public function test(): int|string|array<string> { }
     }');
 
     Assert::equals(
       new TypeUnion([Primitive::$INT, Primitive::$STRING, Type::$ARRAY]),
-      $t->getMethod('test')->getReturnTypeRestriction()
+      $t->method('test')->returns()->type()
     );
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/UsingTest.class.php
@@ -11,7 +11,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function dispose_called() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         Handle::$called= [];
 
@@ -27,7 +27,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function dispose_called_for_all() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         Handle::$called= [];
 
@@ -43,7 +43,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function dispose_called_even_when_exceptions_occur() {
-    $r= $this->run('use lang\{IllegalArgumentException, IllegalStateException}; use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\{IllegalArgumentException, IllegalStateException}; use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         Handle::$called= [];
 
@@ -63,7 +63,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function supports_closeables() {
-    $r= $this->run('use lang\ast\unittest\emit\FileInput; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\FileInput; class %T {
       public function run() {
         FileInput::$open= false;
 
@@ -79,7 +79,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function can_return_from_inside_using() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private function read() {
         using ($x= new Handle(1)) {
           return $x->read();
@@ -97,7 +97,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function variable_undefined_after_using() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         using ($x= new Handle(1)) {
           // NOOP
@@ -110,7 +110,7 @@ class UsingTest extends EmittingTest {
 
   #[Test]
   public function variable_undefined_after_using_even_if_previously_defined() {
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       public function run() {
         $x= new Handle(1);
         using ($x) {

--- a/src/test/php/lang/ast/unittest/emit/VarargsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/VarargsTest.class.php
@@ -6,7 +6,7 @@ class VarargsTest extends EmittingTest {
 
   #[Test]
   public function vsprintf() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function format(string $format, ... $args) {
         return vsprintf($format, $args);
       }
@@ -21,7 +21,7 @@ class VarargsTest extends EmittingTest {
 
   #[Test]
   public function list_of() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function listOf(string... $args) {
         return $args;
       }

--- a/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/VirtualPropertyTypesTest.class.php
@@ -11,25 +11,25 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test]
   public function type_available_via_reflection() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $value;
     }');
 
-    Assert::equals(Primitive::$INT, $t->getField('value')->getType());
+    Assert::equals(Primitive::$INT, $t->property('value')->constraint()->type());
   }
 
   #[Test]
   public function modifiers_available_via_reflection() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $value;
     }');
 
-    Assert::equals(MODIFIER_PRIVATE, $t->getField('value')->getModifiers());
+    Assert::equals(MODIFIER_PRIVATE, $t->property('value')->modifiers()->bits());
   }
 
   #[Test, Expect(class: Error::class, message: '/Cannot access private property .+::\\$value/')]
   public function cannot_read_private_field() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $value;
     }');
 
@@ -38,7 +38,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Expect(class: Error::class, message: '/Cannot access private property .+::\\$value/')]
   public function cannot_write_private_field() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $value;
     }');
 
@@ -47,7 +47,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Expect(class: Error::class, message: '/Cannot access protected property .+::\\$value/')]
   public function cannot_read_protected_field() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       protected int $value;
     }');
 
@@ -56,7 +56,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Expect(class: Error::class, message: '/Cannot access protected property .+::\\$value/')]
   public function cannot_write_protected_field() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       protected int $value;
     }');
 
@@ -65,10 +65,10 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test]
   public function can_access_protected_field_from_subclass() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       protected int $value;
     }');
-    $i= newinstance($t->getName(), [], [
+    $i= newinstance($t->literal(), [], [
       'run' => function() {
         $this->value= 6100;
         return $this->value;
@@ -80,16 +80,16 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test]
   public function initial_value_available_via_reflection() {
-    $t= $this->type('class <T> {
+    $t= $this->declare('class %T {
       private int $value = 6100;
     }');
 
-    Assert::equals(6100, $t->getField('value')->setAccessible(true)->get($t->newInstance()));
+    Assert::equals(6100, $t->property('value')->get($t->newInstance(), $t));
   }
 
   #[Test, Values([[null], ['Test'], [[]]]), Expect(class: Error::class, message: '/property .+::\$value of type int/')]
   public function type_checked_at_runtime($in) {
-    $this->run('class <T> {
+    $this->run('class %T {
       private int $value;
 
       public function run($arg) {
@@ -101,7 +101,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
   #[Test]
   public function value_type_test() {
     $handle= new Handle(0);
-    $r= $this->run('use lang\ast\unittest\emit\Handle; class <T> {
+    $r= $this->run('use lang\ast\unittest\emit\Handle; class %T {
       private Handle $value;
 
       public function run($arg) {
@@ -115,7 +115,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Values(['', 'Test', 1, 1.5, true, false])]
   public function string_type_coercion($in) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private string $value;
 
       public function run($arg) {
@@ -129,7 +129,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Values(['', 'Test', 1, 1.5, true, false])]
   public function bool_type_coercion($in) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private bool $value;
 
       public function run($arg) {
@@ -143,7 +143,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Values(['1', '1.5', 1, 1.5, true, false])]
   public function int_type_coercion($in) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private int $value;
 
       public function run($arg) {
@@ -157,7 +157,7 @@ class VirtualPropertyTypesTest extends EmittingTest {
 
   #[Test, Values(['1', '1.5', 1, 1.5, true, false])]
   public function float_type_coercion($in) {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private float $value;
 
       public function run($arg) {

--- a/src/test/php/lang/ast/unittest/emit/YieldTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/YieldTest.class.php
@@ -7,7 +7,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_without_argument() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         yield;
         yield;
@@ -18,7 +18,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_values() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         yield 1;
         yield 2;
@@ -30,7 +30,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_keys_and_values() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         yield "color" => "orange";
         yield "price" => 12.99;
@@ -41,7 +41,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_from_array() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         yield from [1, 2, 3];
       }
@@ -51,7 +51,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_from_generator() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       private function values() {
         yield 1;
         yield 2;
@@ -67,7 +67,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_from_and_yield() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         yield 1;
         yield from [2, 3];
@@ -79,7 +79,7 @@ class YieldTest extends EmittingTest {
 
   #[Test]
   public function yield_send() {
-    $r= $this->run('class <T> {
+    $r= $this->run('class %T {
       public function run() {
         while ($line= yield) {
           echo $line, "\n";


### PR DESCRIPTION
* [x] The new `declare(string $code): Type` method replaces the `type(string $code): XPClass` method in EmittingTest
* [x] The placeholder used for the unique generated type is `%T` instead of `<T>` to prevent confusion with generics
