### PR TITLE
Support primary constructors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.6 | ^10.16",
     "xp-framework/reflection": "^3.2 | ^2.15",
-    "xp-framework/ast": "^13.0 | ^12.2",
+    "xp-framework/ast": "dev-feature/primary-constructors as 13.1.0",
     "php" : ">=7.4.0"
   },
   "require-dev" : {

--- a/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/ArgumentPromotionTest.class.php
@@ -156,7 +156,7 @@ class ArgumentPromotionTest extends EmittingTest {
 
   #[Test]
   public function promoted_property_hook() {
-    $c= $this->declare('class %T {
+    $t= $this->declare('class %T {
       public function __construct(
         public private(set) float $celsius= 100 {
           set {
@@ -169,7 +169,98 @@ class ArgumentPromotionTest extends EmittingTest {
       ) { }
     }');
 
-    Assert::equals(0.0, $c->newInstance(0.0)->celsius);
-    Assert::throws(InvocationFailed::class, fn() => $c->newInstance(-300.0));
+    Assert::equals(0.0, $t->newInstance(0.0)->celsius);
+    Assert::throws(InvocationFailed::class, fn() => $t->newInstance(-300.0));
+  }
+
+  #[Test]
+  public function primary_constructors() {
+    $t= $this->declare('class %T(public int $x, public int $y) {
+      public function coordinates() {
+        return [$this->x, $this->y];
+      }
+    }');
+
+    Assert::equals([14, 12], $t->newInstance(14, 12)->coordinates());
+  }
+
+  #[Test]
+  public function primary_constructor_with_parent() {
+    $b= $this->declare('class %T {
+      public $invoked= 0;
+      public function __construct($invoked= 1) { $this->invoked+= $invoked; }
+    }');
+    $i= $this->declare('class %T(public string $name) extends '.$b->literal().' { }')->newInstance('admin');
+
+    Assert::equals(0, $i->invoked);
+    Assert::equals('admin', $i->name);
+  }
+
+  #[Test]
+  public function primary_constructor_invoking_parent() {
+    $b= $this->declare('class %T {
+      public $invoked= 0;
+      public function __construct($invoked= 1) { $this->invoked+= $invoked; }
+    }');
+    $i= $this->declare('class %T(public string $name) extends '.$b->literal().'() { }')->newInstance('admin');
+
+    Assert::equals(1, $i->invoked);
+    Assert::equals('admin', $i->name);
+  }
+
+  #[Test]
+  public function primary_constructor_passing_value_to_parent() {
+    $b= $this->declare('class %T {
+      public $invoked= 0;
+      public function __construct($invoked= 1) { $this->invoked+= $invoked; }
+    }');
+    $i= $this->declare('class %T(public string $name) extends '.$b->literal().'(2) { }')->newInstance('admin');
+
+    Assert::equals(2, $i->invoked);
+    Assert::equals('admin', $i->name);
+  }
+
+  #[Test]
+  public function primary_constructor_passing_param_to_parent() {
+    $b= $this->declare('class %T {
+      public $invoked= 0;
+      public function __construct($invoked= 1) { $this->invoked+= $invoked; }
+    }');
+    $i= $this->declare('class %T(public string $name, $i= 2) extends '.$b->literal().'($i) { }')->newInstance('admin');
+
+    Assert::equals(2, $i->invoked);
+    Assert::equals('admin', $i->name);
+  }
+
+  #[Test]
+  public function primary_constructor_with_hooks() {
+    $t= $this->declare('class %T(
+      public private(set) float $celsius {
+        set {
+          if ($value < -273.15) {
+            throw new \lang\IllegalArgumentException("below absolute zero");
+          }
+          $this->celsius = $value;
+        }
+      }
+    ) { }');
+
+    Assert::equals(0.0, $t->newInstance(0.0)->celsius);
+    Assert::throws(InvocationFailed::class, fn() => $t->newInstance(-300.0));
+  }
+
+  #[Test]
+  public function primary_constructor_doc_comment() {
+    $t= $this->declare('/** Test */ class %T(public string $name) { }');
+
+    Assert::equals('Test', $t->comment());
+    Assert::equals('Test', $t->constructor()->comment());
+  }
+
+  #[Test]
+  public function primary_constructor_param_annotations() {
+    $t= $this->declare('class %T(#[Inject] public string $name) { }');
+
+    Assert::true($t->constructor()->parameter('name')->annotations()->provides('Inject'));
   }
 }


### PR DESCRIPTION
Builds on https://github.com/xp-framework/ast/pull/63 and adds [primary constructor](https://wiki.php.net/rfc/primary-constructors) support to the compiler.

## Examples

Temperature:

```php
use lang\IllegalArgumentException;

class Temp(
  public private(set) float $celsius= 100 {
    set {
      if ($value < -273.15) {
        throw new IllegalArgumentException($value.' is below absolute zero');
      }
      $this->celsius= $value;
    }
  }
) { }
```

```bash
$ xp -w 'new Temp(celsius: -300)'
Uncaught exception: Exception lang.IllegalArgumentException (-300 is below absolute zero)
  at Temp::$celsius::set(-300) [line 6 of Temp.php]
  at Temp::__construct(-300) [line 1 of (command line argument)]
  at <main>::include((0x17)'(command line argument)') [line 163 of Code.class.php]
  at xp.runtime.Code::run(array[1]) [line 30 of Dump.class.php]
  at xp.runtime.Dump::main(array[1]) [line 399 of class-main.php]
```

Ranges:

```php
class Range(public readonly int $start, public readonly int $end) implements IteratorAggregate {

  public function getIterator(): Traversable {
    if ($this->start > $this->end) {
      for ($i= $this->start; $i >= $this->end; $i--) yield $i;
    } else {
      for ($i= $this->start; $i <= $this->end; $i++) yield $i;
    }
  }
}
```

```bash
$ xp -w '[...new Range(10, 1)]'
[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
```