### PR TITLE
Add support for compile-time checks

### DIFF
--- a/src/main/php/lang/ast/CodeGen.class.php
+++ b/src/main/php/lang/ast/CodeGen.class.php
@@ -5,6 +5,7 @@ use lang\ast\emit\{Reflection, Declaration, Incomplete};
 class CodeGen {
   private $id= 0;
   public $scope= [];
+  public $source= null;
 
   /** Creates a new, unique symbol */
   public function symbol() { return '_'.($this->id++); }

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -172,14 +172,15 @@ abstract class Emitter {
 
   /**
    * Emitter entry point, takes nodes and emits them to the given target.
-   * 
+   *
    * @param  iterable $nodes
    * @param  io.streams.OutputStream $target
+   * @param  ?string $source
    * @return io.streams.OutputStream
    * @throws lang.ast.Errors
    */
-  public function write($nodes, OutputStream $target) {
-    $result= $this->result($target);
+  public function write($nodes, OutputStream $target, $source= null) {
+    $result= $this->result($target)->from($source);
     try {
       $this->emitAll($result, $nodes);
       return $target;

--- a/src/main/php/lang/ast/checks/Check.class.php
+++ b/src/main/php/lang/ast/checks/Check.class.php
@@ -1,0 +1,36 @@
+<?php namespace lang\ast\checks;
+
+use lang\ast\{Error, Errors};
+
+abstract class Check {
+
+  /** @return string */
+  public abstract function nodeKind();
+
+  /**
+   * Checks node and returns errors
+   *
+   * @param  lang.ast.CodeGen $codegen
+   * @param  lang.ast.Node $node
+   * @return iterable
+   */
+  public abstract function check($codegen, $node);
+
+  /**
+   * Attach this check to a given emitter.
+   *
+   * @param  lang.ast.Emitter $emit
+   * @return void
+   */
+  public function attachTo($emit) {
+    $emit->transform($this->nodeKind(), function($codegen, $node) {
+      $errors= [];
+      foreach ($this->check($codegen, $node) as $error) {
+        $errors[]= new Error($error, $codegen->source, $node->line);
+      }
+      if (empty($errors)) return null;
+
+      throw new Errors($errors, $codegen->source);
+    });
+  }
+}

--- a/src/main/php/lang/ast/checks/MethodOverriding.class.php
+++ b/src/main/php/lang/ast/checks/MethodOverriding.class.php
@@ -2,7 +2,12 @@
 
 use Override;
 
-/** @see https://wiki.php.net/rfc/marking_overriden_methods */
+/**
+ * Checks `#[Override]`
+ *
+ * @see  https://wiki.php.net/rfc/marking_overriden_methods
+ * @test lang.ast.unittest.checks.MethodOverridingTest
+ */
 class MethodOverriding extends Check {
 
   /** @return string */
@@ -19,7 +24,7 @@ class MethodOverriding extends Check {
     if ($method->annotations && $method->annotations->named(Override::class)) {
 
       // Check parent class
-      if ($parent= $codegen->lookup('parent') && $parent->providesMethod($method->name)) return;
+      if (($parent= $codegen->lookup('parent')) && $parent->providesMethod($method->name)) return;
 
       // Check all implemented interfaces
       foreach ($codegen->lookup('self')->implementedInterfaces() as $interface) {
@@ -27,7 +32,7 @@ class MethodOverriding extends Check {
       }
 
       yield sprintf(
-        '%s:%s() has #[\\Override] attribute, but no matching parent method exists',
+        '%s::%s() has #[\\Override] attribute, but no matching parent method exists',
         substr($codegen->scope[0]->type->name, 1),
         $method->name
       );

--- a/src/main/php/lang/ast/checks/MethodOverriding.class.php
+++ b/src/main/php/lang/ast/checks/MethodOverriding.class.php
@@ -1,0 +1,29 @@
+<?php namespace lang\ast\checks;
+
+use Override;
+
+/** @see https://wiki.php.net/rfc/marking_overriden_methods */
+class MethodOverriding extends Check {
+
+  /** @return string */
+  public function nodeKind() { return 'method'; }
+
+  /**
+   * Checks node and returns errors
+   *
+   * @param  lang.ast.CodeGen $codegen
+   * @param  lang.ast.Node $node
+   * @return iterable
+   */
+  public function check($codegen, $method) {
+    if ($method->annotations && $method->annotations->named(Override::class)) {
+      if (!($parent= $codegen->lookup('parent')) || !$parent->providesMethod($method->name)) {
+        yield sprintf(
+          '%s:%s() has #[\\Override] attribute, but no matching parent method exists',
+          substr($codegen->scope[0]->type->name, 1),
+          $method->name
+        );
+      }
+    }
+  }
+}

--- a/src/main/php/lang/ast/emit/Declaration.class.php
+++ b/src/main/php/lang/ast/emit/Declaration.class.php
@@ -15,6 +15,23 @@ class Declaration extends Type {
   /** @return string */
   public function name() { return ltrim($this->type->name, '\\'); }
 
+  /** @return iterable */
+  public function implementedInterfaces() {
+    foreach ($this->type->implements as $interface) {
+      yield $interface->literal();
+    }
+  }
+
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $named
+   * @return bool
+   */
+  public function providesMethod($named) {
+    return isset($this->body["{$named}()"]);
+  }
+
   /**
    * Returns whether a given member is an enum case
    *

--- a/src/main/php/lang/ast/emit/Incomplete.class.php
+++ b/src/main/php/lang/ast/emit/Incomplete.class.php
@@ -9,6 +9,19 @@ class Incomplete extends Type {
   /** @return string */
   public function name() { return $this->name; }
 
+  /** @return iterable */
+  public function implementedInterfaces() { return []; }
+
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $named
+   * @return bool
+   */
+  public function providesMethod($named) {
+    return false;
+  }
+
   /**
    * Returns whether a given member is an enum case
    *

--- a/src/main/php/lang/ast/emit/Reflection.class.php
+++ b/src/main/php/lang/ast/emit/Reflection.class.php
@@ -23,6 +23,19 @@ class Reflection extends Type {
   /** @return string */
   public function name() { return $this->reflect->name; }
 
+  /** @return iterable */
+  public function implementedInterfaces() { return $this->type->getInterfaceNames(); }
+
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $named
+   * @return bool
+   */
+  public function providesMethod($named) {
+    return $this->reflect->hasMethod($named);
+  }
+
   /**
    * Returns whether a given member is an enum case
    *

--- a/src/main/php/lang/ast/emit/Result.class.php
+++ b/src/main/php/lang/ast/emit/Result.class.php
@@ -22,6 +22,17 @@ class Result implements Closeable {
   }
 
   /**
+   * Set filename this result originates from, defaulting to `(unknown)`.
+   *
+   * @param  ?string $file
+   * @return self
+   */
+  public function from($file) {
+    $this->codegen->source= $file ?? '(unknown)';
+    return $this;
+  }
+
+  /**
    * Initialize result. Guaranteed to be called *once* from constructor.
    * Without implementation here - overwrite in subclasses.
    *

--- a/src/main/php/lang/ast/emit/Type.class.php
+++ b/src/main/php/lang/ast/emit/Type.class.php
@@ -11,6 +11,17 @@ abstract class Type {
   /** @return string */
   public abstract function name();
 
+  /** @return iterable */
+  public abstract function implementedInterfaces();
+
+  /**
+   * Checks whether a given method exists
+   *
+   * @param  string $named
+   * @return bool
+   */
+  public abstract function providesMethod($named);
+
   /**
    * Returns whether a given member is an enum case
    *

--- a/src/test/php/lang/ast/unittest/checks/CheckTest.class.php
+++ b/src/test/php/lang/ast/unittest/checks/CheckTest.class.php
@@ -17,7 +17,13 @@ abstract class CheckTest {
   /** @return lang.ast.checks.Check */
   protected abstract function check();
 
-  protected function compile($code) {
+  /**
+   * Verifies code, yielding any errors
+   *
+   * @param  string $code
+   * @return ?string
+   */
+  protected function verify($code) {
     $name= 'C'.(self::$id++);
     try {
       $this->emitter->write(

--- a/src/test/php/lang/ast/unittest/checks/CheckTest.class.php
+++ b/src/test/php/lang/ast/unittest/checks/CheckTest.class.php
@@ -1,0 +1,33 @@
+<?php namespace lang\ast\unittest\checks;
+
+use io\streams\MemoryOutputStream;
+use lang\ast\{Errors, Emitter, Language, Tokens};
+
+abstract class CheckTest {
+  private static $id= 0;
+  private $language, $emitter;
+
+  /** Constructor */
+  public function __construct($output= null) {
+    $this->language= Language::named('PHP');
+    $this->emitter= Emitter::forRuntime('php:'.PHP_VERSION, [])->newInstance();
+    $this->check()->attachTo($this->emitter);
+  }
+
+  /** @return lang.ast.checks.Check */
+  protected abstract function check();
+
+  protected function compile($code) {
+    $name= 'C'.(self::$id++);
+    try {
+      $this->emitter->write(
+        $this->language->parse(new Tokens(str_replace('%T', $name, $code), static::class))->stream(),
+        new MemoryOutputStream(),
+        '%T'
+      );
+      return null;
+    } catch (Errors $e) {
+      return str_replace($name, '%T', $e->diagnostics());
+    }
+  }
+}

--- a/src/test/php/lang/ast/unittest/checks/MethodOverridingTest.class.php
+++ b/src/test/php/lang/ast/unittest/checks/MethodOverridingTest.class.php
@@ -10,12 +10,12 @@ class MethodOverridingTest extends CheckTest {
 
   #[Test]
   public function without_annotations() {
-    Assert::null($this->compile('class %T { public function fixture() { } }'));
+    Assert::null($this->verify('class %T { public function fixture() { } }'));
   }
 
   #[Test]
   public function correctly_overwriting_parent_method() {
-    Assert::null($this->compile('class %T extends \lang\Throwable {
+    Assert::null($this->verify('class %T extends \lang\Throwable {
       #[Override]
       public function compoundMessage() { }
     }'));
@@ -23,7 +23,7 @@ class MethodOverridingTest extends CheckTest {
 
   #[Test]
   public function correctly_implementing_interface_method() {
-    Assert::null($this->compile('class %T implements \lang\Runnable {
+    Assert::null($this->verify('class %T implements \lang\Runnable {
       #[Override]
       public function run() { }
     }'));
@@ -33,7 +33,7 @@ class MethodOverridingTest extends CheckTest {
   public function without_parent() {
     Assert::equals(
       '%T::fixture() has #[\Override] attribute, but no matching parent method exists [line 2 of %T]',
-      $this->compile('class %T {
+      $this->verify('class %T {
         #[Override]
         public function fixture() { }
       }'

--- a/src/test/php/lang/ast/unittest/checks/MethodOverridingTest.class.php
+++ b/src/test/php/lang/ast/unittest/checks/MethodOverridingTest.class.php
@@ -39,4 +39,15 @@ class MethodOverridingTest extends CheckTest {
       }'
     ));
   }
+
+  #[Test]
+  public function overriding_non_existant_method() {
+    Assert::equals(
+      '%T::nonExistant() has #[\Override] attribute, but no matching parent method exists [line 2 of %T]',
+      $this->verify('class %T extends \lang\Throwable {
+        #[Override]
+        public function nonExistant() { }
+      }'
+    ));
+  }
 }

--- a/src/test/php/lang/ast/unittest/checks/MethodOverridingTest.class.php
+++ b/src/test/php/lang/ast/unittest/checks/MethodOverridingTest.class.php
@@ -1,0 +1,42 @@
+<?php namespace lang\ast\unittest\checks;
+
+use lang\ast\checks\MethodOverriding;
+use test\{Assert, Test};
+
+class MethodOverridingTest extends CheckTest {
+
+  /** @return lang.ast.checks.Check */
+  protected function check() { return new MethodOverriding(); }
+
+  #[Test]
+  public function without_annotations() {
+    Assert::null($this->compile('class %T { public function fixture() { } }'));
+  }
+
+  #[Test]
+  public function correctly_overwriting_parent_method() {
+    Assert::null($this->compile('class %T extends \lang\Throwable {
+      #[Override]
+      public function compoundMessage() { }
+    }'));
+  }
+
+  #[Test]
+  public function correctly_implementing_interface_method() {
+    Assert::null($this->compile('class %T implements \lang\Runnable {
+      #[Override]
+      public function run() { }
+    }'));
+  }
+
+  #[Test]
+  public function without_parent() {
+    Assert::equals(
+      '%T::fixture() has #[\Override] attribute, but no matching parent method exists [line 2 of %T]',
+      $this->compile('class %T {
+        #[Override]
+        public function fixture() { }
+      }'
+    ));
+  }
+}


### PR DESCRIPTION
This PR adds `-c [check]` to the command line to check for certain aspects at compile time. 

## Included checks

* [x] Override annotation, see https://wiki.php.net/rfc/marking_overriden_methods and #149
* [ ] Deprecated annotation, see https://wiki.php.net/rfc/deprecated_attribute

## Example

Given the following code inside a file *Overriding.php*:

```php
<?php

class Overriding {

  #[Override]
  public function fixture() { }
}
```

...the compilation yields:

```bash
$ xp compile -c method-overriding Overriding.php > /dev/null
! Overriding.php: Overriding::fixture() has #[\Override] attribute, but no matching parent method exists
[line 5 of Overriding.php]

× Compiled 1 file(s) to - using lang.ast.emit.PHP82, 1 error(s) occurred
Memory used: 2566.99 kB (2619.85 kB peak)
Time taken: 0.008 seconds
```