### PR TITLE
Add support for final properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
     "xp-framework/reflection": "^3.2 | ^2.15",
-    "xp-framework/ast": "^11.3",
+    "xp-framework/ast": "^11.5",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/emit/FinalProperties.class.php
+++ b/src/main/php/lang/ast/emit/FinalProperties.class.php
@@ -1,0 +1,25 @@
+<?php namespace lang\ast\emit;
+
+trait FinalProperties {
+
+  protected function emitProperty($result, $property) {
+    static $lookup= [
+      'public'    => MODIFIER_PUBLIC,
+      'protected' => MODIFIER_PROTECTED,
+      'private'   => MODIFIER_PRIVATE,
+      'static'    => MODIFIER_STATIC,
+      'final'     => MODIFIER_FINAL,
+      'abstract'  => MODIFIER_ABSTRACT,
+      'readonly'  => 0x0080, // XP 10.13: MODIFIER_READONLY
+    ];
+
+    $modifiers= 0;
+    foreach ($property->modifiers as $name) {
+      $modifiers|= $lookup[$name];
+    }
+
+    $property->modifiers= array_diff($property->modifiers, ['final']);
+    parent::emitProperty($result, $property);
+    $result->codegen->scope[0]->meta[self::PROPERTY][$property->name][DETAIL_ARGUMENTS]= [$modifiers];
+  }
+}

--- a/src/main/php/lang/ast/emit/FinalProperties.class.php
+++ b/src/main/php/lang/ast/emit/FinalProperties.class.php
@@ -18,8 +18,9 @@ trait FinalProperties {
       $modifiers|= $lookup[$name];
     }
 
+    // Emit without final modifier, store `final` in xp::$meta
     $property->modifiers= array_diff($property->modifiers, ['final']);
     parent::emitProperty($result, $property);
-    $result->codegen->scope[0]->meta[self::PROPERTY][$property->name][DETAIL_ARGUMENTS]= [$modifiers];
+    $result->codegen->scope[0]->meta[self::PROPERTY][$property->name][DETAIL_ARGUMENTS]= [MODIFIER_FINAL];
   }
 }

--- a/src/main/php/lang/ast/emit/RewriteProperties.class.php
+++ b/src/main/php/lang/ast/emit/RewriteProperties.class.php
@@ -3,8 +3,9 @@
 use ReflectionProperty;
 
 trait RewriteProperties {
-  use PropertyHooks, ReadonlyProperties, AsymmetricVisibility {
+  use PropertyHooks, FinalProperties, ReadonlyProperties, AsymmetricVisibility {
     PropertyHooks::emitProperty as emitPropertyHooks;
+    FinalProperties::emitProperty as emitFinalProperties;
     ReadonlyProperties::emitProperty as emitReadonlyProperties;
     AsymmetricVisibility::emitProperty as emitAsymmetricVisibility;
   }
@@ -17,6 +18,11 @@ trait RewriteProperties {
       array_intersect($property->modifiers, ['private(set)', 'protected(set)', 'public(set)'])
     ) {
       return $this->emitAsymmetricVisibility($result, $property);
+    } else if (
+      $this->targetVersion < 80400 &&
+      in_array('final', $property->modifiers)
+    ) {
+      return $this->emitFinalProperties($result, $property);
     } else if (
       $this->targetVersion < 80100 &&
       in_array('readonly', $property->modifiers)

--- a/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
@@ -10,6 +10,7 @@ use test\{Assert, Expect, Test};
  * @see  https://github.com/xp-framework/rfc/issues/240
  * @see  https://docs.hhvm.com/hack/other-features/constructor-parameter-promotion
  * @see  https://wiki.php.net/rfc/constructor_promotion (PHP 8.0)
+ * @see  https://wiki.php.net/rfc/final_prompotion
  * @see  https://wiki.php.net/rfc/automatic_property_initialization (Declined)
  */
 class ArgumentPromotionTest extends EmittingTest {
@@ -141,5 +142,14 @@ class ArgumentPromotionTest extends EmittingTest {
       public function __construct(private array $list) { }
     }');
     Assert::equals('Test', $t->newInstance(['Test'])->first);
+  }
+
+  #[Test]
+  public function promoted_final() {
+    $t= $this->declare('class %T {
+      public function __construct(public final string $name) { }
+    }');
+
+    Assert::equals(MODIFIER_PUBLIC | MODIFIER_FINAL, $t->property('name')->modifiers()->bits());
   }
 }

--- a/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/MembersTest.class.php
@@ -425,4 +425,13 @@ class MembersTest extends EmittingTest {
 
     Assert::equals('Test', $r);
   }
+
+  #[Test]
+  public function final_property() {
+    $t= $this->declare('class %T {
+      public final string $fixture= "Test";
+    }');
+
+    Assert::equals(MODIFIER_PUBLIC | MODIFIER_FINAL, $t->property('fixture')->modifiers()->bits());
+  }
 }


### PR DESCRIPTION
When property hooks were introduced into PHP 8.4, it also added a mechanism for properties to be declared as `final`.

## TODO
* [x] Final properties
* [x] Syntactic support: https://github.com/xp-framework/reflection/pull/44*
* [x] Parameter promotion

## See:
* https://wiki.php.net/rfc/property-hooks
* https://wiki.php.net/rfc/final_promotion
* https://externals.io/message/126926#126952

