### PR TITLE
Transform multiple nodes without creating statements

### DIFF
--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -148,9 +148,9 @@ abstract class Emitter {
           $this->{'emit'.$r->kind}($result, $r);
           return;
         } else if ($r) {
-          foreach ($r as $n) {
+          foreach ($r as $s => $n) {
             $this->{'emit'.$n->kind}($result, $n);
-            $result->out->write(';');
+            null === $s || $result->out->write(';');
           }
           return;
         }


### PR DESCRIPTION
Otherwise the following would generate a `;` following a method, which is a syntax error.

```php
// Transform one method to two
$emitter->transform('method', function($codegen, $node) {
  yield null => new Method(...);
  yield null => new Method(...);
});
```

*This can be considered a workaround, it would be better to have `Statement` nodes, but this would be a significant refactoring!*