### PR TITLE
Remove Result::$stack

### DIFF
--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -129,7 +129,7 @@ abstract class PHP extends Emitter {
     }
     unset($capture['this']);
 
-    $result->stack[]= $result->locals;
+    $locals= $result->locals;
     $result->locals= [];
     if ($signature) {
       $static ? $result->out->write('static function') : $result->out->write('function');
@@ -151,7 +151,7 @@ abstract class PHP extends Emitter {
     $result->out->write('{');
     $emit($result, $node);
     $result->out->write('}');
-    $result->locals= array_pop($result->stack);
+    $result->locals= $locals;
   }
 
   /**
@@ -331,7 +331,7 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitFunction($result, $function) {
-    $result->stack[]= $result->locals;
+    $locals= $result->locals;
     $result->locals= [];
 
     $result->out->write('function '.($function->signature->byref ? '&' : '').$function->name);
@@ -341,11 +341,11 @@ abstract class PHP extends Emitter {
     $this->emitAll($result, $function->body);
     $result->out->write('}');
 
-    $result->locals= array_pop($result->stack);
+    $result->locals= $locals;
   }
 
   protected function emitClosure($result, $closure) {
-    $result->stack[]= $result->locals;
+    $locals= $result->locals;
     $result->locals= [];
 
     $closure->static ? $result->out->write('static function') : $result->out->write('function');
@@ -361,18 +361,18 @@ abstract class PHP extends Emitter {
     $this->emitAll($result, $closure->body);
     $result->out->write('}');
 
-    $result->locals= array_pop($result->stack);
+    $result->locals= $locals;
   }
 
   protected function emitLambda($result, $lambda) {
-    $result->stack[]= $result->locals;
+    $locals= $result->locals;
 
     $lambda->static ? $result->out->write('static fn') : $result->out->write('fn');
     $this->emitSignature($result, $lambda->signature);
     $result->out->write('=>');
     $this->emitOne($result, $lambda->body);
 
-    $result->locals= array_pop($result->stack);
+    $result->locals= $locals;
   }
 
   protected function emitEnumCase($result, $case) {
@@ -636,7 +636,7 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitMethod($result, $method) {
-    $result->stack[]= $result->locals;
+    $locals= $result->locals;
     $result->locals= ['this' => true];
     $meta= [
       DETAIL_RETURNS     => $method->signature->returns ? $method->signature->returns->name() : 'var',
@@ -708,7 +708,7 @@ abstract class PHP extends Emitter {
       $this->emitProperty($result, new Property(explode(' ', $param->promote), $param->name, $param->type));
     }
 
-    $result->locals= array_pop($result->stack);
+    $result->locals= $locals;
     $result->codegen->scope[0]->meta[self::METHOD][$method->name]= $meta;
   }
 

--- a/src/main/php/lang/ast/emit/Result.class.php
+++ b/src/main/php/lang/ast/emit/Result.class.php
@@ -8,7 +8,6 @@ class Result implements Closeable {
   public $out;
   public $codegen;
   public $locals= [];
-  public $stack= [];
 
   /**
    * Starts a result stream.


### PR DESCRIPTION
Use local variables for backing up and restoring locals. There is no usecase where we need to access locals two or more levels above the current locals, which is what we would need the stack for.

### Slight performance / memory usage improvements

Before:
```
Test cases:  952 succeeded, 8 skipped
Memory used: 11839.18 kB (11893.41 kB peak)
Time taken:  0.155 seconds (0.230 seconds overall)
```

After:
```
Test cases:  952 succeeded, 8 skipped
Memory used: 11832.96 kB (11887.19 kB peak)
Time taken:  0.143 seconds (0.210 seconds overall)
```