### PR TITLE
Emit PHP 8 attributes alongside XP meta information

### DIFF
--- a/src/main/php/lang/ast/emit/php/XpMeta.class.php
+++ b/src/main/php/lang/ast/emit/php/XpMeta.class.php
@@ -102,12 +102,4 @@ trait XpMeta {
   protected function emitComment($result, $comment) {
     // Omit from generated code
   }
-
-  protected function emitAnnotation($result, $annotation) {
-    // Omit from generated code
-  }
-
-  protected function emitAnnotations($result, $annotations) {
-    // Omit from generated code
-  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
@@ -2,6 +2,7 @@
 
 use ReflectionClass;
 use lang\ast\emit\php\XpMeta;
+use test\verify\Runtime;
 use test\{Assert, Test, Values};
 
 /**
@@ -23,7 +24,7 @@ class AnnotationsTest extends AnnotationSupport {
     yield ['#[Test(value: "a")]', ['Test' => ['value' => 'a']]];
   }
 
-  #[Test, Values(from: 'declarations')]
+  #[Test, Runtime(php: '>=8.0.0-dev'), Values(from: 'declarations')]
   public function also_emits_php_attributes($declaration, $expected) {
     $type= $this->declare($declaration);
     $declared= [];

--- a/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
@@ -1,6 +1,8 @@
 <?php namespace lang\ast\unittest\emit;
 
+use ReflectionClass;
 use lang\ast\emit\php\XpMeta;
+use test\{Assert, Test, Values};
 
 /**
  * Annotations via XP Meta information
@@ -13,4 +15,22 @@ class AnnotationsTest extends AnnotationSupport {
   /** @return string[] */
   protected function emitters() { return [XpMeta::class]; }
 
+  /** @return iterable */
+  private function declarations() {
+    yield ['#[Test]', ['Test' => []]];
+    yield ['#[Test("a")]', ['Test' => ['a']]];
+    yield ['#[Test(1, 2, 3)]', ['Test' => [1, 2, 3]]];
+    yield ['#[Test(value: "a")]', ['Test' => ['value' => 'a']]];
+  }
+
+  #[Test, Values(from: 'declarations')]
+  public function also_emits_php_attributes($declaration, $expected) {
+    $type= $this->declare($declaration);
+    $declared= [];
+    foreach ((new ReflectionClass($type->literal()))->getAttributes() as $attribute) {
+      $declared[$attribute->name]= $attribute->getArguments();
+    }
+
+    Assert::equals($expected, $declared);
+  }
 }

--- a/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AnnotationsTest.class.php
@@ -28,7 +28,7 @@ class AnnotationsTest extends AnnotationSupport {
     $type= $this->declare($declaration);
     $declared= [];
     foreach ((new ReflectionClass($type->literal()))->getAttributes() as $attribute) {
-      $declared[$attribute->name]= $attribute->getArguments();
+      $declared[$attribute->getName()]= $attribute->getArguments();
     }
 
     Assert::equals($expected, $declared);

--- a/src/test/php/lang/ast/unittest/emit/AttributesTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/AttributesTest.class.php
@@ -1,7 +1,5 @@
 <?php namespace lang\ast\unittest\emit;
 
-use lang\ast\emit\php\XpMeta;
-
 /**
  * Annotations via PHP 8 attributes
  *


### PR DESCRIPTION
This pull request changes the *XP meta* emitter to emit PHP 8 attributes alongside meta data. This ensures compatibility with XP 12 as well as XP 13. XP 13's class meta information no longer included annotations - its minimum required PHP version is PHP 8, which supports attributes as native syntax!

* Removing `DETAIL_ANNOTATIONS` from the meta information can be done in #194
* See also xp-framework/reflection#28