### PR TITLE
Implement logical AND and OR assignment operators (&&=, ||=)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
     "xp-framework/reflection": "^3.2 | ^2.15",
-    "xp-framework/ast": "^12.0",
+    "xp-framework/ast": "^12.1",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/src/main/php/lang/ast/Emitter.class.php
+++ b/src/main/php/lang/ast/Emitter.class.php
@@ -108,7 +108,7 @@ abstract class Emitter {
   /**
    * Standalone operators
    *
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  lang.ast.Token $operator
    * @return void
    */
@@ -119,7 +119,7 @@ abstract class Emitter {
   /**
    * Emit nodes seperated as statements
    *
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  iterable $nodes
    * @return void
    */
@@ -133,23 +133,21 @@ abstract class Emitter {
   /**
    * Emit single nodes
    *
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  lang.ast.Node $node
    * @return void
    */
   public function emitOne($result, $node) {
-
-    // Check for transformations
-    if (isset($this->transformations[$node->kind])) {
-      foreach ($this->transformations[$node->kind] as $transformation) {
+    if ($transformations= $this->transformations[$node->kind] ?? null) {
+      foreach ($transformations as $transformation) {
         $r= $transformation($result->codegen, $node);
         if ($r instanceof Node) {
           if ($r->kind === $node->kind) continue;
-          $this->{'emit'.$r->kind}($result, $r);
+          $this->{'emit'.$r->kind}($result->at($r->line), $r);
           return;
         } else if ($r) {
           foreach ($r as $s => $n) {
-            $this->{'emit'.$n->kind}($result, $n);
+            $this->{'emit'.$n->kind}($result->at($n->line), $n);
             null === $s || $result->out->write(';');
           }
           return;
@@ -158,14 +156,14 @@ abstract class Emitter {
       // Fall through, use default
     }
 
-    $this->{'emit'.$node->kind}($result, $node);
+    $this->{'emit'.$node->kind}($result->at($node->line), $node);
   }
 
   /**
    * Creates result
    *
    * @param  io.streams.OutputStream $target
-   * @return lang.ast.Result
+   * @return lang.ast.emit.Result
    */
   protected abstract function result($target);
 

--- a/src/main/php/lang/ast/emit/GeneratedCode.class.php
+++ b/src/main/php/lang/ast/emit/GeneratedCode.class.php
@@ -2,7 +2,6 @@
 
 class GeneratedCode extends Result {
   private $prolog, $epilog;
-  public $line= 1;
 
   /**
    * Starts a result stream, including an optional prolog and epilog
@@ -34,20 +33,6 @@ class GeneratedCode extends Result {
    */
   protected function finalize() {
     '' === $this->epilog || $this->out->write($this->epilog);
-  }
-
-  /**
-   * Forwards output line to given line number
-   *
-   * @param  int $line
-   * @return self
-   */
-  public function at($line) {
-    if ($line > $this->line) {
-      $this->out->write(str_repeat("\n", $line - $this->line));
-      $this->line= $line;
-    }
-    return $this;
   }
 
   /**

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -820,7 +820,15 @@ abstract class PHP extends Emitter {
 
   protected function emitAssignment($result, $assignment) {
     $this->emitAssign($result, $assignment->variable);
-    $result->out->write($assignment->operator);
+
+    if ('||=' === $assignment->operator || '&&=' === $assignment->operator) {
+      $result->out->write(substr($assignment->operator, 0, 2));
+      $this->emitAssign($result, $assignment->variable);
+      $result->out->write('=');
+    } else {
+      $result->out->write($assignment->operator);
+    }
+
     $this->emitOne($result, $assignment->expression);
   }
 

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -820,15 +820,15 @@ abstract class PHP extends Emitter {
 
   protected function emitAssignment($result, $assignment) {
     $this->emitAssign($result, $assignment->variable);
+    $result->out->write($assignment->operator);
+    $this->emitOne($result, $assignment->expression);
+  }
 
-    if ('||=' === $assignment->operator || '&&=' === $assignment->operator) {
-      $result->out->write(substr($assignment->operator, 0, 2));
-      $this->emitAssign($result, $assignment->variable);
-      $result->out->write('=');
-    } else {
-      $result->out->write($assignment->operator);
-    }
-
+  protected function emitLogicalAssignment($result, $assignment) {
+    $this->emitOne($result, $assignment->variable);
+    $result->out->write(substr($assignment->operator, 0, 2));
+    $this->emitOne($result, $assignment->variable);
+    $result->out->write('=');
     $this->emitOne($result, $assignment->expression);
   }
 

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -32,7 +32,7 @@ abstract class PHP extends Emitter {
    * Creates result
    *
    * @param  io.streams.OutputStream $target
-   * @return lang.ast.Result
+   * @return lang.ast.emit.Result
    */
   protected function result($target) {
     return new GeneratedCode($target, '<?php ');
@@ -57,7 +57,7 @@ abstract class PHP extends Emitter {
    * - Binary expression where left- and right hand side are literals
    *
    * @see    https://wiki.php.net/rfc/const_scalar_exprs
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  lang.ast.Node $node
    * @return bool
    */
@@ -116,11 +116,11 @@ abstract class PHP extends Emitter {
   /**
    * Enclose a node inside a closure
    *
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  lang.ast.Node $node
    * @param  ?lang.ast.nodes.Signature $signature
    * @param  bool $static
-   * @param  function(lang.ast.Result, lang.ast.Node): void $emit
+   * @param  function(lang.ast.emit.Result, lang.ast.Node): void $emit
    */
   protected function enclose($result, $node, $signature, $static, $emit) {
     $capture= [];
@@ -159,7 +159,7 @@ abstract class PHP extends Emitter {
   /**
    * Emits local initializations
    *
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  [:lang.ast.Node] $init
    * @return void
    */
@@ -175,7 +175,7 @@ abstract class PHP extends Emitter {
    * Convert blocks to IIFEs to allow a list of statements where PHP syntactically
    * doesn't, e.g. `fn`-style lambdas or match expressions.
    *
-   * @param  lang.ast.Result $result
+   * @param  lang.ast.emit.Result $result
    * @param  lang.ast.Node $expression
    * @return void
    */
@@ -1207,16 +1207,5 @@ abstract class PHP extends Emitter {
   protected function emitFrom($result, $from) {
     $result->out->write('yield from ');
     $this->emitOne($result, $from->iterable);
-  }
-
-  /**
-   * Emit single nodes
-   *
-   * @param  lang.ast.Result $result
-   * @param  lang.ast.Node $node
-   * @return void
-   */
-  public function emitOne($result, $node) {
-    parent::emitOne($result->at($node->line), $node);
   }
 }

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -825,10 +825,17 @@ abstract class PHP extends Emitter {
   }
 
   protected function emitLogicalAssignment($result, $assignment) {
-    $this->emitOne($result, $assignment->variable);
-    $result->out->write(substr($assignment->operator, 0, 2));
-    $this->emitOne($result, $assignment->variable);
-    $result->out->write('=');
+    if ($assignment->variable instanceof Variable) {
+      $this->emitOne($result, $assignment->variable);
+      $result->out->write(substr($assignment->operator, 0, 2));
+      $this->emitOne($result, $assignment->variable);
+      $result->out->write('=');
+    } else {
+      $t= $result->temp();
+      $result->out->write('('.$t.'= &');
+      $this->emitOne($result, $assignment->variable);
+      $result->out->write(')'.substr($assignment->operator, 0, 2).$t.'=');
+    }
     $this->emitOne($result, $assignment->expression);
   }
 

--- a/src/main/php/lang/ast/emit/Result.class.php
+++ b/src/main/php/lang/ast/emit/Result.class.php
@@ -7,6 +7,7 @@ use lang\ast\CodeGen;
 class Result implements Closeable {
   public $out;
   public $codegen;
+  public $line= 1;
   public $locals= [];
 
   /**
@@ -31,6 +32,19 @@ class Result implements Closeable {
     return $this;
   }
 
+  /**
+   * Forwards output line to given line number
+   *
+   * @param  int $line
+   * @return self
+   */
+  public function at($line) {
+    if ($line > $this->line) {
+      $this->out->write(str_repeat("\n", $line - $this->line));
+      $this->line= $line;
+    }
+    return $this;
+  }
 
   /**
    * Initialize result. Guaranteed to be called *once* from constructor.

--- a/src/test/php/lang/ast/unittest/emit/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/OperatorTest.class.php
@@ -142,4 +142,24 @@ class OperatorTest extends EmittingTest {
 
     Assert::equals($expected, $r);
   }
+
+  #[Test, Values(['??=', '||=', '&&='])]
+  public function assignment_lhs_evaluated_only_once($op) {
+    $r= $this->run('class %T {
+      private $evaluated= 0;
+      private $a= null;
+
+      private function test() {
+        $this->evaluated++;
+        return $this;
+      }
+
+      public function run() {
+        $this->test()->a '.$op.' "default";
+        return $this->evaluated;
+      }
+    }');
+
+    Assert::equals(1, $r);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/OperatorTest.class.php
@@ -143,7 +143,7 @@ class OperatorTest extends EmittingTest {
     Assert::equals($expected, $r);
   }
 
-  #[Test, Values(['??=', '||=', '&&='])]
+  #[Test, Values(['||=', '&&='])]
   public function assignment_lhs_evaluated_only_once($op) {
     $r= $this->run('class %T {
       private $evaluated= 0;

--- a/src/test/php/lang/ast/unittest/emit/OperatorTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/OperatorTest.class.php
@@ -118,4 +118,28 @@ class OperatorTest extends EmittingTest {
 
     Assert::equals($expected, $r[0]);
   }
+
+  #[Test, Values([[null, 'default'], ['test', 'test']])]
+  public function logical_or_assign($input, $expected) {
+    $r= $this->run('class %T {
+      public function run($a) {
+        $a||= "default";
+        return $a;
+      }
+    }', $input);
+
+    Assert::equals($expected, $r);
+  }
+
+  #[Test, Values([[null, null], ['test', 'changed']])]
+  public function logical_and_assign($input, $expected) {
+    $r= $this->run('class %T {
+      public function run($a) {
+        $a&&= "changed";
+        return $a;
+      }
+    }', $input);
+
+    Assert::equals($expected, $r);
+  }
 }


### PR DESCRIPTION
Implements feature suggested in #133. These operators are both in JS and baseline available.

* [x] Assignment to variables
* [x] Assignment to expressions like `test()->result= ...` without *test()* being re-evaluated

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment