### PR TITLE
Add emitting support for asymmetric visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
     "xp-framework/reflection": "^3.2",
-    "xp-framework/ast": "dev-feature/asymmetric-visibility as 11.3.0",
+    "xp-framework/ast": "^11.3",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
-    "xp-framework/reflection": "^3.0 | ^2.13",
+    "xp-framework/reflection": "dev-feature/asymmetric-visibility as 3.2.0",
     "xp-framework/ast": "dev-feature/asymmetric-visibility as 11.3.0",
     "php" : ">=7.4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
-    "xp-framework/reflection": "dev-feature/asymmetric-visibility as 3.2.0",
+    "xp-framework/reflection": "^3.2",
     "xp-framework/ast": "dev-feature/asymmetric-visibility as 11.3.0",
     "php" : ">=7.4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
     "xp-framework/reflection": "^3.0 | ^2.13",
-    "xp-framework/ast": "^11.1",
+    "xp-framework/ast": "dev-feature/asymmetric-visibility as 11.3.0",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -21,13 +21,13 @@ trait AsymmetricVisibility {
       $check= (
         '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
         'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot access private property ".__CLASS__."::".$name);'
+        'throw new \\Error("Cannot modify private(set) property ".__CLASS__."::\$".$name." from ".($scope ? "scope ".$scope : "global scope"));'
       );
     } else if (in_array('protected(set)', $property->modifiers)) {
       $check= (
         '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
         'if (__CLASS__ !== $scope && !is_subclass_of($scope, __CLASS__) && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot access protected property ".__CLASS__."::".$name);'
+        'throw new \\Error("Cannot modify protected(set) property ".__CLASS__."::\$".$name." from ".($scope ? "scope ".$scope : "global scope"));'
       );
     }
 

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -18,23 +18,25 @@ trait AsymmetricVisibility {
     $virtual= new InstanceExpression(new Variable('this'), new OffsetExpression(new Literal('__virtual'), $literal));
 
     if (in_array('private(set)', $property->modifiers)) {
-      $check= (
+      $check= [new Code(
         '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
         'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
         'throw new \\Error("Cannot modify private(set) property ".__CLASS__."::\$".$name." from ".($scope ? "scope ".$scope : "global scope"));'
-      );
+      )];
     } else if (in_array('protected(set)', $property->modifiers)) {
-      $check= (
+      $check= [new Code(
         '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
         'if (__CLASS__ !== $scope && !is_subclass_of($scope, __CLASS__) && \\lang\\VirtualProperty::class !== $scope)'.
         'throw new \\Error("Cannot modify protected(set) property ".__CLASS__."::\$".$name." from ".($scope ? "scope ".$scope : "global scope"));'
-      );
+      )];
+    } else {
+      $check= [];
     }
 
     $scope= $result->codegen->scope[0];
     $scope->virtual[$property->name]= [
       new ReturnStatement($virtual),
-      new Block([new Code($check), new Assignment($virtual, '=', new Variable('value'))]),
+      new Block([...$check, new Assignment($virtual, '=', new Variable('value'))]),
     ];
     if (isset($property->expression)) {
       $scope->init[sprintf('$this->__virtual["%s"]', $property->name)]= $property->expression;

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -14,9 +14,6 @@ use lang\ast\nodes\{
 trait AsymmetricVisibility {
 
   protected function emitProperty($result, $property) {
-    $literal= new Literal("'{$property->name}'");
-    $virtual= new InstanceExpression(new Variable('this'), new OffsetExpression(new Literal('__virtual'), $literal));
-
     if (in_array('private(set)', $property->modifiers)) {
       $check= [new Code(
         '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
@@ -32,6 +29,11 @@ trait AsymmetricVisibility {
     } else {
       $check= [];
     }
+
+    $virtual= new InstanceExpression(new Variable('this'), new OffsetExpression(
+      new Literal('__virtual'),
+      new Literal("'{$property->name}'"))
+    );
 
     $scope= $result->codegen->scope[0];
     $scope->virtual[$property->name]= [

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -10,6 +10,12 @@ use lang\ast\nodes\{
   Variable
 };
 
+/**
+ * Asymmetric Visibility
+ *
+ * @see  https://wiki.php.net/rfc/asymmetric-visibility-v2
+ * @test lang.ast.unittest.emit.AsymmetricVisibilityTest
+ */
 trait AsymmetricVisibility {
   use VisibilityChecks;
 

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -28,9 +28,9 @@ trait AsymmetricVisibility {
       'final'          => MODIFIER_FINAL,
       'abstract'       => MODIFIER_ABSTRACT,
       'readonly'       => MODIFIER_READONLY,
-      'private(set)'   => 0x0400,
+      'public(set)'    => 0x0400,
       'protected(set)' => 0x0800,
-      'public(set)'    => 0x1000,
+      'private(set)'   => 0x1000,
     ];
 
     // Emit XP meta information for the reflection API
@@ -48,7 +48,7 @@ trait AsymmetricVisibility {
     ];
 
     $checks= [];
-    if ($modifiers & 0x0400) {
+    if ($modifiers & 0x1000) {
       $checks[]= $this->private($property->name, 'modify private(set)');
     } else if ($modifiers & 0x0800) {
       $checks[]= $this->protected($property->name, 'modify protected(set)');

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -1,6 +1,5 @@
 <?php namespace lang\ast\emit;
 
-use lang\ast\Code;
 use lang\ast\nodes\{
   Assignment,
   Block,
@@ -12,20 +11,13 @@ use lang\ast\nodes\{
 };
 
 trait AsymmetricVisibility {
+  use VisibilityChecks;
 
   protected function emitProperty($result, $property) {
     if (in_array('private(set)', $property->modifiers)) {
-      $check= [new Code(
-        '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
-        'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot modify private(set) property ".__CLASS__."::\$".$name." from ".($scope ? "scope ".$scope : "global scope"));'
-      )];
+      $check= [$this->private($property->name, 'modify private(set)')];
     } else if (in_array('protected(set)', $property->modifiers)) {
-      $check= [new Code(
-        '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
-        'if (__CLASS__ !== $scope && !is_subclass_of($scope, __CLASS__) && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot modify protected(set) property ".__CLASS__."::\$".$name." from ".($scope ? "scope ".$scope : "global scope"));'
-      )];
+      $check= [$this->protected($property->name, 'modify protected(set)')];
     } else {
       $check= [];
     }

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -1,0 +1,37 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\Code;
+use lang\ast\nodes\{
+  Assignment,
+  Block,
+  InstanceExpression,
+  Literal,
+  OffsetExpression,
+  ReturnStatement,
+  Variable
+};
+
+trait AsymmetricVisibility {
+
+  protected function emitProperty($result, $property) {
+    $literal= new Literal("'{$property->name}'");
+    $virtual= new InstanceExpression(new Variable('this'), new OffsetExpression(new Literal('__virtual'), $literal));
+
+    if (in_array('private(set)', $property->modifiers)) {
+      $check= (
+        '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
+        'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
+        'throw new \\Error("Cannot access private property ".__CLASS__."::".$name);'
+      );
+    }
+
+    $scope= $result->codegen->scope[0];
+    $scope->virtual[$property->name]= [
+      new ReturnStatement($virtual),
+      new Block([new Code($check), new Assignment($virtual, '=', new Variable('value'))]),
+    ];
+    if (isset($property->expression)) {
+      $scope->init[sprintf('$this->__virtual["%s"]', $property->name)]= $property->expression;
+    }
+  }
+}

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -20,12 +20,16 @@ trait AsymmetricVisibility {
   use VisibilityChecks;
 
   protected function emitProperty($result, $property) {
+    $checks= [];
     if (in_array('private(set)', $property->modifiers)) {
-      $check= [$this->private($property->name, 'modify private(set)')];
+      $checks[]= $this->private($property->name, 'modify private(set)');
     } else if (in_array('protected(set)', $property->modifiers)) {
-      $check= [$this->protected($property->name, 'modify protected(set)')];
-    } else {
-      $check= [];
+      $checks[]= $this->protected($property->name, 'modify protected(set)');
+    }
+
+    // The readonly flag is really two flags in one: write-once and restricted(set)
+    if (in_array('readonly', $property->modifiers)) {
+      $checks[]= $this->initonce($property->name);
     }
 
     $virtual= new InstanceExpression(new Variable('this'), new OffsetExpression(
@@ -36,7 +40,7 @@ trait AsymmetricVisibility {
     $scope= $result->codegen->scope[0];
     $scope->virtual[$property->name]= [
       new ReturnStatement($virtual),
-      new Block([...$check, new Assignment($virtual, '=', new Variable('value'))]),
+      new Block([...$checks, new Assignment($virtual, '=', new Variable('value'))]),
     ];
     if (isset($property->expression)) {
       $scope->init[sprintf('$this->__virtual["%s"]', $property->name)]= $property->expression;

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -28,9 +28,9 @@ trait AsymmetricVisibility {
       'final'          => MODIFIER_FINAL,
       'abstract'       => MODIFIER_ABSTRACT,
       'readonly'       => MODIFIER_READONLY,
-      'public(set)'    => 0x0400,
-      'protected(set)' => 0x0800,
-      'private(set)'   => 0x1000,
+      'public(set)'    => 0x1000000,
+      'protected(set)' => 0x0000800,
+      'private(set)'   => 0x0001000,
     ];
 
     $scope= $result->codegen->scope[0];
@@ -41,15 +41,15 @@ trait AsymmetricVisibility {
 
     // Declare checks for private(set) and protected(set), folding declarations
     // like `[visibility] [visibility](set)` to just the visibility itself.
-    if ($modifiers & 0x0400) {
+    if ($modifiers & 0x1000000) {
       $checks= [];
-      $modifiers&= ~0x0400;
-    } else if ($modifiers & 0x0800) {
+      $modifiers&= ~0x1000000;
+    } else if ($modifiers & 0x0000800) {
       $checks= [$this->protected($property->name, 'modify protected(set)')];
-      $modifiers & MODIFIER_PROTECTED && $modifiers&= ~0x0800;
-    } else if ($modifiers & 0x1000) {
+      $modifiers & MODIFIER_PROTECTED && $modifiers&= ~0x0000800;
+    } else if ($modifiers & 0x0001000) {
       $checks= [$this->private($property->name, 'modify private(set)')];
-      $modifiers & MODIFIER_PRIVATE && $modifiers&= ~0x1000;
+      $modifiers & MODIFIER_PRIVATE && $modifiers&= ~0x0001000;
     }
 
     // Emit XP meta information for the reflection API

--- a/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
+++ b/src/main/php/lang/ast/emit/AsymmetricVisibility.class.php
@@ -23,6 +23,12 @@ trait AsymmetricVisibility {
         'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
         'throw new \\Error("Cannot access private property ".__CLASS__."::".$name);'
       );
+    } else if (in_array('protected(set)', $property->modifiers)) {
+      $check= (
+        '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
+        'if (__CLASS__ !== $scope && !is_subclass_of($scope, __CLASS__) && \\lang\\VirtualProperty::class !== $scope)'.
+        'throw new \\Error("Cannot access protected property ".__CLASS__."::".$name);'
+      );
     }
 
     $scope= $result->codegen->scope[0];

--- a/src/main/php/lang/ast/emit/PHP74.class.php
+++ b/src/main/php/lang/ast/emit/PHP74.class.php
@@ -28,6 +28,8 @@ class PHP74 extends PHP {
     RewriteThrowableExpressions
   ;
 
+  public $targetVersion= 70400;
+
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [

--- a/src/main/php/lang/ast/emit/PHP80.class.php
+++ b/src/main/php/lang/ast/emit/PHP80.class.php
@@ -31,6 +31,8 @@ class PHP80 extends PHP {
     RewriteStaticVariableInitializations
   ;
 
+  public $targetVersion= 80000;
+
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -23,9 +23,9 @@ class PHP81 extends PHP {
     RewriteBlockLambdaExpressions,
     RewriteDynamicClassConstants,
     RewriteStaticVariableInitializations,
+    RewriteProperties,
     ReadonlyClasses,
-    OmitConstantTypes,
-    PropertyHooks
+    OmitConstantTypes
   ;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP81.class.php
+++ b/src/main/php/lang/ast/emit/PHP81.class.php
@@ -28,6 +28,8 @@ class PHP81 extends PHP {
     OmitConstantTypes
   ;
 
+  public $targetVersion= 80100;
+
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -23,9 +23,9 @@ class PHP82 extends PHP {
     RewriteBlockLambdaExpressions,
     RewriteDynamicClassConstants,
     RewriteStaticVariableInitializations,
+    RewriteProperties,
     ReadonlyClasses,
-    OmitConstantTypes,
-    PropertyHooks
+    OmitConstantTypes
   ;
 
   /** Sets up type => literal mappings */

--- a/src/main/php/lang/ast/emit/PHP82.class.php
+++ b/src/main/php/lang/ast/emit/PHP82.class.php
@@ -28,6 +28,8 @@ class PHP82 extends PHP {
     OmitConstantTypes
   ;
 
+  public $targetVersion= 80200;
+
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [

--- a/src/main/php/lang/ast/emit/PHP83.class.php
+++ b/src/main/php/lang/ast/emit/PHP83.class.php
@@ -18,7 +18,7 @@ use lang\ast\types\{
  * @see  https://wiki.php.net/rfc#php_83
  */
 class PHP83 extends PHP {
-  use RewriteBlockLambdaExpressions, ReadonlyClasses, PropertyHooks;
+  use RewriteBlockLambdaExpressions, RewriteProperties, ReadonlyClasses;
 
   /** Sets up type => literal mappings */
   public function __construct() {

--- a/src/main/php/lang/ast/emit/PHP83.class.php
+++ b/src/main/php/lang/ast/emit/PHP83.class.php
@@ -20,6 +20,8 @@ use lang\ast\types\{
 class PHP83 extends PHP {
   use RewriteBlockLambdaExpressions, RewriteProperties, ReadonlyClasses;
 
+  public $targetVersion= 80300;
+
   /** Sets up type => literal mappings */
   public function __construct() {
     $this->literals= [

--- a/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
@@ -66,8 +66,8 @@ trait ReadonlyProperties {
       $check ? new Block([$check, new ReturnStatement($virtual)]) : new ReturnStatement($virtual),
       new Block([
         $check ?? new Code('$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'),
+        $this->initonce($property->name),
         new Code(sprintf(
-          'if (isset($this->__virtual["%1$s"])) throw new \\Error("Cannot modify readonly property ".__CLASS__."::{$name}");'.
           'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
           'throw new \\Error("Cannot initialize readonly property ".__CLASS__."::{$name} from ".($scope ? "scope {$scope}": "global scope"));'.
           '$this->__virtual["%1$s"]= [$value];',

--- a/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
+++ b/src/main/php/lang/ast/emit/ReadonlyProperties.class.php
@@ -1,5 +1,15 @@
 <?php namespace lang\ast\emit;
 
+use lang\ast\nodes\{
+  Assignment,
+  Block,
+  InstanceExpression,
+  InvokeExpression,
+  Literal,
+  OffsetExpression,
+  ReturnStatement,
+  Variable
+};
 use lang\ast\{Code, Error, Errors};
 
 /**
@@ -9,6 +19,7 @@ use lang\ast\{Code, Error, Errors};
  * @see  https://wiki.php.net/rfc/readonly_properties_v2
  */
 trait ReadonlyProperties {
+  use VisibilityChecks;
 
   protected function emitProperty($result, $property) {
     static $lookup= [
@@ -37,33 +48,33 @@ trait ReadonlyProperties {
     ];
 
     // Add visibility check for accessing private and protected properties
-    if (in_array('private', $property->modifiers)) {
-      $check= (
-        '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
-        'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot access private property ".__CLASS__."::\\$%1$s");'
-      );
-    } else if (in_array('protected', $property->modifiers)) {
-      $check= (
-        '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
-        'if (__CLASS__ !== $scope && !is_subclass_of($scope, __CLASS__) && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot access protected property ".__CLASS__."::\\$%1$s");'
-      );
+    if ($modifiers & MODIFIER_PRIVATE) {
+      $check= $this->private($property->name, 'access private');
+    } else if ($modifiers & MODIFIER_PROTECTED) {
+      $check= $this->protected($property->name, 'access protected');
     } else {
-      $check= '';
+      $check= null;
     }
+
+    $virtual= new InstanceExpression(new Variable('this'), new OffsetExpression(
+      new Literal('__virtual'),
+      new Literal("'{$property->name}'"))
+    );
 
     // Create virtual property implementing the readonly semantics
     $scope->virtual[$property->name]= [
-      new Code(sprintf($check.'return $this->__virtual["%1$s"][0];', $property->name)),
-      new Code(sprintf(
-        ($check ?: '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;').
-        'if (isset($this->__virtual["%1$s"])) throw new \\Error("Cannot modify readonly property ".__CLASS__."::{$name}");'.
-        'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
-        'throw new \\Error("Cannot initialize readonly property ".__CLASS__."::{$name} from ".($scope ? "scope {$scope}": "global scope"));'.
-        '$this->__virtual["%1$s"]= [$value];',
-        $property->name
-      )),
+      $check ? new Block([$check, new ReturnStatement($virtual)]) : new ReturnStatement($virtual),
+      new Block([
+        $check ?? new Code('$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'),
+        new Code(sprintf(
+          'if (isset($this->__virtual["%1$s"])) throw new \\Error("Cannot modify readonly property ".__CLASS__."::{$name}");'.
+          'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
+          'throw new \\Error("Cannot initialize readonly property ".__CLASS__."::{$name} from ".($scope ? "scope {$scope}": "global scope"));'.
+          '$this->__virtual["%1$s"]= [$value];',
+          $property->name
+        )),
+        new Assignment($virtual, '=', new Variable('value'))
+      ]),
     ];
   }
 }

--- a/src/main/php/lang/ast/emit/RewriteProperties.class.php
+++ b/src/main/php/lang/ast/emit/RewriteProperties.class.php
@@ -1,15 +1,18 @@
 <?php namespace lang\ast\emit;
 
 trait RewriteProperties {
-  use PropertyHooks, ReadonlyProperties {
+  use PropertyHooks, ReadonlyProperties, AsymmetricVisibility {
     PropertyHooks::emitProperty as emitPropertyHooks;
     ReadonlyProperties::emitProperty as emitReadonlyProperties;
+    AsymmetricVisibility::emitProperty as emitAsymmetricVisibility;
   }
 
   protected function emitProperty($result, $property) {
     if ($property->hooks) {
       return $this->emitPropertyHooks($result, $property);
-    } else if (in_array('readonly', $property->modifiers)) {
+    } else if (in_array('private(set)', $property->modifiers)) {
+      return $this->emitAsymmetricVisibility($result, $property);
+    } else if (PHP_VERSION_ID <= 80100 && in_array('readonly', $property->modifiers)) {
       return $this->emitReadonlyProperties($result, $property);
     }
     parent::emitProperty($result, $property);

--- a/src/main/php/lang/ast/emit/RewriteProperties.class.php
+++ b/src/main/php/lang/ast/emit/RewriteProperties.class.php
@@ -1,5 +1,7 @@
 <?php namespace lang\ast\emit;
 
+use ReflectionProperty;
+
 trait RewriteProperties {
   use PropertyHooks, ReadonlyProperties, AsymmetricVisibility {
     PropertyHooks::emitProperty as emitPropertyHooks;
@@ -8,9 +10,13 @@ trait RewriteProperties {
   }
 
   protected function emitProperty($result, $property) {
+    static $asymmetric= null;
     if ($property->hooks) {
       return $this->emitPropertyHooks($result, $property);
-    } else if (array_intersect($property->modifiers, ['private(set)', 'protected(set)', 'public(set)'])) {
+    } else if (
+      !($asymmetric ?? $asymmetric= method_exists(ReflectionProperty::class, 'isPrivateSet')) &&
+      array_intersect($property->modifiers, ['private(set)', 'protected(set)', 'public(set)'])
+    ) {
       return $this->emitAsymmetricVisibility($result, $property);
     } else if (PHP_VERSION_ID <= 80100 && in_array('readonly', $property->modifiers)) {
       return $this->emitReadonlyProperties($result, $property);

--- a/src/main/php/lang/ast/emit/RewriteProperties.class.php
+++ b/src/main/php/lang/ast/emit/RewriteProperties.class.php
@@ -10,7 +10,7 @@ trait RewriteProperties {
   protected function emitProperty($result, $property) {
     if ($property->hooks) {
       return $this->emitPropertyHooks($result, $property);
-    } else if (in_array('private(set)', $property->modifiers) || in_array('protected(set)', $property->modifiers)) {
+    } else if (array_intersect($property->modifiers, ['private(set)', 'protected(set)', 'public(set)'])) {
       return $this->emitAsymmetricVisibility($result, $property);
     } else if (PHP_VERSION_ID <= 80100 && in_array('readonly', $property->modifiers)) {
       return $this->emitReadonlyProperties($result, $property);

--- a/src/main/php/lang/ast/emit/RewriteProperties.class.php
+++ b/src/main/php/lang/ast/emit/RewriteProperties.class.php
@@ -10,7 +10,7 @@ trait RewriteProperties {
   protected function emitProperty($result, $property) {
     if ($property->hooks) {
       return $this->emitPropertyHooks($result, $property);
-    } else if (in_array('private(set)', $property->modifiers)) {
+    } else if (in_array('private(set)', $property->modifiers) || in_array('protected(set)', $property->modifiers)) {
       return $this->emitAsymmetricVisibility($result, $property);
     } else if (PHP_VERSION_ID <= 80100 && in_array('readonly', $property->modifiers)) {
       return $this->emitReadonlyProperties($result, $property);

--- a/src/main/php/lang/ast/emit/RewriteProperties.class.php
+++ b/src/main/php/lang/ast/emit/RewriteProperties.class.php
@@ -10,15 +10,17 @@ trait RewriteProperties {
   }
 
   protected function emitProperty($result, $property) {
-    static $asymmetric= null;
     if ($property->hooks) {
       return $this->emitPropertyHooks($result, $property);
     } else if (
-      !($asymmetric ?? $asymmetric= method_exists(ReflectionProperty::class, 'isPrivateSet')) &&
+      $this->targetVersion < 80400 &&
       array_intersect($property->modifiers, ['private(set)', 'protected(set)', 'public(set)'])
     ) {
       return $this->emitAsymmetricVisibility($result, $property);
-    } else if (PHP_VERSION_ID <= 80100 && in_array('readonly', $property->modifiers)) {
+    } else if (
+      $this->targetVersion < 80100 &&
+      in_array('readonly', $property->modifiers)
+    ) {
       return $this->emitReadonlyProperties($result, $property);
     }
     parent::emitProperty($result, $property);

--- a/src/main/php/lang/ast/emit/VisibilityChecks.class.php
+++ b/src/main/php/lang/ast/emit/VisibilityChecks.class.php
@@ -4,6 +4,10 @@ use lang\ast\Code;
 
 trait VisibilityChecks {
 
+  private function initonce($name) {
+    return new Code('if (isset($this->__virtual["'.$name.'"])) throw new \\Error("Cannot modify readonly property ".__CLASS__."::\$'.$name.'");');
+  }
+
   private function private($name, $access) {
     return new Code(
       '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.

--- a/src/main/php/lang/ast/emit/VisibilityChecks.class.php
+++ b/src/main/php/lang/ast/emit/VisibilityChecks.class.php
@@ -1,0 +1,22 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\Code;
+
+trait VisibilityChecks {
+
+  private function private($name, $access) {
+    return new Code(
+      '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
+      'if (__CLASS__ !== $scope && \\lang\\VirtualProperty::class !== $scope)'.
+      'throw new \\Error("Cannot '.$access.' property ".__CLASS__."::\$'.$name.' from ".($scope ? "scope ".$scope : "global scope"));'
+    );
+  }
+
+  private function protected($name, $access) {
+    return new Code(
+      '$scope= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]["class"] ?? null;'.
+      'if (__CLASS__ !== $scope && !is_subclass_of($scope, __CLASS__) && \\lang\\VirtualProperty::class !== $scope)'.
+      'throw new \\Error("Cannot '.$access.' property ".__CLASS__."::\$'.$name.' from ".($scope ? "scope ".$scope : "global scope"));'
+    );
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -96,7 +96,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
     $t->newInstance()->rename();
   }
 
-  #[Test, Values(['private', 'protected', 'public'])]
+  #[Test, Values(['private', 'protected'])]
   public function reflection($modifier) {
     $t= $this->declare('class %T {
       public '.$modifier.'(set) string $fixture= "Test";

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace lang\ast\unittest\emit;
 
 use lang\Error;
-use test\{Assert, Expect, Test};
+use test\{Assert, Expect, Test, Values};
 
 /**
  * Asymmetric visibility tests
@@ -94,5 +94,17 @@ class AsymmetricVisibilityTest extends EmittingTest {
       }
     }');
     $t->newInstance()->rename();
+  }
+
+  #[Test, Values(['private', 'protected', 'public'])]
+  public function reflection($modifier) {
+    $t= $this->declare('class %T {
+      public '.$modifier.'(set) string $fixture= "Test";
+    }');
+
+    Assert::equals(
+      'public '.$modifier.'(set) string $fixture',
+      $t->property('fixture')->toString()
+    );
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -28,6 +28,22 @@ class AsymmetricVisibilityTest extends EmittingTest {
         return $this;
       }
     }');
+
+    Assert::throws(Error::class, fn() => $t->newInstance()->fixture= 'Changed');
+    Assert::equals('Changed', $t->newInstance()->rename('Changed')->fixture);
+  }
+
+  #[Test]
+  public function writing_from_inherited_scope() {
+    $parent= $this->declare('class %T { public protected(set) $fixture= "Test"; }');
+    $t= $this->declare('class %T extends '.$parent->literal().' {
+      public function rename($name) {
+        $this->fixture= $name;
+        return $this;
+      }
+    }');
+
+    Assert::throws(Error::class, fn() => $t->newInstance()->fixture= 'Changed');
     Assert::equals('Changed', $t->newInstance()->rename('Changed')->fixture);
   }
 

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -46,4 +46,12 @@ class AsymmetricVisibilityTest extends EmittingTest {
     }');
     $t->newInstance()->fixture= 'Changed';
   }
+
+  #[Test]
+  public function promoted_constructor_parameter() {
+    $t= $this->declare('class %T {
+      public function __construct(public private(set) $fixture) { }
+    }');
+    Assert::equals('Test', $t->newInstance('Test')->fixture);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -19,7 +19,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   }
 
   #[Test]
-  public function writing() {
+  public function writing_from_self_scope() {
     $t= $this->declare('class %T {
       public private(set) $fixture= "Test";
 
@@ -29,6 +29,17 @@ class AsymmetricVisibilityTest extends EmittingTest {
       }
     }');
     Assert::equals('Changed', $t->newInstance()->rename('Changed')->fixture);
+  }
+
+  #[Test]
+  public function writing_explicitely_public_set() {
+    $t= $this->declare('class %T {
+      public public(set) $fixture= "Test";
+    }');
+
+    $instance= $t->newInstance();
+    $instance->fixture= 'Changed';
+    Assert::equals('Changed', $instance->fixture);
   }
 
   #[Test, Expect(class: Error::class, message: '/Cannot modify private\(set\) property T.+::\$fixture/')]

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -18,7 +18,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
     Assert::equals('Test', $t->newInstance()->fixture);
   }
 
-  #[Test, Expect(class: Error::class, message: '/Cannot access private property T.+::fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot modify private\(set\) property T.+::\$fixture/')]
   public function writing_private() {
     $t= $this->declare('class %T {
       public private(set) $fixture= "Test";
@@ -26,7 +26,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
     $t->newInstance()->fixture= 'Changed';
   }
 
-  #[Test, Expect(class: Error::class, message: '/Cannot access protected property T.+::fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot modify protected\(set\) property T.+::\$fixture/')]
   public function writing_protected() {
     $t= $this->declare('class %T {
       public protected(set) $fixture= "Test";

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -107,4 +107,16 @@ class AsymmetricVisibilityTest extends EmittingTest {
       $t->property('fixture')->toString()
     );
   }
+
+  #[Test, Values(['private', 'protected', 'public'])]
+  public function same_modifier_for_get_and_set($modifier) {
+    $t= $this->declare('class %T {
+      '.$modifier.' '.$modifier.'(set) string $fixture= "Test";
+    }');
+
+    Assert::equals(
+      $modifier.' string $fixture',
+      $t->property('fixture')->toString()
+    );
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -81,4 +81,18 @@ class AsymmetricVisibilityTest extends EmittingTest {
     }');
     Assert::equals('Test', $t->newInstance('Test')->fixture);
   }
+
+  #[Test, Expect(class: Error::class, message: '/Cannot modify readonly property .+fixture/')]
+  public function readonly() {
+    $t= $this->declare('class %T {
+
+      // public-read, protected-write, write-once property
+      public protected(set) readonly string $fixture= "Test";
+
+      public function rename() {
+        $this->fixture= "Changed"; // Will always error
+      }
+    }');
+    $t->newInstance()->rename();
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -18,6 +18,19 @@ class AsymmetricVisibilityTest extends EmittingTest {
     Assert::equals('Test', $t->newInstance()->fixture);
   }
 
+  #[Test]
+  public function writing() {
+    $t= $this->declare('class %T {
+      public private(set) $fixture= "Test";
+
+      public function rename($name) {
+        $this->fixture= $name;
+        return $this;
+      }
+    }');
+    Assert::equals('Changed', $t->newInstance()->rename('Changed')->fixture);
+  }
+
   #[Test, Expect(class: Error::class, message: '/Cannot modify private\(set\) property T.+::\$fixture/')]
   public function writing_private() {
     $t= $this->declare('class %T {

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -13,7 +13,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   #[Test]
   public function reading() {
     $t= $this->declare('class %T {
-      public private(set) $fixture= "Test";
+      public private(set) string $fixture= "Test";
     }');
     Assert::equals('Test', $t->newInstance()->fixture);
   }
@@ -21,7 +21,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   #[Test]
   public function writing_from_self_scope() {
     $t= $this->declare('class %T {
-      public private(set) $fixture= "Test";
+      public private(set) string $fixture= "Test";
 
       public function rename($name) {
         $this->fixture= $name;
@@ -35,7 +35,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
 
   #[Test]
   public function writing_from_inherited_scope() {
-    $parent= $this->declare('class %T { public protected(set) $fixture= "Test"; }');
+    $parent= $this->declare('class %T { public protected(set) string $fixture= "Test"; }');
     $t= $this->declare('class %T extends '.$parent->literal().' {
       public function rename($name) {
         $this->fixture= $name;
@@ -50,7 +50,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   #[Test]
   public function writing_explicitely_public_set() {
     $t= $this->declare('class %T {
-      public public(set) $fixture= "Test";
+      public public(set) string $fixture= "Test";
     }');
 
     $instance= $t->newInstance();
@@ -61,7 +61,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   #[Test, Expect(class: Error::class, message: '/Cannot modify private\(set\) property T.+::\$fixture/')]
   public function writing_private() {
     $t= $this->declare('class %T {
-      public private(set) $fixture= "Test";
+      public private(set) string $fixture= "Test";
     }');
     $t->newInstance()->fixture= 'Changed';
   }
@@ -69,7 +69,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   #[Test, Expect(class: Error::class, message: '/Cannot modify protected\(set\) property T.+::\$fixture/')]
   public function writing_protected() {
     $t= $this->declare('class %T {
-      public protected(set) $fixture= "Test";
+      public protected(set) string $fixture= "Test";
     }');
     $t->newInstance()->fixture= 'Changed';
   }
@@ -77,7 +77,7 @@ class AsymmetricVisibilityTest extends EmittingTest {
   #[Test]
   public function promoted_constructor_parameter() {
     $t= $this->declare('class %T {
-      public function __construct(public private(set) $fixture) { }
+      public function __construct(public private(set) string $fixture) { }
     }');
     Assert::equals('Test', $t->newInstance('Test')->fixture);
   }
@@ -87,7 +87,11 @@ class AsymmetricVisibilityTest extends EmittingTest {
     $t= $this->declare('class %T {
 
       // public-read, protected-write, write-once property
-      public protected(set) readonly string $fixture= "Test";
+      public protected(set) readonly string $fixture;
+
+      public function __construct() {
+        $this->fixture= "Test";
+      }
 
       public function rename() {
         $this->fixture= "Changed"; // Will always error

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -1,0 +1,28 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\Error;
+use test\{Assert, Expect, Test};
+
+/**
+ * Asymmetric visibility tests
+ *
+ * @see  https://wiki.php.net/rfc/asymmetric-visibility-v2
+ */
+class AsymmetricVisibilityTest extends EmittingTest {
+
+  #[Test]
+  public function reading() {
+    $t= $this->declare('class %T {
+      public private(set) $fixture= "Test";
+    }');
+    Assert::equals('Test', $t->newInstance()->fixture);
+  }
+
+  #[Test, Expect(class: Error::class, message: '/Cannot access private property T.+::fixture/')]
+  public function writing() {
+    $t= $this->declare('class %T {
+      public private(set) $fixture= "Test";
+    }');
+    $t->newInstance()->fixture= 'Changed';
+  }
+}

--- a/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AsymmetricVisibilityTest.class.php
@@ -19,9 +19,17 @@ class AsymmetricVisibilityTest extends EmittingTest {
   }
 
   #[Test, Expect(class: Error::class, message: '/Cannot access private property T.+::fixture/')]
-  public function writing() {
+  public function writing_private() {
     $t= $this->declare('class %T {
       public private(set) $fixture= "Test";
+    }');
+    $t->newInstance()->fixture= 'Changed';
+  }
+
+  #[Test, Expect(class: Error::class, message: '/Cannot access protected property T.+::fixture/')]
+  public function writing_protected() {
+    $t= $this->declare('class %T {
+      public protected(set) $fixture= "Test";
     }');
     $t->newInstance()->fixture= 'Changed';
   }

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -151,7 +151,7 @@ class ReadonlyTest extends EmittingTest {
     Assert::equals('Test', $i->fixture);
   }
 
-  #[Test, Expect(class: Error::class, message: '/Cannot initialize readonly property .+fixture/')]
+  #[Test, Expect(class: Error::class, message: '/Cannot (initialize readonly|modify protected\(set\)) property .+fixture/')]
   public function cannot_initialize_from_outside() {
     $t= $this->declare('class %T {
       public readonly string $fixture;

--- a/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ReadonlyTest.class.php
@@ -27,7 +27,7 @@ class ReadonlyTest extends EmittingTest {
     }');
 
     Assert::equals(
-      'public readonly int $fixture',
+      'public readonly protected(set) int $fixture',
       $t->property('fixture')->toString()
     );
   }
@@ -39,7 +39,7 @@ class ReadonlyTest extends EmittingTest {
     }');
 
     Assert::equals(
-      'public readonly int $fixture',
+      'public readonly protected(set) int $fixture',
       $t->property('fixture')->toString()
     );
   }
@@ -51,7 +51,7 @@ class ReadonlyTest extends EmittingTest {
     }');
 
     Assert::equals(
-      'public readonly string $fixture',
+      'public readonly protected(set) string $fixture',
       $t->property('fixture')->toString()
     );
     Assert::equals('Test', $t->newInstance('Test')->fixture);
@@ -64,7 +64,7 @@ class ReadonlyTest extends EmittingTest {
     }');
 
     Assert::equals(
-      'public readonly string $fixture',
+      'public readonly protected(set) string $fixture',
       $t->property('fixture')->toString()
     );
     Assert::equals('Test', $t->newInstance('Test')->fixture);


### PR DESCRIPTION
This pull request adds emitting support for asymmetric visibility using `(set)` specifiers on property modifiers

* [x] Rewrite *private(set)* and *protected(set)* to virtual properties
* [x] Constructor parameter promotion
* [x] Asymmetric visibility with readonly
* [x] Reflection, depending on xp-framework/reflection#43

See https://wiki.php.net/rfc/asymmetric-visibility-v2 and xp-framework/compiler#182