### PR TITLE
Add PHP 8.6 emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ lang.ast.emit.PHP74
 lang.ast.emit.PHP80
 lang.ast.emit.PHP81
 lang.ast.emit.PHP82
-lang.ast.emit.PHP83 [*]
-lang.ast.emit.PHP84
+lang.ast.emit.PHP83
+lang.ast.emit.PHP84 [*]
 lang.ast.emit.PHP85
+lang.ast.emit.PHP86
 lang.ast.syntax.php.Using [*]
 
 @FileSystemCL<./vendor/xp-lang/php-is-operator/src/main/php>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ class HelloWorld {
     $author= Reflection::type(self::class)->annotation(Author::class)->argument(0);
 
     Console::writeLine(new Date()->toString(), ': ');
-    $greet($args[0] ?? 'World', from: $author) |> Console::writeLine(?);
+    $hello= $greet(?, from: $author);
+    $hello($args[0] ?? 'World') |> Console::writeLine(?);
   }
 }
 ```

--- a/src/main/php/lang/ast/emit/PHP.class.php
+++ b/src/main/php/lang/ast/emit/PHP.class.php
@@ -13,6 +13,7 @@ use lang\ast\nodes\{
   InstanceExpression,
   Literal,
   NewExpression,
+  Placeholder,
   Property,
   ScopeExpression,
   UnpackExpression,
@@ -1123,6 +1124,16 @@ abstract class PHP extends Emitter {
     $result->out->write(')');
   }
 
+  protected function emitPlaceholder($result, $placeholder) {
+    if (Placeholder::$VARIADIC === $placeholder) {
+      $result->out->write('...');
+    } else if (Placeholder::$ARGUMENT === $placeholder) {
+      $result->out->write('?');
+    } else {
+      $this->raise('Unsupportet placeholder '.$placeholder->kind());
+    }
+  }
+
   protected function emitCallable($result, $callable) {
 
     // Disambiguate the following:
@@ -1132,7 +1143,9 @@ abstract class PHP extends Emitter {
     $callable->expression->line= -1;
 
     $this->emitOne($result, $callable->expression);
-    $result->out->write('(...)');
+    $result->out->write('(');
+    $this->emitArguments($result, $callable->arguments);
+    $result->out->write(')');
   }
 
   protected function emitCallableNew($result, $callable) {

--- a/src/main/php/lang/ast/emit/PHP86.class.php
+++ b/src/main/php/lang/ast/emit/PHP86.class.php
@@ -1,0 +1,57 @@
+<?php namespace lang\ast\emit;
+
+use lang\ast\types\{
+  IsArray,
+  IsFunction,
+  IsGeneric,
+  IsIntersection,
+  IsLiteral,
+  IsMap,
+  IsNullable,
+  IsUnion,
+  IsValue
+};
+
+/**
+ * PHP 8.6 syntax
+ *
+ * @test lang.ast.unittest.emit.PHP85Test
+ * @see  https://wiki.php.net/rfc#php_86
+ */
+class PHP86 extends PHP {
+  use RewriteBlockLambdaExpressions;
+
+  public $targetVersion= 80600;
+
+  /** Sets up type => literal mappings */
+  public function __construct() {
+    $this->literals= [
+      IsArray::class        => function($t) { return 'array'; },
+      IsMap::class          => function($t) { return 'array'; },
+      IsFunction::class     => function($t) { return 'callable'; },
+      IsValue::class        => function($t) { return $t->literal(); },
+      IsNullable::class     => function($t) {
+        if (null === ($l= $this->literal($t->element))) return null;
+        return $t->element instanceof IsUnion ? $l.'|null' : '?'.$l;
+      },
+      IsIntersection::class => function($t) {
+        $i= '';
+        foreach ($t->components as $component) {
+          if (null === ($l= $this->literal($component))) return null;
+          $i.= '&'.$l;
+        }
+        return substr($i, 1);
+      },
+      IsUnion::class        => function($t) {
+        $u= '';
+        foreach ($t->components as $component) {
+          if (null === ($l= $this->literal($component))) return null;
+          $u.= '|'.$l;
+        }
+        return substr($u, 1);
+      },
+      IsLiteral::class      => function($t) { return $t->literal(); },
+      IsGeneric::class      => function($t) { return null; }
+    ];
+  }
+}

--- a/src/main/php/lang/ast/emit/PHP86.class.php
+++ b/src/main/php/lang/ast/emit/PHP86.class.php
@@ -15,7 +15,7 @@ use lang\ast\types\{
 /**
  * PHP 8.6 syntax
  *
- * @test lang.ast.unittest.emit.PHP85Test
+ * @test lang.ast.unittest.emit.PHP86Test
  * @see  https://wiki.php.net/rfc#php_86
  */
 class PHP86 extends PHP {

--- a/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
+++ b/src/test/php/lang/ast/unittest/emit/CallableSyntaxTest.class.php
@@ -423,25 +423,13 @@ class CallableSyntaxTest extends EmittingTest {
     Assert::equals(1, $count);
   }
 
-  #[Test, Runtime(php: '>=8.6.0')]
+  #[Test, Runtime(php: '>=8.6.0-dev')]
   public function partial_function_application_with_named() {
     $r= $this->run('class %T {
 
       public function run() {
         $f= str_replace("test", "ok", ?);
         return $f(subject: "test.");
-      }
-    }');
-    Assert::equals('ok.', $r);
-  }
-
-  #[Test, Runtime(php: '>=8.6.0')]
-  public function partial_function_application_variadic_before_named() {
-    $r= $this->run('class %T {
-
-      public function run() {
-        $f= str_replace("test", ..., subject: ?);
-        return $f("ok", "test.");
       }
     }');
     Assert::equals('ok.', $r);

--- a/src/test/php/lang/ast/unittest/emit/PHP86Test.class.php
+++ b/src/test/php/lang/ast/unittest/emit/PHP86Test.class.php
@@ -1,0 +1,26 @@
+<?php namespace lang\ast\unittest\emit;
+
+use lang\ast\emit\Type;
+use test\{Assert, Test};
+
+class PHP86Test extends EmittingTest {
+
+  /** @return string */
+  protected function runtime() { return 'php:8.6.0'; }
+
+  #[Test]
+  public function partial_function_application_argument() {
+    Assert::equals(
+      'str_replace("test","ok",?);',
+      $this->emit('str_replace("test", "ok", ?)')
+    );
+  }
+
+  #[Test]
+  public function partial_function_application_variadic() {
+    Assert::equals(
+      'str_replace("test","ok",...);',
+      $this->emit('str_replace("test", "ok", ...)')
+    );
+  }
+}


### PR DESCRIPTION
Following the [release of PHP 8.6 alpha3](https://www.php.net/archive/2026.php#2026-07-30-3), this pull request introduces a specialized emitter for this version. It differs from the PHP 8.5 emitter in that it emits partial function application natively.

* https://wiki.php.net/rfc/partial_function_application_v2
* https://wiki.php.net/rfc/partial_function_application_optional_placeholder