### PR TITLE
Use string interpolation instead of string concatenation

### DIFF
--- a/src/main/php/lang/ast/CompilingClassloader.class.php
+++ b/src/main/php/lang/ast/CompilingClassloader.class.php
@@ -137,7 +137,7 @@ class CompilingClassLoader implements IClassLoader {
    */
   public function loadUri($uri) {
     if (!$this->providesUri($uri)) {
-      throw new ClassNotFoundException('No such class at '.$uri);
+      throw new ClassNotFoundException("No such class at {$uri}");
     }
 
     $class= $this->loadClass($this->source[$uri]);
@@ -174,16 +174,16 @@ class CompilingClassLoader implements IClassLoader {
     $uri= strtr($class, '.', '/').self::EXTENSION;
     Compiled::$source[$uri]= $source;
 
-    \xp::$cl[$class]= nameof($this).'://'.$this->instanceId();
+    \xp::$cl[$class]= nameof($this)."://{$this->instanceId()}";
     \xp::$cll++;
     try {
-      include($this->version.'://'.$uri);
+      include("{$this->version}://{$uri}");
     } catch (ClassLoadingException $e) {
       unset(\xp::$cl[$class]); // @codeCoverageIgnore
       throw $e;                // @codeCoverageIgnore
     } catch (\Throwable $e) {
       unset(\xp::$cl[$class]);
-      throw new ClassFormatException('Compiler error: '.$e->getMessage(), $e);
+      throw new ClassFormatException("Compiler error: {$e->getMessage()}", $e);
     } finally {
       \xp::$cll--;
       unset(Compiled::$source[$uri]);
@@ -267,7 +267,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return string
    */
   public function toString() {
-    return 'CompilingCL<'.$this->version.'>';
+    return "CompilingCL<{$this->version}>";
   }
 
   /**
@@ -276,7 +276,7 @@ class CompilingClassLoader implements IClassLoader {
    * @return string
    */
   public function hashCode() {
-    return 'C'.$this->version;
+    return "C{$this->version}";
   }
 
   /**

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -40,7 +40,7 @@ abstract class Emitter {
       }
     } while ($minor-- > 0);
 
-    throw new IllegalArgumentException('XP Compiler does not support '.$runtime.' yet');
+    throw new IllegalArgumentException("XP Compiler does not support {$runtime} yet");
   }
 
   /**
@@ -113,7 +113,7 @@ abstract class Emitter {
    * @return void
    */
   protected function emitOperator($result, $operator) {
-    throw new IllegalStateException('Unexpected operator '.$operator->value.' at line '.$operator->line);
+    throw new IllegalStateException("Unexpected operator {$operator->value} at line {$operator->line}");
   }
 
   /**
@@ -145,11 +145,11 @@ abstract class Emitter {
         $r= $transformation($result->codegen, $node);
         if ($r instanceof Node) {
           if ($r->kind === $node->kind) continue;
-          $this->{'emit'.$r->kind}($result, $r);
+          $this->{"emit{$r->kind}"}($result, $r);
           return;
         } else if ($r) {
           foreach ($r as $n) {
-            $this->{'emit'.$n->kind}($result, $n);
+            $this->{"emit{$n->kind}"}($result, $n);
             $result->out->write(';');
           }
           return;
@@ -158,7 +158,7 @@ abstract class Emitter {
       // Fall through, use default
     }
 
-    $this->{'emit'.$node->kind}($result, $node);
+    $this->{"emit{$node->kind}"}($result, $node);
   }
 
   /**

--- a/src/main/php/lang/ast/emit/ArbitrayNewExpressions.class.php
+++ b/src/main/php/lang/ast/emit/ArbitrayNewExpressions.class.php
@@ -15,14 +15,14 @@ trait ArbitrayNewExpressions {
 
     // Emit supported `new $var`, rewrite unsupported `new ($expr)`
     if ($new->type->expression instanceof Variable && $new->type->expression->const) {
-      $result->out->write('new $'.$new->type->expression->pointer.'(');
+      $result->out->write("new \${$new->type->expression->pointer}(");
       $this->emitArguments($result, $new->arguments);
       $result->out->write(')');
     } else {
       $t= $result->temp();
-      $result->out->write('('.$t.'= ');
+      $result->out->write("({$t}= ");
       $this->emitOne($result, $new->type->expression);
-      $result->out->write(') ? new '.$t.'(');
+      $result->out->write(") ? new {$t}(");
       $this->emitArguments($result, $new->arguments);
       $result->out->write(') : null');
     }

--- a/src/main/php/lang/ast/emit/ArrayUnpackUsingMerge.class.php
+++ b/src/main/php/lang/ast/emit/ArrayUnpackUsingMerge.class.php
@@ -41,9 +41,9 @@ trait ArrayUnpackUsingMerge {
             $result->out->write(',[');
           } else {
             $t= $result->temp();
-            $result->out->write('],('.$t.'=');
+            $result->out->write("],({$t}=");
             $this->emitOne($result, $pair[1]->expression);
-            $result->out->write(') instanceof \Traversable ? iterator_to_array('.$t.') : '.$t.',[');
+            $result->out->write(") instanceof \\Traversable ? iterator_to_array({$t}) : {$t},[");
           }
         } else {
           $this->emitOne($result, $pair[1]);

--- a/src/main/php/lang/ast/emit/AttributesAsComments.class.php
+++ b/src/main/php/lang/ast/emit/AttributesAsComments.class.php
@@ -13,7 +13,7 @@
 trait AttributesAsComments {
 
   protected function emitAnnotation($result, $annotation) {
-    $result->out->write('\\'.$annotation->name);
+    $result->out->write("\\{$annotation->name}");
     if (empty($annotation->arguments)) return;
 
     // Check whether arguments are constant, enclose in `eval` array

--- a/src/main/php/lang/ast/emit/Declaration.class.php
+++ b/src/main/php/lang/ast/emit/Declaration.class.php
@@ -102,7 +102,7 @@ class Declaration extends Type {
     if (!self::$ENUMS && 'enum' === $this->type->kind) {
       return ($this->type->body[$member] ?? null) instanceof EnumCase;
     } else if ('class' === $this->type->kind && $this->type->parent && '\\lang\\Enum' === $this->type->parent->literal()) {
-      return ($this->type->body['$'.$member] ?? null) instanceof Property;
+      return ($this->type->body["\${$member}"] ?? null) instanceof Property;
     }
     return false;
   }

--- a/src/main/php/lang/ast/emit/ForeachDestructuringAsStatement.class.php
+++ b/src/main/php/lang/ast/emit/ForeachDestructuringAsStatement.class.php
@@ -26,7 +26,7 @@ trait ForeachDestructuringAsStatement {
 
     if ('array' === $foreach->value->kind) {
       $t= $result->temp();
-      $result->out->write('&'.$t.') {');
+      $result->out->write("&{$t}) {");
       $this->rewriteDestructuring($result, new Assignment($foreach->value, '=', new Variable(substr($t, 1))));
       $result->out->write(';');
       $this->emitAll($result, $foreach->body);

--- a/src/main/php/lang/ast/emit/GeneratedCode.class.php
+++ b/src/main/php/lang/ast/emit/GeneratedCode.class.php
@@ -56,7 +56,7 @@ class GeneratedCode extends Result {
    * @return string
    */
   public function temp() {
-    return '$'.$this->codegen->symbol();
+    return "\${$this->codegen->symbol()}";
   }
 
   /**

--- a/src/main/php/lang/ast/emit/MatchAsTernaries.class.php
+++ b/src/main/php/lang/ast/emit/MatchAsTernaries.class.php
@@ -10,9 +10,9 @@ trait MatchAsTernaries {
   protected function emitMatch($result, $match) {
     $t= $result->temp();
     if (null === $match->expression) {
-      $result->out->write('('.$t.'=true)');
+      $result->out->write("({$t}=true)");
     } else {
-      $result->out->write('('.$t.'=');
+      $result->out->write("({$t}=");
       $this->emitOne($result, $match->expression);
       $result->out->write(')');
     }
@@ -32,7 +32,7 @@ trait MatchAsTernaries {
 
     // Emit IIFE for raising an error until we have throw expressions
     if (null === $match->default) {
-      $result->out->write('function() use('.$t.') { throw new \\Error("Unhandled match value of type ".gettype('.$t.')); })(');
+      $result->out->write("function() use({$t}) { throw new \\Error('Unhandled match value of type '.gettype({$t})); })(");
     } else {
       $this->emitAsExpression($result, $match->default);
     }

--- a/src/main/php/lang/ast/emit/NonCapturingCatchVariables.class.php
+++ b/src/main/php/lang/ast/emit/NonCapturingCatchVariables.class.php
@@ -8,11 +8,11 @@
 trait NonCapturingCatchVariables {
 
   protected function emitCatch($result, $catch) {
-    $capture= $catch->variable ? '$'.$catch->variable : $result->temp();
+    $capture= $catch->variable ? "\${$catch->variable}" : $result->temp();
     if (empty($catch->types)) {
-      $result->out->write('catch(\\Throwable '.$capture.') {');
+      $result->out->write("catch(\\Throwable {$capture}) {");
     } else {
-      $result->out->write('catch('.implode('|', $catch->types).' '.$capture.') {');
+      $result->out->write('catch('.implode('|', $catch->types)." {$capture}) {");
     }
     $this->emitAll($result, $catch->body);
     $result->out->write('}');

--- a/src/main/php/lang/ast/emit/NullsafeAsTernaries.class.php
+++ b/src/main/php/lang/ast/emit/NullsafeAsTernaries.class.php
@@ -9,9 +9,9 @@ trait NullsafeAsTernaries {
 
   protected function emitNullsafeInstance($result, $instance) {
     $t= $result->temp();
-    $result->out->write('null===('.$t.'=');
+    $result->out->write("null===({$t}=");
     $this->emitOne($result, $instance->expression);
-    $result->out->write(')?null:'.$t.'->');
+    $result->out->write(")?null:{$t}->");
     $this->emitOne($result, $instance->member);
   }
 }

--- a/src/main/php/lang/ast/emit/OmitConstModifiers.class.php
+++ b/src/main/php/lang/ast/emit/OmitConstModifiers.class.php
@@ -17,7 +17,7 @@ trait OmitConstModifiers {
       DETAIL_ARGUMENTS   => []
     ];
 
-    $result->out->write('const '.$const->name.'=');
+    $result->out->write("const {$const->name}=");
     $this->emitOne($result, $const->expression);
     $result->out->write(';');
   }

--- a/src/main/php/lang/ast/emit/PHP70.class.php
+++ b/src/main/php/lang/ast/emit/PHP70.class.php
@@ -64,7 +64,7 @@ class PHP70 extends PHP {
 
   protected function emitCallable($result, $callable) {
     $t= $result->temp();
-    $result->out->write('(is_callable('.$t.'=');
+    $result->out->write("(is_callable({$t}=");
     if ($callable->expression instanceof Literal) {
 
       // Rewrite f() => "f"
@@ -111,7 +111,7 @@ class PHP70 extends PHP {
 
     // Emit equivalent of Closure::fromCallable() which doesn't exist until PHP 7.1
     $a= $result->temp();
-    $result->out->write(')?function(...'.$a.') use('.$t.') { return '.$t.'(...'.$a.'); }:');
+    $result->out->write(")?function(...{$a}) use({$t}) { return {$t}(...{$a}); }:");
     $result->out->write('(function() { throw new \Error("Given argument is not callable"); })())');
   }
 

--- a/src/main/php/lang/ast/emit/PHP71.class.php
+++ b/src/main/php/lang/ast/emit/PHP71.class.php
@@ -38,7 +38,7 @@ class PHP71 extends PHP {
       IsArray::class        => function($t) { return 'array'; },
       IsMap::class          => function($t) { return 'array'; },
       IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : "?{$l}"; },
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {

--- a/src/main/php/lang/ast/emit/PHP72.class.php
+++ b/src/main/php/lang/ast/emit/PHP72.class.php
@@ -38,7 +38,7 @@ class PHP72 extends PHP {
       IsMap::class          => function($t) { return 'array'; },
       IsFunction::class     => function($t) { return 'callable'; },
       IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : "?{$l}"; },
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {

--- a/src/main/php/lang/ast/emit/PHP73.class.php
+++ b/src/main/php/lang/ast/emit/PHP73.class.php
@@ -38,7 +38,7 @@ class PHP73 extends PHP {
       IsMap::class          => function($t) { return 'array'; },
       IsFunction::class     => function($t) { return 'callable'; },
       IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : "?{$l}"; },
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -35,7 +35,7 @@ class PHP74 extends PHP {
       IsMap::class          => function($t) { return 'array'; },
       IsFunction::class     => function($t) { return 'callable'; },
       IsValue::class        => function($t) { $l= $t->literal(); return 'static' === $l ? 'self' : $l; },
-      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : '?'.$l; },
+      IsNullable::class     => function($t) { $l= $this->literal($t->element); return null === $l ? null : "?{$l}"; },
       IsUnion::class        => function($t) { return null; },
       IsIntersection::class => function($t) { return null; },
       IsLiteral::class      => function($t) {

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -40,7 +40,7 @@ class PHP80 extends PHP {
       IsValue::class        => function($t) { return $t->literal(); },
       IsNullable::class     => function($t) {
         if (null === ($l= $this->literal($t->element))) return null;
-        return $t->element instanceof IsUnion ? $l.'|null' : '?'.$l;
+        return $t->element instanceof IsUnion ? "{$l}|null" : "?{$l}";
       },
       IsIntersection::class => function($t) { return null; },
       IsUnion::class        => function($t) {
@@ -49,7 +49,7 @@ class PHP80 extends PHP {
           if ('null' === $component->literal) {
             $u.= '|null';
           } else if (null !== ($l= $this->literal($component))) {
-            $u.= '|'.$l;
+            $u.= "|{$l}";
           } else {
             return null;  // One of the components didn't resolve
           }

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -36,13 +36,13 @@ class PHP81 extends PHP {
       IsValue::class        => function($t) { return $t->literal(); },
       IsNullable::class     => function($t) {
         if (null === ($l= $this->literal($t->element))) return null;
-        return $t->element instanceof IsUnion ? $l.'|null' : '?'.$l;
+        return $t->element instanceof IsUnion ? "{$l}|null" : "?{$l}";
       },
       IsIntersection::class => function($t) {
         $i= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
-          $i.= '&'.$l;
+          $i.= "&{$l}";
         }
         return substr($i, 1);
       },
@@ -52,7 +52,7 @@ class PHP81 extends PHP {
           if ('null' === $component->literal) {
             $u.= '|null';
           } else if (null !== ($l= $this->literal($component))) {
-            $u.= '|'.$l;
+            $u.= "|{$l}";
           } else {
             return null;  // One of the components didn't resolve
           }

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -36,13 +36,13 @@ class PHP82 extends PHP {
       IsValue::class        => function($t) { return $t->literal(); },
       IsNullable::class     => function($t) {
         if (null === ($l= $this->literal($t->element))) return null;
-        return $t->element instanceof IsUnion ? $l.'|null' : '?'.$l;
+        return $t->element instanceof IsUnion ? "{$l}|null" : "?{$l}";
       },
       IsIntersection::class => function($t) {
         $i= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
-          $i.= '&'.$l;
+          $i.= "&{$l}";
         }
         return substr($i, 1);
       },
@@ -50,7 +50,7 @@ class PHP82 extends PHP {
         $u= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
-          $u.= '|'.$l;
+          $u.= "|{$l}";
         }
         return substr($u, 1);
       },

--- a/src/main/php/lang/ast/emit/PHP83.class.php
+++ b/src/main/php/lang/ast/emit/PHP83.class.php
@@ -29,13 +29,13 @@ class PHP83 extends PHP {
       IsValue::class        => function($t) { return $t->literal(); },
       IsNullable::class     => function($t) {
         if (null === ($l= $this->literal($t->element))) return null;
-        return $t->element instanceof IsUnion ? $l.'|null' : '?'.$l;
+        return $t->element instanceof IsUnion ? "{$l}|null" : "?{$l}";
       },
       IsIntersection::class => function($t) {
         $i= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
-          $i.= '&'.$l;
+          $i.= "&{$l}";
         }
         return substr($i, 1);
       },
@@ -43,7 +43,7 @@ class PHP83 extends PHP {
         $u= '';
         foreach ($t->components as $component) {
           if (null === ($l= $this->literal($component))) return null;
-          $u.= '|'.$l;
+          $u.= "|{$l}";
         }
         return substr($u, 1);
       },

--- a/src/main/php/lang/ast/emit/RewriteAssignments.class.php
+++ b/src/main/php/lang/ast/emit/RewriteAssignments.class.php
@@ -20,7 +20,7 @@ trait RewriteAssignments {
 
   protected function rewriteDestructuring($result, $assignment) {
     $t= $result->temp();
-    $result->out->write('is_array('.$t.'=');
+    $result->out->write("is_array({$t}=");
 
     // Create reference to right-hand if possible
     $r= $assignment->expression;
@@ -63,7 +63,7 @@ trait RewriteAssignments {
       }
       $result->out->write(',');
     }
-    $result->out->write(']?'.$t.':null)');
+    $result->out->write("]?{$t}:null)");
   }
 
   protected function emitAssignment($result, $assignment) {

--- a/src/main/php/lang/ast/emit/RewriteDynamicClassConstants.class.php
+++ b/src/main/php/lang/ast/emit/RewriteDynamicClassConstants.class.php
@@ -11,7 +11,7 @@ trait RewriteDynamicClassConstants {
 
   protected function emitScope($result, $scope) {
     if ($scope->member instanceof Expression && -1 !== $scope->line) {
-      $result->out->write('constant('.$scope->type.'::class."::".');
+      $result->out->write("constant({$scope->type}::class.'::'.");
       $this->emitOne($result, $scope->member->inline);
       $result->out->write(')');
     } else {

--- a/src/main/php/lang/ast/emit/RewriteEnums.class.php
+++ b/src/main/php/lang/ast/emit/RewriteEnums.class.php
@@ -8,17 +8,18 @@
 trait RewriteEnums {
 
   protected function emitEnumCase($result, $case) {
-    $result->out->write('public static $'.$case->name.';');
+    $result->out->write("public static \${$case->name};");
   }
 
   protected function emitEnum($result, $enum) {
     $context= $result->codegen->enter(new InType($enum));
-    $result->out->write('final class '.$enum->declaration().' implements \\'.($enum->base ? 'BackedEnum' : 'UnitEnum'));
+    $base= $enum->base ? 'BackedEnum' : 'UnitEnum';
+    $result->out->write("final class {$enum->declaration()} implements \\{$base}");
 
     if ($enum->implements) {
       $list= '';
       foreach ($enum->implements as $type) {
-        $list.= ', '.$type->literal();
+        $list.= ", {$type->literal()}";
       }
       $result->out->write($list);
     }
@@ -62,7 +63,7 @@ trait RewriteEnums {
     // Enum cases
     $result->out->write('public static function cases() { return [');
     foreach ($cases as $case) {
-      $result->out->write('self::$'.$case->name.', ');
+      $result->out->write("self::\${$case->name}, ");
     }
     $result->out->write(']; }');
 
@@ -70,18 +71,18 @@ trait RewriteEnums {
     $result->out->write('static function __init() {');
     if ($enum->base) {
       foreach ($cases as $case) {
-        $result->out->write('self::$'.$case->name.'= new self("'.$case->name.'", ');
+        $result->out->write("self::\${$case->name}= new self('{$case->name}', ");
         $this->emitOne($result, $case->expression);
         $result->out->write(');');
       }
     } else {
       foreach ($cases as $case) {
-        $result->out->write('self::$'.$case->name.'= new self("'.$case->name.'");');
+        $result->out->write("self::\${$case->name}= new self('{$case->name}');");
       }
     }
     $this->emitInitializations($result, $context->statics);
     $this->emitMeta($result, $enum->name, $enum->annotations, $enum->comment);
-    $result->out->write('}} '.$enum->name.'::__init();');
+    $result->out->write("}} {$enum->name}::__init();");
     $result->codegen->leave();
   }
 }

--- a/src/main/php/lang/ast/emit/RewriteMultiCatch.class.php
+++ b/src/main/php/lang/ast/emit/RewriteMultiCatch.class.php
@@ -8,16 +8,16 @@
 trait RewriteMultiCatch {
  
   protected function emitCatch($result, $catch) {
-    $capture= $catch->variable ? '$'.$catch->variable : $result->temp();
+    $capture= $catch->variable ? "\${$catch->variable}" : $result->temp();
     if (empty($catch->types)) {
-      $result->out->write('catch(\\Throwable '.$capture.') {');
+      $result->out->write("catch(\\Throwable {$capture}) {");
     } else {
       $last= array_pop($catch->types);
       $label= $result->codegen->symbol();
       foreach ($catch->types as $type) {
-        $result->out->write('catch('.$type.' '.$capture.') { goto '.$label.'; }');
+        $result->out->write("catch({$type} {$capture}) { goto {$label}; }");
       }
-      $result->out->write('catch('.$last.' '.$capture.') { '.$label.':');
+      $result->out->write("catch({$last} {$capture}) { {$label}:");
     }
 
     $this->emitAll($result, $catch->body);

--- a/src/main/php/lang/ast/emit/RewriteStaticVariableInitializations.class.php
+++ b/src/main/php/lang/ast/emit/RewriteStaticVariableInitializations.class.php
@@ -10,13 +10,13 @@ trait RewriteStaticVariableInitializations {
 
   protected function emitStatic($result, $static) {
     foreach ($static->initializations as $variable => $initial) {
-      $result->out->write('static $'.$variable);
+      $result->out->write("static \${$variable}");
       if ($initial) {
         if ($this->isConstant($result, $initial)) {
           $result->out->write('=');
           $this->emitOne($result, $initial);
         } else {
-          $result->out->write('= null; null === $'.$variable.' && $'.$variable.'= ');
+          $result->out->write("= null; null === \${$variable} && \${$variable}=");
           $this->emitOne($result, $initial);
         }
       }

--- a/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
+++ b/src/main/php/lang/ast/emit/php/VirtualPropertyTypes.class.php
@@ -80,7 +80,7 @@ trait VirtualPropertyTypes {
 
     // Initialize via constructor
     if (isset($property->expression)) {
-      $scope->init['$this->'.$property->name]= $property->expression;
+      $scope->init["\$this->{$property->name}"]= $property->expression;
     }
 
     // Emit XP meta information for the reflection API

--- a/src/main/php/lang/ast/emit/php/XpMeta.class.php
+++ b/src/main/php/lang/ast/emit/php/XpMeta.class.php
@@ -24,7 +24,7 @@ trait XpMeta {
     foreach ($annotations as $name => $arguments) {
       $p= strrpos($name, '\\');
       $key= lcfirst(false === $p ? $name : substr($name, $p + 1));
-      $result->out->write("'".$key."' => ");
+      $result->out->write("'{$key}' => ");
       $name === $key || $lookup[$key]= $name;
 
       if (empty($arguments)) {
@@ -36,7 +36,7 @@ trait XpMeta {
       } else {
         $result->out->write('[');
         foreach ($arguments as $name => $argument) {
-          is_string($name) && $result->out->write("'".$name."' => ");
+          is_string($name) && $result->out->write("'{$name}' => ");
           $this->emitOne($result, $argument);
           $result->out->write(',');
         }
@@ -52,7 +52,7 @@ trait XpMeta {
     $lookup= $this->annotations($result, $annotations);
     $result->out->write('], DETAIL_TARGET_ANNO => [');
     foreach ($target as $name => $annotations) {
-      $result->out->write("'$".$name."' => [");
+      $result->out->write("'\${$name}' => [");
       foreach ($this->annotations($result, $annotations, $name) as $key => $value) {
         $lookup[$key]= $value;
       }
@@ -74,21 +74,21 @@ trait XpMeta {
     if (null === $type) {
       $result->out->write('\xp::$meta[strtr(self::class, "\\\\", ".")]= [');
     } else if ($type instanceof IsGeneric) {
-      $result->out->write('\xp::$meta[\''.$type->base->name().'\']= [');
+      $result->out->write("\\xp::\$meta['{$type->base->name()}']= [");
     } else {
-      $result->out->write('\xp::$meta[\''.$type->name().'\']= [');
+      $result->out->write("\\xp::\$meta['{$type->name()}']= [");
     }
     $result->out->write('"class" => [');
     $this->attributes($result, $annotations, []);
-    $result->out->write(', DETAIL_COMMENT => '.$this->comment($comment).'],');
+    $result->out->write(", DETAIL_COMMENT => {$this->comment($comment)}],");
 
     foreach ($result->codegen->scope[0]->meta as $type => $lookup) {
       $result->out->write($type.' => [');
       foreach ($lookup as $key => $meta) {
-        $result->out->write("'".$key."' => [");
+        $result->out->write("'{$key}' => [");
         $this->attributes($result, $meta[DETAIL_ANNOTATIONS], $meta[DETAIL_TARGET_ANNO]);
-        $result->out->write(', DETAIL_RETURNS => \''.$meta[DETAIL_RETURNS].'\'');
-        $result->out->write(', DETAIL_COMMENT => '.$this->comment($meta[DETAIL_COMMENT]));
+        $result->out->write(", DETAIL_RETURNS => '{$meta[DETAIL_RETURNS]}'");
+        $result->out->write(", DETAIL_COMMENT => {$this->comment($meta[DETAIL_COMMENT])}");
         $result->out->write(', DETAIL_ARGUMENTS => ['.($meta[DETAIL_ARGUMENTS]
           ? "'".implode("', '", $meta[DETAIL_ARGUMENTS])."']],"
           : ']],'


### PR DESCRIPTION
This should [theoretically improve speed](https://github.com/orgs/xp-framework/projects/4/views/1?pane=issue&itemId=36335023) - however, the effect is not measurable in the XP Compiler:

### Best run before

```bash
$ xp test src/test/php
# ...
Test cases:  956 succeeded, 3 skipped
Memory used: 11623.54 kB (11677.67 kB peak)
Time taken:  0.232 seconds (0.508 seconds overall)
```

### Best run after

```bash
$ xp test src/test/php
# ...
Test cases:  956 succeeded, 3 skipped
Memory used: 11630.20 kB (11684.33 kB peak)
Time taken:  0.234 seconds (0.499 seconds overall)
```